### PR TITLE
Pass provider.Context to infer.Component.Construct

### DIFF
--- a/examples/random-login/main.go
+++ b/examples/random-login/main.go
@@ -48,7 +48,7 @@ type MoreRandomPasswordState struct {
 	Password *random.RandomPassword `pulumi:"password" provider:"type=random@v4.8.1:index/randomPassword:RandomPassword"`
 }
 
-func (r *MoreRandomPassword) Construct(ctx *pulumi.Context, name, typ string, args MoreRandomPasswordArgs, opts pulumi.ResourceOption) (*MoreRandomPasswordState, error) {
+func (r *MoreRandomPassword) Construct(pctx p.Context, ctx *pulumi.Context, name, typ string, args MoreRandomPasswordArgs, opts pulumi.ResourceOption) (*MoreRandomPasswordState, error) {
 	comp := &MoreRandomPasswordState{}
 	err := ctx.RegisterComponentResource(typ, name, comp, opts)
 	if err != nil {
@@ -79,7 +79,7 @@ type RandomLoginOutput struct {
 	Password pulumi.StringOutput `pulumi:"password"`
 }
 
-func (r *RandomLogin) Construct(ctx *pulumi.Context, name, typ string, args RandomLoginArgs, opts pulumi.ResourceOption) (*RandomLoginOutput, error) {
+func (r *RandomLogin) Construct(pctx p.Context, ctx *pulumi.Context, name, typ string, args RandomLoginArgs, opts pulumi.ResourceOption) (*RandomLoginOutput, error) {
 	comp := &RandomLoginOutput{}
 	err := ctx.RegisterComponentResource(typ, name, comp, opts)
 	if err != nil {

--- a/infer/component.go
+++ b/infer/component.go
@@ -34,7 +34,7 @@ type ComponentResource[I any, O pulumi.ComponentResource] interface {
 	//
 	// ctx.RegisterResource needs to be called, but ctx.RegisterOutputs does not need to
 	// be called.
-	Construct(ctx *pulumi.Context, name, typ string, inputs I, opts pulumi.ResourceOption) (O, error)
+	Construct(pctx p.Context, ctx *pulumi.Context, name, typ string, inputs I, opts pulumi.ResourceOption) (O, error)
 }
 
 // A component resource inferred from code. To get an instance of an InferredComponent,
@@ -85,7 +85,7 @@ func (rc *derivedComponentController[R, I, O]) Construct(pctx p.Context, typ str
 	if err != nil {
 		return nil, fmt.Errorf("failed to copy inputs for %s (%s): %w", name, typ, err)
 	}
-	res, err := r.Construct(ctx, name, typ, i, opts)
+	res, err := r.Construct(pctx, ctx, name, typ, i, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/component_test.go
+++ b/tests/component_test.go
@@ -30,7 +30,7 @@ import (
 
 type Foo struct{ pulumi.ComponentResource }
 
-func (*Foo) Construct(ctx *pulumi.Context, name string, typ string, inputs FooArgs, opts pulumi.ResourceOption) (*Foo, error) {
+func (*Foo) Construct(p.Context, *pulumi.Context, string, string, FooArgs, pulumi.ResourceOption) (*Foo, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Fixes #54 

I'm not aware of a way to unify the `*pulumi.Context` and `provider.Context` types such that a new type `*pulumi.Context&provider.Context` can be passed in place of either. For this, we would need `*pulumi.Context` to be an `interface` instead of a `struct`.

I'm open to other ideas here.