### PR TITLE
Allow selecting all fields with a `infer.FieldSelector`

### DIFF
--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -20,6 +20,7 @@ import (
 
 	r "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractSecrets(t *testing.T) {
@@ -177,4 +178,92 @@ func TestTypedUnknowns(t *testing.T) {
 	assert.True(t, m["inner"].OutputValue().Element.IsObject(), "Object")
 	assert.Len(t, m["inner"].OutputValue().Element.ObjectValue(), 1)
 	assert.True(t, m["data"].OutputValue().Element.IsObject(), "Map")
+}
+
+func TestFieldGenerator(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		Fizz string  `pulumi:"a1,optional"`
+		Bar  float64 `pulumi:"a2"`
+	}
+	type state struct {
+		F1 int    `pulumi:"f1,optional"`
+		F2 string `pulumi:"f2"`
+	}
+
+	tests := []struct {
+		name   string
+		wire   func(fs FieldSelector, a *args, s *state)
+		assert func(t *testing.T, fg fieldGenerator)
+	}{
+		{
+			name: "all deps",
+			wire: func(fs FieldSelector, a *args, s *state) {
+				allFields := fs.InputField(a)
+				fs.OutputField(&s.F1).DependsOn(allFields)
+			},
+			assert: func(t *testing.T, fg fieldGenerator) {
+				out := r.NewPropertyMapFromMap(map[string]interface{}{
+					"f1": 0,
+					"f2": "a string",
+				})
+
+				fg.MarkMap(r.PropertyMap{
+					"a1": r.MakeSecret(r.NewStringProperty("")),
+					"a2": r.NewNumberProperty(0.0),
+				}, out)
+				require.NoError(t, fg.err.ErrorOrNil())
+				t.Logf("depsMap: %#v", fg.deps)
+				assert.True(t, out["f1"].IsSecret(), "f1")
+				assert.False(t, out["f2"].IsSecret(), "f2")
+			},
+		},
+		{
+			name: "individual deps",
+			wire: func(fs FieldSelector, a *args, s *state) {
+				fs.OutputField(&s.F1).DependsOn(fs.InputField(&a.Fizz))
+				fs.OutputField(&s.F2).DependsOn(fs.InputField(&a.Bar))
+			},
+			assert: func(t *testing.T, fg fieldGenerator) {
+				out := r.NewPropertyMapFromMap(map[string]interface{}{
+					"f1": 0,
+					"f2": "a string",
+				})
+				in := r.NewPropertyMapFromMap(map[string]interface{}{
+					"a1": r.NewStringProperty(""),
+					"a2": r.NewNumberProperty(0),
+				})
+				test := func(fizz, bar bool) {
+					out := out.Copy()
+					in := in.Copy()
+					if fizz {
+						in["a1"] = r.MakeSecret(in["a1"])
+					}
+					if bar {
+						in["a2"] = r.MakeSecret(in["a2"])
+					}
+					fg.MarkMap(in, out)
+					assert.Equal(t, fizz, out["f1"].IsSecret())
+					assert.Equal(t, bar, out["f2"].IsSecret())
+				}
+
+				for _, fizz := range []bool{true, false} {
+					for _, bar := range []bool{true, false} {
+						test(fizz, bar)
+					}
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			i, o := &args{}, &state{}
+			fm := newFieldGenerator(i, o)
+			tt.wire(fm, i, o)
+			tt.assert(t, *fm)
+		})
+	}
+
 }

--- a/internal/introspect/introspect_test.go
+++ b/internal/introspect/introspect_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi-go-provider/internal/introspect"
@@ -106,4 +107,37 @@ func TestAnnotate(t *testing.T) {
 	assert.Equal(t, "Fizz", a.Defaults["foo"])
 	assert.Equal(t, "Fizz is not MyStruct.Foo.", a.Descriptions["fizz"])
 	assert.Equal(t, "This is MyStruct, but also your struct.", a.Descriptions[""])
+}
+
+func TestAllFields(t *testing.T) {
+	t.Parallel()
+
+	type MyStruct struct {
+		Foo     string `pulumi:"foo,optional" provider:"secret,output"`
+		Fizz    *int   `pulumi:"fizz"`
+		ExtType string
+	}
+	s := &MyStruct{}
+	fm := introspect.NewFieldMatcher(s)
+
+	fields, ok, err := fm.TargetStructFields(s)
+	require.True(t, ok)
+	assert.NoError(t, err)
+	assert.Len(t, fields, 2)
+}
+
+func TestAllFieldsMiss(t *testing.T) {
+	t.Parallel()
+
+	type MyStruct struct {
+		Foo     string `pulumi:"foo,optional" provider:"secret,output"`
+		Fizz    *int   `pulumi:"fizz"`
+		ExtType string
+	}
+	s := &MyStruct{}
+	fm := introspect.NewFieldMatcher(s)
+
+	_, ok, err := fm.TargetStructFields(&s.Fizz)
+	require.False(t, ok)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Fixes #65

I view this as a pre-req for https://github.com/pulumi/pulumi-go-provider/issues/66. The new default behavior will just be `fs.OutputField(state).DependsOn(fs.InputField(input))`.