### PR TITLE
Add cancel middleware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ build:
 
 test: build
 	go test ./...
+	cd integration && go test ./...
 	for d in examples/*; do if [ -d $$d ]; then \
 		cd $$d; go test ./... || exit $$?; \
 	cd -; fi; done

--- a/infer/provider.go
+++ b/infer/provider.go
@@ -19,6 +19,7 @@ import (
 
 	p "github.com/pulumi/pulumi-go-provider"
 	t "github.com/pulumi/pulumi-go-provider/middleware"
+	"github.com/pulumi/pulumi-go-provider/middleware/cancel"
 	mContext "github.com/pulumi/pulumi-go-provider/middleware/context"
 	"github.com/pulumi/pulumi-go-provider/middleware/dispatch"
 	"github.com/pulumi/pulumi-go-provider/middleware/schema"
@@ -49,12 +50,13 @@ func NewProvider() *Provider {
 		dispatcher: d,
 		schema:     s,
 	}
-	ret.Provider = mContext.Wrap(s, func(ctx p.Context) p.Context {
+	withConfig := mContext.Wrap(s, func(ctx p.Context) p.Context {
 		if ret.config == nil {
 			return ctx
 		}
 		return p.CtxWithValue(ctx, configKey, ret.config)
 	})
+	ret.Provider = cancel.Wrap(withConfig)
 	return ret
 }
 

--- a/infer/provider.go
+++ b/infer/provider.go
@@ -37,9 +37,9 @@ type Provider struct {
 	config     InferredConfig
 }
 
-type configKeyType int
+type configKeyType struct{}
 
-var configKey configKeyType = 0
+var configKey configKeyType
 
 // Create a new base provider to serve resources inferred from go code.
 func NewProvider() *Provider {

--- a/integration/tests/cancel_test.go
+++ b/integration/tests/cancel_test.go
@@ -1,0 +1,37 @@
+package cancel_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/blang/semver"
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/integration"
+	"github.com/pulumi/pulumi-go-provider/middleware"
+	"github.com/pulumi/pulumi-go-provider/middleware/cancel"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGlobalCancel(t *testing.T) {
+	wg := new(sync.WaitGroup)
+	wg.Add(3)
+	s := integration.NewServer("cancel", semver.MustParse("1.2.3"),
+		cancel.Wrap(&middleware.Scaffold{
+			CreateFn: func(ctx p.Context, req p.CreateRequest) (p.CreateResponse, error) {
+				select {
+				case <-ctx.Done():
+					wg.Done()
+					return p.CreateResponse{
+						ID:         "cancled",
+						Properties: req.Properties,
+					}, nil
+				}
+			},
+		}))
+	go func() { _, err := s.Create(p.CreateRequest{}); assert.NoError(t, err) }()
+	go func() { _, err := s.Create(p.CreateRequest{}); assert.NoError(t, err) }()
+	go func() { _, err := s.Create(p.CreateRequest{}); assert.NoError(t, err) }()
+	assert.NoError(t, s.Cancel())
+	go func() { _, err := s.Create(p.CreateRequest{}); assert.NoError(t, err) }()
+	wg.Wait()
+}

--- a/integration/tests/cancel_test.go
+++ b/integration/tests/cancel_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cancel_test
 
 import (
@@ -13,8 +27,9 @@ import (
 )
 
 func TestGlobalCancel(t *testing.T) {
+	t.Parallel()
 	wg := new(sync.WaitGroup)
-	wg.Add(3)
+	wg.Add(4)
 	s := integration.NewServer("cancel", semver.MustParse("1.2.3"),
 		cancel.Wrap(&middleware.Scaffold{
 			CreateFn: func(ctx p.Context, req p.CreateRequest) (p.CreateResponse, error) {
@@ -33,5 +48,32 @@ func TestGlobalCancel(t *testing.T) {
 	go func() { _, err := s.Create(p.CreateRequest{}); assert.NoError(t, err) }()
 	assert.NoError(t, s.Cancel())
 	go func() { _, err := s.Create(p.CreateRequest{}); assert.NoError(t, err) }()
+	wg.Wait()
+}
+
+func TestTimeoutApplication(t *testing.T) {
+	t.Parallel()
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+	s := integration.NewServer("cancel", semver.MustParse("1.2.3"),
+		cancel.Wrap(&middleware.Scaffold{
+			CreateFn: func(ctx p.Context, req p.CreateRequest) (p.CreateResponse, error) {
+				select {
+				case <-ctx.Done():
+					wg.Done()
+					return p.CreateResponse{
+						ID:         "cancled",
+						Properties: req.Properties,
+					}, nil
+				}
+			},
+		}))
+
+	go func() {
+		_, err := s.Create(p.CreateRequest{
+			Timeout: 0.5,
+		})
+		assert.NoError(t, err)
+	}()
 	wg.Wait()
 }

--- a/middleware/cancel/cancel.go
+++ b/middleware/cancel/cancel.go
@@ -1,0 +1,193 @@
+// Copyright 2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Cancel ensures that contexts are canceled when their associated tasks are completed.
+// There are two parts of this middleware:
+// 1. Tying Provider.Cancel to all associated contexts.
+// 2. Applying timeout information when available.
+package cancel
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	pprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
+
+	p "github.com/pulumi/pulumi-go-provider"
+)
+
+func Wrap(provider p.Provider) p.Provider {
+	return &cancelProvider{
+		inner:       provider,
+		cancelFuncs: inOutCache[context.CancelFunc]{},
+	}
+}
+
+type cancelProvider struct {
+	inner       p.Provider
+	cancelFuncs inOutCache[context.CancelFunc]
+	canceled    bool // If Cancel has been called on this provider
+}
+
+func (c *cancelProvider) Cancel(ctx p.Context) error {
+	for _, f := range c.cancelFuncs.drain() {
+		f()
+	}
+	return c.inner.Cancel(ctx)
+}
+
+const noTimeout float64 = 0
+
+func (c *cancelProvider) cancel(ctx p.Context, timeout float64) (p.Context, func()) {
+	var cancel context.CancelFunc
+	if timeout == noTimeout {
+		ctx, cancel = p.CtxWithCancel(ctx)
+	} else {
+		ctx, cancel = p.CtxWithTimeout(ctx, time.Second*time.Duration(timeout))
+	}
+	if c.canceled {
+		cancel()
+		return ctx, func() {}
+	}
+	evict := c.cancelFuncs.insert(cancel)
+	return ctx, func() {
+		if !evict() {
+			cancel()
+		}
+	}
+}
+
+func (c *cancelProvider) GetSchema(ctx p.Context, req p.GetSchemaRequest) (p.GetSchemaResponse, error) {
+	ctx, end := c.cancel(ctx, noTimeout)
+	defer end()
+	return c.inner.GetSchema(ctx, req)
+}
+
+func (c *cancelProvider) CheckConfig(ctx p.Context, req p.CheckRequest) (p.CheckResponse, error) {
+	ctx, end := c.cancel(ctx, noTimeout)
+	defer end()
+	return c.inner.CheckConfig(ctx, req)
+}
+
+func (c *cancelProvider) DiffConfig(ctx p.Context, req p.DiffRequest) (p.DiffResponse, error) {
+	ctx, end := c.cancel(ctx, noTimeout)
+	defer end()
+	return c.inner.DiffConfig(ctx, req)
+}
+
+func (c *cancelProvider) Configure(ctx p.Context, req p.ConfigureRequest) error {
+	ctx, end := c.cancel(ctx, noTimeout)
+	defer end()
+	return c.inner.Configure(ctx, req)
+}
+
+func (c *cancelProvider) Invoke(ctx p.Context, req p.InvokeRequest) (p.InvokeResponse, error) {
+	ctx, end := c.cancel(ctx, noTimeout)
+	defer end()
+	return c.inner.Invoke(ctx, req)
+}
+
+func (c *cancelProvider) Check(ctx p.Context, req p.CheckRequest) (p.CheckResponse, error) {
+	ctx, end := c.cancel(ctx, noTimeout)
+	defer end()
+	return c.inner.Check(ctx, req)
+}
+
+func (c *cancelProvider) Diff(ctx p.Context, req p.DiffRequest) (p.DiffResponse, error) {
+	ctx, end := c.cancel(ctx, noTimeout)
+	defer end()
+	return c.inner.Diff(ctx, req)
+}
+
+func (c *cancelProvider) Create(ctx p.Context, req p.CreateRequest) (p.CreateResponse, error) {
+	ctx, end := c.cancel(ctx, req.Timeout)
+	defer end()
+	return c.inner.Create(ctx, req)
+}
+
+func (c *cancelProvider) Read(ctx p.Context, req p.ReadRequest) (p.ReadResponse, error) {
+	ctx, end := c.cancel(ctx, noTimeout)
+	defer end()
+	return c.inner.Read(ctx, req)
+}
+
+func (c *cancelProvider) Update(ctx p.Context, req p.UpdateRequest) (p.UpdateResponse, error) {
+	ctx, end := c.cancel(ctx, req.Timeout)
+	defer end()
+	return c.inner.Update(ctx, req)
+}
+
+func (c *cancelProvider) Delete(ctx p.Context, req p.DeleteRequest) error {
+	ctx, end := c.cancel(ctx, req.Timeout)
+	defer end()
+	return c.inner.Delete(ctx, req)
+}
+
+func (c *cancelProvider) Construct(pctx p.Context, typ string, name string,
+	ctx *pulumi.Context, inputs pprovider.ConstructInputs, opts pulumi.ResourceOption) (pulumi.ComponentResource, error) {
+	pctx, end := c.cancel(pctx, noTimeout)
+	defer end()
+	return c.inner.Construct(pctx, typ, name, ctx, inputs, opts)
+}
+
+// A data structure which provides amortized O(1) insertion, removal, and draining.
+type inOutCache[T any] struct {
+	values     []*T  // An unorderd list of stored values
+	tombstones []int // An unordered list of empty slots in values
+	m          sync.Mutex
+}
+
+// Insert a new element into the inOutCahce. The new element can be ejected by calling
+// `evict`. If the element was already drained or if `evict` was already called, then
+// `evict` will return true. Otherwise it returns false.
+func (h *inOutCache[T]) insert(t T) (evict func() (missing bool)) {
+	h.m.Lock()
+	defer h.m.Unlock()
+	var i int
+	if len(h.tombstones) == 0 {
+		h.values = append(h.values, &t)
+		i = len(h.values) - 1
+	} else {
+		i = h.tombstones[len(h.tombstones)-1]
+		h.tombstones = h.tombstones[:len(h.tombstones)-1]
+		h.values[i] = &t
+	}
+	return func() bool {
+		h.m.Lock()
+		defer h.m.Unlock()
+		gone := h.values[i] == nil
+		h.values[i] = nil
+		h.tombstones = append(h.tombstones, i)
+		return gone
+	}
+}
+
+// Remove all values from the inOutCache.
+func (h *inOutCache[T]) drain() []T {
+	h.m.Lock()
+	defer h.m.Unlock()
+	values := []T{}
+	// We reset tombstones.
+	h.tombstones = h.tombstones[:0]
+	for i, v := range h.values {
+		if v != nil {
+			values = append(values, *v)
+			h.values[i] = nil
+		}
+		h.tombstones = append(h.tombstones, i)
+	}
+	return values
+}

--- a/middleware/cancel/cancel.go
+++ b/middleware/cancel/cancel.go
@@ -157,10 +157,10 @@ func (c *cancelProvider) Construct(pctx p.Context, typ string, name string,
 
 // A data structure which provides amortized O(1) insertion, removal, and draining.
 type inOutCache[T any] struct {
-	values     []*entry[T] // An unorderd list of stored values
+	values     []*entry[T] // An unorderd list of stored values or tombstone (nil) entries.
 	tombstones []int       // An unordered list of empty slots in values
 	m          sync.Mutex
-	inDrain    bool
+	inDrain    bool // Wheither the cache is currently being drained. inDrain=true implies m can be ignored.
 }
 
 type entry[T any] struct {

--- a/middleware/cancel/cancel_test.go
+++ b/middleware/cancel/cancel_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cancel
 
 import (
@@ -7,6 +21,7 @@ import (
 )
 
 func TestInOutCache(t *testing.T) {
+	t.Parallel()
 	cache := inOutCache[int]{}
 	evicts := make([]func() bool, 1000)
 	for i := 0; i < 1000; i++ {

--- a/middleware/cancel/cancel_test.go
+++ b/middleware/cancel/cancel_test.go
@@ -1,0 +1,42 @@
+package cancel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInOutCache(t *testing.T) {
+	cache := inOutCache[int]{}
+	evicts := make([]func() bool, 1000)
+	for i := 0; i < 1000; i++ {
+		evicts[i] = cache.insert(i)
+	}
+	for i := 0; i < 1000; i += 2 {
+		assert.False(t, evicts[i]())
+	}
+
+	for i := 1000; i < 1500; i++ {
+		evicts = append(evicts, cache.insert(i))
+	}
+
+	assert.Len(t, cache.values, 1001)
+
+	expected := make([]int, 0, 1000)
+	for i := 1; i < 1000; i += 2 {
+		expected = append(expected, i)
+	}
+	for i := 1000; i < 1500; i++ {
+		expected = append(expected, i)
+	}
+	elements := cache.drain()
+	assert.ElementsMatch(t, elements, expected)
+
+	// Refill the cache
+	for i := 0; i < 1000; i++ {
+		cache.insert(i + 2000)
+	}
+	for _, f := range evicts {
+		assert.True(t, f(), "cache element was evicted")
+	}
+}

--- a/provider.go
+++ b/provider.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/blang/semver"
 	pprovider "github.com/pulumi/pulumi/pkg/v3/resource/provider"
@@ -350,17 +351,45 @@ func (p *pkgContext) RuntimeInformation() RunInfo {
 	}
 }
 
-type valueCtx struct {
-	Context
-	key, value any
+type wrapCtx struct {
+	context.Context
+	log                func(severity diag.Severity, msg string)
+	logf               func(severity diag.Severity, msg string, args ...any)
+	logStatus          func(severity diag.Severity, msg string)
+	logStatusf         func(severity diag.Severity, msg string, args ...any)
+	runtimeInformation func() RunInfo
 }
 
-func (v *valueCtx) Value(key any) any {
-	if key == v.key {
-		return v.value
+// replaceContext replaces the embedded context.Context in a Context.
+func replaceContext(ctx Context, new context.Context) Context {
+	switch ctx := ctx.(type) {
+	case *wrapCtx:
+		ctx.Context = new
+		return ctx
+	case *pkgContext:
+		ctx.Context = new
+		return ctx
+	default:
+		return &wrapCtx{
+			Context:            new,
+			log:                ctx.Log,
+			logf:               ctx.Logf,
+			logStatus:          ctx.LogStatus,
+			logStatusf:         ctx.LogStatusf,
+			runtimeInformation: ctx.RuntimeInformation,
+		}
 	}
-	return v.Context.Value(key)
 }
+
+func (c *wrapCtx) Log(severity diag.Severity, msg string) { c.log(severity, msg) }
+func (c *wrapCtx) Logf(severity diag.Severity, msg string, args ...any) {
+	c.logf(severity, msg, args...)
+}
+func (c *wrapCtx) LogStatus(severity diag.Severity, msg string) { c.logStatus(severity, msg) }
+func (c *wrapCtx) LogStatusf(severity diag.Severity, msg string, args ...any) {
+	c.logStatusf(severity, msg, args...)
+}
+func (c *wrapCtx) RuntimeInformation() RunInfo { return c.runtimeInformation() }
 
 // Add a value to a Context. This is the moral equivalent to context.WithValue from the Go
 // standard library.
@@ -372,7 +401,17 @@ func CtxWithValue(ctx Context, key, value any) Context {
 			urn:      ctx.urn,
 		}
 	}
-	return &valueCtx{ctx, key, value}
+	return replaceContext(ctx, context.WithValue(ctx, key, value))
+}
+
+func CtxWithCancel(ctx Context) (Context, context.CancelFunc) {
+	c, cancel := context.WithCancel(ctx)
+	return replaceContext(ctx, c), cancel
+}
+
+func CtxWithTimeout(ctx Context, timeout time.Duration) (Context, context.CancelFunc) {
+	c, cancel := context.WithTimeout(ctx, timeout)
+	return replaceContext(ctx, c), cancel
 }
 
 func (p *provider) ctx(ctx context.Context, urn presource.URN) Context {

--- a/provider.go
+++ b/provider.go
@@ -361,7 +361,7 @@ type wrapCtx struct {
 }
 
 // replaceContext replaces the embedded context.Context in a Context.
-func replaceContext(ctx Context, new context.Context) Context {
+func replaceContext(ctx Context, new context.Context) Context { //nolint:revive
 	switch ctx := ctx.(type) {
 	case *wrapCtx:
 		ctx.Context = new


### PR DESCRIPTION
This PR adds a new middleware that ensures passed in contexts are canceled as appropriate. 

There are two distinct problems this solves:
1. Applying timeouts to their appropriate contexts.
2. Applying the `Cancel` RPC request to all other contexts.

Fixes #30 