### PR TITLE
Separate computed and secret dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 examples/**/pulumi-resource-*
 
 /.vscode
+
+**/testdata/rapid/**

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -332,10 +332,10 @@ func markSecret(
 		return ende.MakeSecret(prop)
 	}
 
-	if input, ok := inputs[key]; ok && !ende.IsSecret(input) && ende.DeepEquals(input, prop) {
+	if input, ok := inputs[key]; ok && ende.DeepEquals(input, prop) {
 		// prop might depend on a secret value, but the output mirrors a input in
-		// name and value. We don't make it secret since it will be public in the
-		// state anyway.
+		// name and value. We don't make it secret since it will either be public
+		// in the state as an input, or is already a secret.
 		return prop
 	}
 
@@ -345,7 +345,7 @@ func markSecret(
 		if !k.has(inputSecret) {
 			continue
 		}
-		if ende.IsSecret(inputs[resource.PropertyKey(k.name)]) {
+		if inputs[resource.PropertyKey(k.name)].ContainsSecrets() {
 			return ende.MakeSecret(prop)
 		}
 	}

--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -111,7 +111,7 @@ func TestDefaultDependencies(t *testing.T) {
 
 		for k, v := range output {
 			// An input of the same name is secret, so this should be too.
-			if ende.IsSecret(newInput[k]) {
+			if newInput[k].ContainsSecrets() {
 				assert.Truef(t, ende.IsSecret(v),
 					"key: %q", string(k))
 			}

--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -102,8 +102,7 @@ func TestDefaultDependencies(t *testing.T) {
 			// If there is a change, then every item item should be
 			// computed, except items that mirror a known input.
 			for k, v := range output {
-				if n, ok := newInput[k]; !ok ||
-					ende.IsComputed(n) {
+				if _, ok := newInput[k]; !ok {
 					assert.True(t, ende.IsComputed(v),
 						"key: %q", string(k))
 				}

--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -94,7 +94,7 @@ func TestDefaultDependencies(t *testing.T) {
 					continue
 				}
 				assert.True(t, ende.IsComputed(v),
-					"key: %q, value: %#v", string(k), v)
+					"key: %q", string(k))
 			}
 		} else if !ende.DeepEquals(
 			r.NewObjectProperty(oldInput),
@@ -102,8 +102,8 @@ func TestDefaultDependencies(t *testing.T) {
 			// If there is a change, then every item item should be
 			// computed, except items that mirror a known input.
 			for k, v := range output {
-				if new, ok := newInput[k]; !ok ||
-					ende.IsComputed(new) {
+				if n, ok := newInput[k]; !ok ||
+					ende.IsComputed(n) {
 					assert.True(t, ende.IsComputed(v),
 						"key: %q", string(k))
 				}

--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -102,9 +102,12 @@ func TestDefaultDependencies(t *testing.T) {
 			// If there is a change, then every item item should be
 			// computed, except items that mirror a known input.
 			for k, v := range output {
-				if _, ok := newInput[k]; !ok {
+				newV, ok := newInput[k]
+				if !ok {
 					assert.True(t, ende.IsComputed(v),
 						"key: %q", string(k))
+				} else if !ende.IsComputed(v) {
+					assert.True(t, ende.DeepEquals(v, newV))
 				}
 			}
 		}

--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -16,14 +16,111 @@ package infer
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
-	provider "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	r "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+
+	provider "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer/internal/ende"
+	rRapid "github.com/pulumi/pulumi-go-provider/internal/rapid/resource"
 )
+
+// testGetDependencies runs a property test that asserts on the flow between inputs and
+// outputs for some I, O ∈ GoType and ∀ (old,new) ∈ I, out ∈ O.
+func testGetDependencies[I any, O any](t *testing.T,
+	wire func(FieldSelector, *I, *O),
+	assert func(t *testing.T, oldInput, newInput, output r.PropertyMap),
+) {
+	var i I
+	var o O
+	wireDeps := func(f FieldSelector) {
+		if wire != nil {
+			wire(f, &i, &o)
+		}
+	}
+	setDeps, err := getDependenciesRaw(
+		&i, &o, wireDeps,
+		false, /*isCreate*/
+		true /*isPreview*/)
+	require.NoError(t, err)
+
+	inputT := rapid.Just(reflect.TypeOf(i))
+	outputT := rapid.Just(reflect.TypeOf(o))
+
+	getMap := func(t rRapid.Typed) r.PropertyMap {
+		return t.Value.ObjectValue()
+	}
+
+	rapid.Check(t, func(rt *rapid.T) {
+		oldInput := rapid.Map(rRapid.ValueOf(inputT), getMap).
+			Draw(rt, "oldInput")
+		newInput := rapid.Map(rRapid.ValueOf(inputT), getMap).
+			Draw(rt, "newInput")
+		output := rapid.Map(rRapid.ValueOf(outputT), getMap).
+			Draw(rt, "output")
+
+		setDeps(oldInput, newInput, output)
+
+		assert(t, oldInput, newInput, output)
+	})
+}
+
+func TestDefaultDependencies(t *testing.T) {
+	t.Parallel()
+	type input struct {
+		I1 string            `pulumi:"i1"`
+		I2 *int              `pulumi:"i2,optional"`
+		I3 map[string]string `pulumi:"i3"`
+	}
+
+	type output struct {
+		input
+
+		O1 *string        `pulumi:"o1,optional"`
+		O2 float64        `pulumi:"o2"`
+		O3 map[string]int `pulumi:"o2"`
+	}
+
+	assert := func(t *testing.T, oldInput, newInput, output r.PropertyMap) {
+		if newInput.ContainsUnknowns() {
+			for k, v := range output {
+				if newV, ok := newInput[k]; ok &&
+					ende.DeepEquals(newV, v) {
+					continue
+				}
+				assert.True(t, ende.IsComputed(v),
+					"key: %q, value: %#v", string(k), v)
+			}
+		} else if !ende.DeepEquals(
+			r.NewObjectProperty(oldInput),
+			r.NewObjectProperty(newInput)) {
+			// If there is a change, then every item item should be
+			// computed, except items that mirror a known input.
+			for k, v := range output {
+				if new, ok := newInput[k]; !ok ||
+					ende.IsComputed(new) {
+					assert.True(t, ende.IsComputed(v),
+						"key: %q", string(k))
+				}
+			}
+		}
+
+		for k, v := range output {
+			// An input of the same name is secret, so this should be too.
+			if ende.IsSecret(newInput[k]) {
+				assert.Truef(t, ende.IsSecret(v),
+					"key: %q", string(k))
+			}
+		}
+	}
+
+	testGetDependencies[input, output](t, nil, assert)
+}
 
 func TestFieldGenerator(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes #122 

---

This PR separates dependency flow for computedness and secretness.

By default, we apply the following strategies:

### Secrets
An output property is secret if and only if there is an input property of the same name that is also secret

### Computed
An output property is computed if there is any change in between old and new inputs unless there is an input property of the same name and value that is not computed.