### PR TITLE
Add Enum support based on PR#9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,9 @@ install_examples: build_examples
 	@if [ -d ~/.pulumi/plugins/resource-schema-test-v0.1.0/ ]; then \
 		mkdir -p ~/.pulumi/plugins/resource-schema-test-v0.1.0/; \
 	fi
-	rm -fr examples/schema-test/sdk
+	rm -rf examples/schema-test/sdk
 	cd examples/schema-test && ./schema-test -sdkGen -emitSchema
+	mkdir -p ~/.pulumi/plugins/resource-schema-test-v0.1.0
 	mv examples/schema-test/schema-test ~/.pulumi/plugins/resource-schema-test-v0.1.0/pulumi-resource-schema-test
 	cd examples/schema-test/sdk/go/schematest && go mod init && go mod edit -replace github.com/pulumi/pulumi-go-provider=../../../../ && go mod tidy
 
@@ -31,6 +32,7 @@ install_examples: build_examples
 	fi
 	rm -rf examples/command/sdk
 	cd examples/command && ./command -sdkGen -emitSchema
+	mkdir -p ~/.pulumi/plugins/resource-command-v0.3.2
 	mv examples/command/command ~/.pulumi/plugins/resource-command-v0.3.2/pulumi-resource-command
 	cd examples/command/sdk/go/command && go mod init && go mod edit -replace github.com/pulumi/pulumi-go-provider=../../../../ && go mod tidy
 
@@ -38,8 +40,9 @@ install_examples: build_examples
 	@if [ -d ~/.pulumi/plugins/resource-random-login-v0.1.0/ ]; then \
 		mkdir -p ~/.pulumi/plugins/resource-random-login-v0.1.0/; \
 	fi
-	rm -fr examples/random-login/sdk
+	rm -rf examples/random-login/sdk
 	cd examples/random-login && ./random-login -sdkGen -emitSchema
+	mkdir -p ~/.pulumi/plugins/resource-random-login-v0.1.0
 	mv examples/random-login/random-login ~/.pulumi/plugins/resource-random-login-v0.1.0/pulumi-resource-random-login
 	cd examples/random-login/sdk/go/randomlogin && go mod init && go mod edit -replace github.com/pulumi/pulumi-go-provider=../../../../ && go mod tidy
 

--- a/examples/random-login/main.go
+++ b/examples/random-login/main.go
@@ -34,7 +34,7 @@ type RandomLogin struct {
 	Password pulumi.StringOutput `pulumi:"password" provider:"output"`
 
 	// Inputs
-	PasswordLength pulumi.IntPtrInput `pulumi:"passwordLength"`
+	PasswordLength pulumi.IntPtrInput `pulumi:"passwordLength,optional"`
 }
 
 func (r *RandomLogin) Construct(name string, ctx *pulumi.Context) error {

--- a/examples/random-login/schema.json
+++ b/examples/random-login/schema.json
@@ -18,17 +18,13 @@
       },
       "required": [
         "username",
-        "password",
-        "passwordLength"
+        "password"
       ],
       "inputProperties": {
         "passwordLength": {
           "type": "integer"
         }
       },
-      "requiredInputs": [
-        "passwordLength"
-      ],
       "isComponent": true
     },
     "random-login:index:RandomSalt": {

--- a/examples/schema-test/main.go
+++ b/examples/schema-test/main.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/blang/semver"
 	provider "github.com/pulumi/pulumi-go-provider"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
 type Enum int
@@ -19,36 +18,25 @@ const (
 	G
 )
 
-type strct struct {
-	enum  Enum     `pulumi:"enum"`
-	names []string `pulumi:"names"`
+type Strct struct {
+	Enum  Enum     `pulumi:"enum"`
+	Names []string `pulumi:"names"`
 }
 
 func main() {
 	println(reflect.TypeOf((*Enum)(nil)).Elem().String())
 
-	spec := schema.PackageSpec{}
-
-	enum, err := provider.Enum[int]((*Enum)(nil), "schema-test", provider.EnumVals(
-		provider.EnumVal("A", 0),
-		provider.EnumVal("C", 1),
-		provider.EnumVal("T", 2),
-		provider.EnumVal("G", 3),
-	))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", err.Error())
-		os.Exit(1)
-	}
-
-	err = provider.Run("schema-test", semver.Version{Minor: 1},
-		provider.Components(),
-		provider.Resources(),
-		provider.Types((*strct)(nil)),
-		provider.Enums(enum),
-		provider.PartialSpec(spec),
+	err := provider.Run("schema-test", semver.Version{Minor: 1},
+		provider.Types(
+			provider.Enum[Enum](
+				provider.EnumVal("A", A),
+				provider.EnumVal("C", C),
+				provider.EnumVal("T", T),
+				provider.EnumVal("G", G)),
+			&Strct{}),
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", err.Error())
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
 		os.Exit(1)
 	}
 }

--- a/examples/schema-test/schema.json
+++ b/examples/schema-test/schema.json
@@ -24,7 +24,7 @@
         }
       ]
     },
-    "schema-test:index:strct": {
+    "schema-test:index:Strct": {
       "properties": {
         "enum": {
           "$ref": "#/types/schema-test:index:Enum"

--- a/internal/introspect/introspect.go
+++ b/internal/introspect/introspect.go
@@ -131,10 +131,6 @@ func GetToken(pkg tokens.Package, t interface{}) (tokens.Type, error) {
 			return "", fmt.Errorf("Cannot get token of nil type")
 		}
 	}
-	/*
-		if typ.Kind() != reflect.Struct {
-			return "", fmt.Errorf("Can only get tokens with underlying structs")
-		}*/
 
 	name := typ.Name()
 	if name == "" {

--- a/provider.go
+++ b/provider.go
@@ -33,7 +33,6 @@ import (
 
 	goGen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
 
-	"github.com/pulumi/pulumi-go-provider/internal/introspect"
 	"github.com/pulumi/pulumi-go-provider/internal/server"
 	"github.com/pulumi/pulumi-go-provider/resource"
 	"github.com/pulumi/pulumi-go-provider/types"
@@ -192,7 +191,6 @@ type options struct {
 	Customs     []resource.Custom
 	Types       []interface{}
 	Components  []resource.Component
-	Enums       []types.Enum
 	PartialSpec schema.PackageSpec
 
 	Language map[string]schema.RawMessage
@@ -221,40 +219,25 @@ func Components(components ...resource.Component) Options {
 	}
 }
 
-func Enums(enums ...types.Enum) Options {
-	return func(o *options) {
-		o.Enums = append(o.Enums, enums...)
-	}
-}
-
 func PartialSpec(spec schema.PackageSpec) Options {
 	return func(o *options) {
 		o.PartialSpec = spec
 	}
 }
 
-func Enum[T any](enum any, pkgname string, values []types.EnumValue) (types.Enum, error) {
-	t := reflect.TypeOf(enum)
-	token, err := introspect.GetToken(tokens.Package(pkgname), enum)
-	if err != nil {
-		return types.Enum{}, err
-	}
-
+func Enum[T any](values ...types.EnumValue) types.Enum {
+	v := new(T)
+	t := reflect.TypeOf(v).Elem()
 	return types.Enum{
 		Type:   t,
-		Token:  token.String(),
 		Values: values,
-	}, nil
-}
-
-func EnumVals(values ...types.EnumValue) []types.EnumValue {
-	return values
+	}
 }
 
 func EnumVal(name string, value any) types.EnumValue {
 	return types.EnumValue{
-		Value: value,
 		Name:  name,
+		Value: value,
 	}
 }
 func GoOptions(opts goGen.GoPackageInfo) Options {

--- a/resource/context.go
+++ b/resource/context.go
@@ -98,7 +98,6 @@ func (c *SContext) Log(severity diag.Severity, msg string, args ...any) error {
 // LogStatus logs a global status message, including errors and warnings. Status messages will
 // appear in the `Info` column of the progress display, but not in the final output.
 func (c *SContext) LogStatus(severity diag.Severity, msg string, args ...any) error {
-	fmt.Printf("URN: '%s'\n", c.urn)
 	return c.host.LogStatus(c.Context, severity, c.urn, fmt.Sprintf(msg, args...))
 }
 

--- a/types/enum.go
+++ b/types/enum.go
@@ -20,11 +20,10 @@ import (
 
 type Enum struct {
 	Type   reflect.Type
-	Token  string
 	Values []EnumValue
 }
 
 type EnumValue struct {
-	Value interface{}
 	Name  string
+	Value any
 }


### PR DESCRIPTION
Here I simplify the user API by requiring only a type parameter and the set of values. I also remove the `provider.Enums` function, folding that functionality into the `provider.Types` option. Since enums are conceptually just "types" in the schema, it makes sense to define them as types in this library.