### PR TITLE
Allow a schema.*Resource to give its own aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 examples/**/pulumi-resource-*
 
 /.vscode
+
+examples/*/*.json

--- a/infer/component.go
+++ b/infer/component.go
@@ -59,18 +59,19 @@ func Component[R ComponentResource[I, O], I any, O pulumi.ComponentResource]() I
 type derivedComponentController[R ComponentResource[I, O], I any, O pulumi.ComponentResource] struct{}
 
 func (rc *derivedComponentController[R, I, O]) GetSchema(reg schema.RegisterDerivativeType) (
-	pschema.ResourceSpec, error) {
+	pschema.ResourceSpec, schema.Associated, error) {
 	r, err := getResourceSchema[R, I, O](true)
 	if err := err.ErrorOrNil(); err != nil {
-		return pschema.ResourceSpec{}, err
+		return pschema.ResourceSpec{}, schema.Associated{}, err
 	}
 	if err := registerTypes[I](reg); err != nil {
-		return pschema.ResourceSpec{}, err
+		return pschema.ResourceSpec{}, schema.Associated{}, err
 	}
 	if err := registerTypes[O](reg); err != nil {
-		return pschema.ResourceSpec{}, err
+		return pschema.ResourceSpec{}, schema.Associated{}, err
 	}
-	return r, nil
+
+	return r, schema.Associated{}, nil
 }
 
 func (rc *derivedComponentController[R, I, O]) GetToken() (tokens.Type, error) {

--- a/infer/function.go
+++ b/infer/function.go
@@ -74,7 +74,9 @@ func fnToken(tk tokens.Type) tokens.Type {
 	return tokens.NewTypeToken(tk.Module(), tokens.TypeName(name))
 }
 
-func (*derivedInvokeController[F, I, O]) GetSchema(reg schema.RegisterDerivativeType) (pschema.FunctionSpec, schema.Associated, error) {
+func (*derivedInvokeController[F, I, O]) GetSchema(
+	reg schema.RegisterDerivativeType,
+) (pschema.FunctionSpec, schema.Associated, error) {
 	var f F
 	descriptions := getAnnotated(reflect.TypeOf(f))
 

--- a/infer/function.go
+++ b/infer/function.go
@@ -74,31 +74,31 @@ func fnToken(tk tokens.Type) tokens.Type {
 	return tokens.NewTypeToken(tk.Module(), tokens.TypeName(name))
 }
 
-func (*derivedInvokeController[F, I, O]) GetSchema(reg schema.RegisterDerivativeType) (pschema.FunctionSpec, error) {
+func (*derivedInvokeController[F, I, O]) GetSchema(reg schema.RegisterDerivativeType) (pschema.FunctionSpec, schema.Associated, error) {
 	var f F
 	descriptions := getAnnotated(reflect.TypeOf(f))
 
 	input, err := objectSchema(reflect.TypeOf(new(I)))
 	if err != nil {
-		return pschema.FunctionSpec{}, err
+		return pschema.FunctionSpec{}, schema.Associated{}, err
 	}
 	output, err := objectSchema(reflect.TypeOf(new(O)))
 	if err != nil {
-		return pschema.FunctionSpec{}, err
+		return pschema.FunctionSpec{}, schema.Associated{}, err
 	}
 
 	if err := registerTypes[I](reg); err != nil {
-		return pschema.FunctionSpec{}, err
+		return pschema.FunctionSpec{}, schema.Associated{}, err
 	}
 	if err := registerTypes[O](reg); err != nil {
-		return pschema.FunctionSpec{}, err
+		return pschema.FunctionSpec{}, schema.Associated{}, err
 	}
 
 	return pschema.FunctionSpec{
 		Description: descriptions.Descriptions[""],
 		Inputs:      input,
 		Outputs:     output,
-	}, nil
+	}, schema.Associated{}, nil
 }
 
 func objectSchema(t reflect.Type) (*pschema.ObjectTypeSpec, error) {

--- a/middleware/schema/schema.go
+++ b/middleware/schema/schema.go
@@ -307,7 +307,7 @@ func (s *state) generateSchema(ctx p.Context) (schema.PackageSpec, error) {
 	}
 
 	pkg = transformTypes(pkg, func(typ schema.TypeSpec) schema.TypeSpec {
-		const internalRefPrefx = "#/tokens/type/"
+		const internalRefPrefx = "#/types/"
 		if !strings.HasPrefix(typ.Ref, internalRefPrefx) {
 			return typ
 		}
@@ -315,14 +315,15 @@ func (s *state) generateSchema(ctx p.Context) (schema.PackageSpec, error) {
 		if !ok {
 			return typ
 		}
-		typ.Ref = internalRefPrefx + changeTo.String()
+		typ.Ref = "#/resources/" + assignTo(changeTo, pkg.Name, s.ModuleMap).String()
 		return typ
 	})
 
 	for from := range aliases {
 		// We delete aliased resources and types, since they are unreferencable
-		delete(pkg.Resources, from.reconstruct(tokens.PackageName(pkg.Name)).String())
-		delete(pkg.Types, from.reconstruct(tokens.PackageName(pkg.Name)).String())
+		token := from.reconstruct(tokens.PackageName(pkg.Name)).String()
+		delete(pkg.Resources, token)
+		delete(pkg.Types, token)
 	}
 
 	return pkg, nil

--- a/tests/component_test.go
+++ b/tests/component_test.go
@@ -124,7 +124,7 @@ const componentSchema = `{
         "foo:tests:Foo": {
             "inputProperties": {
                 "bar": {
-                    "$ref": "#/types/foo:tests:BarState"
+                    "$ref": "#/resources/foo:tests:Bar"
                 },
                 "bundle": {
                     "$ref": "#/types/foo:tests:Bundle"

--- a/tests/schema_test.go
+++ b/tests/schema_test.go
@@ -39,10 +39,10 @@ func (r *givenResource) GetToken() (tokens.Type, error) {
 	return r.token, nil
 }
 
-func (r *givenResource) GetSchema(f schema.RegisterDerivativeType) (pschema.ResourceSpec, error) {
+func (r *givenResource) GetSchema(f schema.RegisterDerivativeType) (pschema.ResourceSpec, schema.Associated, error) {
 	var s pschema.ResourceSpec
 	s.Description = r.text
-	return s, nil
+	return s, schema.Associated{}, nil
 }
 
 func TestMergeSchema(t *testing.T) {


### PR DESCRIPTION
Note: This is a differnt concept of alias then a schema alias. This alias is used to rewrite the schema, pointing references of the alias to the original TK.

Use case:

This allows a component resource to embed the state of a custom resource and get the expected result (instead of a seperate `#/type/pkg:mod:FooState`).