### PR TITLE
Fix context and add default deps

### DIFF
--- a/infer/resource.go
+++ b/infer/resource.go
@@ -100,7 +100,9 @@ type CustomUpdate[I, O any] interface {
 
 // A resource that can recover its state from the provider.
 //
-// There is no default behavior for CustomRead.
+// If CustomRead is not implemented, it will default to checking that the inputs and state
+// fit into I and O respectively. If they do, then the values will be returned as is.
+// Otherwise an error will be returned.
 //
 // Example:
 // TODO - Probably something to do with the file system.
@@ -630,10 +632,6 @@ func (rc *derivedResourceController[R, I, O]) Create(ctx p.Context, req p.Create
 
 func (rc *derivedResourceController[R, I, O]) Read(ctx p.Context, req p.ReadRequest) (p.ReadResponse, error) {
 	r := rc.getInstance(ctx, req.Urn, "Read")
-	read, ok := ((interface{})(*r)).(CustomRead[I, O])
-	if !ok {
-		return p.ReadResponse{}, status.Errorf(codes.Unimplemented, "Read is not implemented for resource %s", req.Urn)
-	}
 	var inputs I
 	var state O
 	var err error
@@ -644,6 +642,18 @@ func (rc *derivedResourceController[R, I, O]) Read(ctx p.Context, req p.ReadRequ
 	stateSecrets, err := decode(req.Properties, &state, true)
 	if err != nil {
 		return p.ReadResponse{}, err
+	}
+	read, ok := ((interface{})(*r)).(CustomRead[I, O])
+	if !ok {
+		// Default read implementation:
+		//
+		// We have already confirmed that we deserialize state and properties correctly.
+		// We now just return them as is.
+		return p.ReadResponse{
+			ID:         req.ID,
+			Properties: req.Properties,
+			Inputs:     req.Inputs,
+		}, nil
 	}
 	id, inputs, state, err := read.Read(ctx, req.ID, inputs, state)
 	if err != nil {

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -614,6 +614,12 @@ func (rc *derivedResourceController[R, I, O]) Create(ctx p.Context, req p.Create
 			return p.CreateResponse{}, err
 		}
 		fg.MarkMap(req.Properties, m)
+	} else if req.Properties.ContainsUnknowns() {
+		for k, v := range m {
+			if !v.IsComputed() {
+				m[k] = resource.MakeComputed(v)
+			}
+		}
 	}
 
 	return p.CreateResponse{
@@ -694,6 +700,12 @@ func (rc *derivedResourceController[R, I, O]) Update(ctx p.Context, req p.Update
 			return p.UpdateResponse{}, err
 		}
 		fg.MarkMap(req.News, m)
+	} else if req.News.ContainsUnknowns() {
+		for k, v := range m {
+			if !v.IsComputed() {
+				m[k] = resource.MakeComputed(v)
+			}
+		}
 	}
 
 	return p.UpdateResponse{

--- a/provider.go
+++ b/provider.go
@@ -385,11 +385,20 @@ type wrapCtx struct {
 func replaceContext(ctx Context, new context.Context) Context { //nolint:revive
 	switch ctx := ctx.(type) {
 	case *wrapCtx:
-		ctx.Context = new
-		return ctx
+		return &wrapCtx{
+			Context:            new,
+			log:                ctx.log,
+			logf:               ctx.logf,
+			logStatus:          ctx.logStatus,
+			logStatusf:         ctx.logStatusf,
+			runtimeInformation: ctx.runtimeInformation,
+		}
 	case *pkgContext:
-		ctx.Context = new
-		return ctx
+		return &pkgContext{
+			Context:  new,
+			provider: ctx.provider,
+			urn:      ctx.urn,
+		}
 	default:
 		return &wrapCtx{
 			Context:            new,
@@ -415,13 +424,6 @@ func (c *wrapCtx) RuntimeInformation() RunInfo { return c.runtimeInformation() }
 // Add a value to a Context. This is the moral equivalent to context.WithValue from the Go
 // standard library.
 func CtxWithValue(ctx Context, key, value any) Context {
-	if ctx, ok := ctx.(*pkgContext); ok {
-		return &pkgContext{
-			Context:  context.WithValue(ctx.Context, key, value),
-			provider: ctx.provider,
-			urn:      ctx.urn,
-		}
-	}
 	return replaceContext(ctx, context.WithValue(ctx, key, value))
 }
 

--- a/provider_test.go
+++ b/provider_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package provider
 
 import (
@@ -8,6 +22,7 @@ import (
 )
 
 func TestCtx(t *testing.T) {
+	t.Parallel()
 	var ctx Context = &pkgContext{
 		Context: context.Background(),
 		urn:     "foo",

--- a/provider_test.go
+++ b/provider_test.go
@@ -1,0 +1,23 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCtx(t *testing.T) {
+	var ctx Context = &pkgContext{
+		Context: context.Background(),
+		urn:     "foo",
+	}
+
+	ctx = CtxWithValue(ctx, "foo", "bar")
+	ctx, cancel := CtxWithCancel(ctx)
+	ctx = CtxWithValue(ctx, "fizz", "buzz")
+	assert.Equal(t, "bar", ctx.Value("foo").(string))
+	cancel()
+	assert.Equal(t, "buzz", ctx.Value("fizz").(string))
+	assert.Error(t, ctx.Err(), "This should be cancled")
+}


### PR DESCRIPTION
Part of #38 
- The first commit prevents nested contexts from unbounded recursion.
- The second defaults resources to mark all outputs as unknown if any inputs are unknown (and inputs are not explicitly wired to outputs).
- The last PR adds a default READ implementation so that refresh works out of the box.