### PR TITLE
Comply with invoke naming conventions

### DIFF
--- a/examples/str/main_test.go
+++ b/examples/str/main_test.go
@@ -17,7 +17,7 @@ const schema = `{
   "config": {},
   "provider": {},
   "functions": {
-    "str:index:GiveMeAString": {
+    "str:index:giveMeAString": {
       "description": "Return a string, withing any inputs",
       "inputs": {
         "type": "object"
@@ -34,7 +34,7 @@ const schema = `{
         ]
       }
     },
-    "str:index:Print": {
+    "str:index:print": {
       "description": "Print to stdout",
       "inputs": {
         "properties": {
@@ -51,7 +51,7 @@ const schema = `{
         "type": "object"
       }
     },
-    "str:index:Replace": {
+    "str:index:replace": {
       "description": "Replace returns a copy of the string s with all\nnon-overlapping instances of old replaced by new.\nIf old is empty, it matches at the beginning of the string\nand after each UTF-8 sequence, yielding up to k+1 replacements\nfor a k-rune string.",
       "inputs": {
         "properties": {
@@ -87,7 +87,7 @@ const schema = `{
         ]
       }
     },
-    "str:regex:Replace": {
+    "str:regex:replace": {
       "description": "Replace returns a copy of ` + "`s`" + `, replacing matches of the ` + "`old`" + `\nwith the replacement string ` + "`new`" + `.",
       "inputs": {
         "properties": {
@@ -139,7 +139,7 @@ func TestInvokes(t *testing.T) {
 	server := integration.NewServer("str", semver.Version{Minor: 1}, provider())
 
 	r, err := server.Invoke(p.InvokeRequest{
-		Token: "str:index:Replace",
+		Token: "str:index:replace",
 		Args: presource.NewPropertyMapFromMap(map[string]interface{}{
 			"s":   "foo!bar",
 			"old": "!",
@@ -151,7 +151,7 @@ func TestInvokes(t *testing.T) {
 	assert.Equal(t, "foo-bar", r.Return["out"].StringValue())
 
 	r, err = server.Invoke(p.InvokeRequest{
-		Token: "str:regex:Replace",
+		Token: "str:regex:replace",
 		Args: presource.NewPropertyMapFromMap(map[string]interface{}{
 			"s":       "fizz, buzz, zzz...",
 			"pattern": "z+",

--- a/infer/function_test.go
+++ b/infer/function_test.go
@@ -1,0 +1,40 @@
+// Copyright 2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infer
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFnTokens(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ input, expected tokens.Type }{
+		{"pkg:foo:Run", "pkg:foo:run"},
+		{"pkg:foo:ToJSON", "pkg:foo:toJSON"},
+		{"pkg:foo:FOO", "pkg:foo:foo"},
+		{"pkg:foo:FIZZBuzz", "pkg:foo:fizzBuzz"},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(string(c.input), func(t *testing.T) {
+			assert.Equal(t, c.expected, fnToken(c.input))
+		})
+	}
+
+}

--- a/infer/function_test.go
+++ b/infer/function_test.go
@@ -33,6 +33,7 @@ func TestFnTokens(t *testing.T) {
 	for _, c := range cases {
 		c := c
 		t.Run(string(c.input), func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, c.expected, fnToken(c.input))
 		})
 	}

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -126,13 +126,13 @@ type CustomDelete[O any] interface {
 // The methods of Annotator must be called on pointers to fields of their receivers, or on
 // their receiver itself.
 //
-// func (*s Struct) Annotated(a Annotator) {
-//  a.Describe(&s, "A struct")            // Legal
-//	a.Describe(&s.field1, "A field")      // Legal
-//	a.Describe(s.field2, "A field")       // Not legal, since the pointer is missing.
-//	otherS := &Struct{}
-//	a.Describe(&otherS.field1, "A field") // Not legal, since describe is not called on its receiver.
-// }
+//	func (*s Struct) Annotated(a Annotator) {
+//		a.Describe(&s, "A struct")            // Legal
+//		a.Describe(&s.field1, "A field")      // Legal
+//		a.Describe(s.field2, "A field")       // Not legal, since the pointer is missing.
+//		otherS := &Struct{}
+//		a.Describe(&otherS.field1, "A field") // Not legal, since describe is not called on its receiver.
+//	}
 type Annotator interface {
 	// Annotate a struct field with a text description.
 	Describe(i any, description string)


### PR DESCRIPTION
It looks like invokes should start with a lower case letter. This PR brings inferred schemas into compliance. 