### PR TITLE
Support custom configure call

### DIFF
--- a/examples/credentials/consumer/Pulumi.yaml
+++ b/examples/credentials/consumer/Pulumi.yaml
@@ -10,13 +10,15 @@ resources:
   provider:
     type: pulumi:providers:credentials
     properties:
-      user: "Username"
+      user: "PlantRoot"
       password: "123456"
+      hash: "Adler32"
   user:
     type: credentials:User
     options:
       provider: ${provider}
 
 outputs:
-  user: ${user.value}
-  password: ${provider.password}
+  user: ${user.name}
+  password: ${user.password}
+  rawPassword: ${provider.password}

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -436,7 +436,7 @@ func (rc *derivedResourceController[R, I, O]) GetToken() (tokens.Type, error) {
 	return introspect.GetToken("pkg", r)
 }
 
-func (rc *derivedResourceController[R, I, O]) getInstance(_ p.Context, urn resource.URN, call string) *R {
+func (rc *derivedResourceController[R, I, O]) getInstance(_ p.Context, urn resource.URN, _ string) *R {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 	_, ok := rc.m[urn]
@@ -848,13 +848,12 @@ func typeUnknowns(m resource.PropertyValue, dst reflect.Type) resource.PropertyV
 			if !ok {
 				if tag.Optional {
 					continue
-				} else {
-					// Create a new unknown output, which we will then type
-					v = resource.NewOutputProperty(resource.Output{
-						Element: resource.NewNullProperty(),
-						Known:   false,
-					})
 				}
+				// Create a new unknown output, which we will then type
+				v = resource.NewOutputProperty(resource.Output{
+					Element: resource.NewNullProperty(),
+					Known:   false,
+				})
 			}
 			result[resource.PropertyKey(tag.Name)] = typeUnknowns(v, field.Type)
 		}


### PR DESCRIPTION
Support for running custom (non user-facing) logic within the `Configure` step of a provider.