### PR TITLE
Bug fixes for command

### DIFF
--- a/infer/configuration.go
+++ b/infer/configuration.go
@@ -133,7 +133,7 @@ func (c *config[T]) diffConfig(ctx p.Context, req p.DiffRequest) (p.DiffResponse
 	if c.t == nil {
 		c.t = new(T)
 	}
-	return diff[T, T, T](ctx, req, c.t, true)
+	return diff[T, T, T](ctx, req, c.t, func(string) bool { return true })
 }
 
 // Fetch an environmental or default value for a missing key.

--- a/infer/provider.go
+++ b/infer/provider.go
@@ -158,6 +158,11 @@ func (prov *Provider) WithModuleMap(m map[tokens.ModuleName]tokens.ModuleName) *
 	return prov
 }
 
+func (prov *Provider) WithLanguageMap(languages map[string]any) *Provider {
+	prov.schema.WithLanguageMap(languages)
+	return prov
+}
+
 // Give the provider global state. This will define a provider resource.
 func (prov *Provider) WithConfig(config InferredConfig) *Provider {
 	prov.config = config

--- a/infer/provider.go
+++ b/infer/provider.go
@@ -190,3 +190,43 @@ func (prov *Provider) Configure(ctx p.Context, req p.ConfigureRequest) error {
 	}
 	return prov.Provider.Configure(ctx, req)
 }
+
+func (prov *Provider) WithDisplayName(name string) *Provider {
+	prov.schema.WithDisplayName(name)
+	return prov
+}
+
+func (prov *Provider) WithKeywords(keywords []string) *Provider {
+	prov.schema.WithKeywords(keywords)
+	return prov
+}
+
+func (prov *Provider) WithHomepage(homepage string) *Provider {
+	prov.schema.WithHomepage(homepage)
+	return prov
+}
+
+func (prov *Provider) WithRepository(repoUrl string) *Provider {
+	prov.schema.WithRepository(repoUrl)
+	return prov
+}
+
+func (prov *Provider) WithPublisher(publisher string) *Provider {
+	prov.schema.WithPublisher(publisher)
+	return prov
+}
+
+func (prov *Provider) WithLogoURL(logoURL string) *Provider {
+	prov.schema.WithLogoURL(logoURL)
+	return prov
+}
+
+func (prov *Provider) WithLicense(license string) *Provider {
+	prov.schema.WithLicense(license)
+	return prov
+}
+
+func (prov *Provider) WithDescription(description string) *Provider {
+	prov.schema.WithDescription(description)
+	return prov
+}

--- a/infer/provider.go
+++ b/infer/provider.go
@@ -206,8 +206,8 @@ func (prov *Provider) WithHomepage(homepage string) *Provider {
 	return prov
 }
 
-func (prov *Provider) WithRepository(repoUrl string) *Provider {
-	prov.schema.WithRepository(repoUrl)
+func (prov *Provider) WithRepository(repoURL string) *Provider {
+	prov.schema.WithRepository(repoURL)
 	return prov
 }
 

--- a/infer/schema.go
+++ b/infer/schema.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -115,6 +116,17 @@ func serializeTypeAsPropertyType(t reflect.Type, indicatePlain bool, extType str
 	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
+	if t == reflect.TypeOf(resource.Asset{}) {
+		return schema.TypeSpec{
+			Ref: "pulumi.json#/Asset",
+		}, nil
+	}
+	if t == reflect.TypeOf(resource.Archive{}) {
+		return schema.TypeSpec{
+			Ref: "pulumi.json#/Archive",
+		}, nil
+	}
+
 	if enum, ok := isEnum(t); ok {
 		return schema.TypeSpec{
 			Ref: "#/types/" + enum.token,

--- a/infer/types.go
+++ b/infer/types.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
@@ -196,6 +197,9 @@ func crawlTypes[T any](crawler Crawler) error {
 // registerTypes recursively examines fields of T, calling reg on the schematized type when appropriate.
 func registerTypes[T any](reg schema.RegisterDerivativeType) error {
 	crawler := func(t reflect.Type) (bool, error) {
+		if t == reflect.TypeOf(resource.Asset{}) || t == reflect.TypeOf(resource.Archive{}) {
+			return false, nil
+		}
 		if enum, ok := isEnum(t); ok {
 			tSpec := pschema.ComplexTypeSpec{}
 			for _, v := range enum.values {

--- a/infer/types.go
+++ b/infer/types.go
@@ -158,8 +158,7 @@ func crawlTypes[T any](crawler Crawler) error {
 			// Could hold a reference to other types
 			return drill(t.Elem())
 		case reflect.Struct:
-			for i := 0; i < t.NumField(); i++ {
-				f := t.Field(i)
+			for _, f := range reflect.VisibleFields(t) {
 				info, err := introspect.ParseTag(f)
 				if err != nil {
 					return err

--- a/internal/introspect/introspect_test.go
+++ b/internal/introspect/introspect_test.go
@@ -51,7 +51,6 @@ func TestParseTag(t *testing.T) {
 				Name:     "foo",
 				Optional: true,
 				Secret:   true,
-				Output:   true,
 			},
 		},
 		{

--- a/middleware/schema/schema.go
+++ b/middleware/schema/schema.go
@@ -63,7 +63,7 @@ type Provider struct {
 	homepage          string
 	repository        string
 	publisher         string
-	logoUrl           string
+	logoURL           string
 	license           string
 	pluginDownloadURL string
 
@@ -150,9 +150,9 @@ func (s *Provider) WithHomepage(homepage string) *Provider {
 	return s
 }
 
-func (s *Provider) WithRepository(repoUrl string) *Provider {
+func (s *Provider) WithRepository(repoURL string) *Provider {
 	s.schema = ""
-	s.repository = repoUrl
+	s.repository = repoURL
 	return s
 }
 
@@ -164,7 +164,7 @@ func (s *Provider) WithPublisher(publisher string) *Provider {
 
 func (s *Provider) WithLogoURL(logoURL string) *Provider {
 	s.schema = ""
-	s.logoUrl = logoURL
+	s.logoURL = logoURL
 	return s
 }
 
@@ -192,7 +192,7 @@ func (s *Provider) generateSchema(ctx p.Context) error {
 		Homepage:          s.homepage,
 		Repository:        s.repository,
 		Publisher:         s.publisher,
-		LogoURL:           s.logoUrl,
+		LogoURL:           s.logoURL,
 		License:           s.license,
 		PluginDownloadURL: s.pluginDownloadURL,
 		Resources:         map[string]schema.ResourceSpec{},

--- a/middleware/schema/schema.go
+++ b/middleware/schema/schema.go
@@ -223,8 +223,8 @@ func renamePackage[T any](typ T, pkg string, modMap map[tokens.ModuleName]tokens
 				rewritten := fixReference(field.String(), pkg, modMap)
 				field.SetString(rewritten)
 			}
-			for i := 0; i < v.Type().NumField(); i++ {
-				f := v.Field(i)
+			for _, f := range reflect.VisibleFields(v.Type()) {
+				f := v.FieldByIndex(f.Index)
 				rename(f)
 			}
 		case reflect.Array, reflect.Slice:


### PR DESCRIPTION
Part of #38 

Various bug fixes for problems I found porting over the command provider:
- The command provider makes extensive use of embedded fields. We should support this use case: https://github.com/pulumi/pulumi-go-provider/commit/41c622504e90eb57ce406b2ba4f199adf0047f46
- To avoid writing manual diffs whenever possible, we should enforce the `provider:"replaceOnChanges"` during an inferred diff: https://github.com/pulumi/pulumi-go-provider/commit/6fa2ef0766416108e5da04503f9b54f5b5089595
- We need to support embedding `resource.Asset` and `resource.Archive` in serialized structs, both at the type and schema level: https://github.com/pulumi/pulumi-go-provider/commit/7c73385922f962e37d15c5b2a9a15399afbb471e.