### PR TITLE
Fix a few issues with diff

### DIFF
--- a/infer/resource.go
+++ b/infer/resource.go
@@ -573,12 +573,14 @@ func diff[R, I, O any](ctx p.Context, req p.DiffRequest, r *R, forceReplace func
 	if err != nil {
 		return p.DiffResponse{}, err
 	}
-	objDiff := req.News.Diff(req.Olds, func(prop resource.PropertyKey) bool {
-		// Olds is an Output, but news is an Input. Output should be a superset of Input,
-		// so we need to filter out fields that are in Output but not Input.
-		_, isInput := inputProps[string(prop)]
-		return !isInput
-	})
+	// Olds is an Output, but news is an Input. Output should be a superset of Input,
+	// so we need to filter out fields that are in Output but not Input.
+	oldInputs := resource.PropertyMap{}
+	for k := range inputProps {
+		key := resource.PropertyKey(k)
+		oldInputs[key] = req.Olds[key]
+	}
+	objDiff := oldInputs.Diff(req.News)
 	pluginDiff := plugin.NewDetailedDiffFromObjectDiff(objDiff)
 	diff := map[string]p.PropertyDiff{}
 


### PR DESCRIPTION
The diff routine has three issues:
1. It does not correctly handled changes in nested properties
2. It inverts adds/deletes in the diffs it reports, leading to confusing diff presentation
3. It is untested.

This PR fixes these issues.

The first issue was introduced by the use of `ignoreKeys` callbacks on PropertyValue Diff.  Unfortunately, that feature in pulumi/pulumi is not really safe to use, because it doesn't return full property paths, only the final key name in the nested path.  So the caller cannot determine which nested key is really being referenced.  The only other place it is used in pulumi/pulumi happens to only need to be correct for top-level properties, so happens to work.  But it does not work for the way it was being used here.

The second issue is an inversion of the order of arguments to PropertyMap#Diff.

Test coverage for all the core of Diff is added.  Additional coverage for ignoreChanges, CustomDiff, and Replacements should also be added in the future.

Fixes https://github.com/pulumi/pulumi-command/issues/231.