### PR TITLE
Don't hydrate nil structs that are marked as optional

### DIFF
--- a/infer/tests/provider.go
+++ b/infer/tests/provider.go
@@ -193,13 +193,24 @@ type WithDefaultsArgs struct {
 	String       string                     `pulumi:"s,optional"`
 	IntPtr       *int                       `pulumi:"pi,optional"`
 	Nested       NestedDefaults             `pulumi:"nested,optional"`
-	NestedPtr    *NestedDefaults            `pulumi:"nestedPtr,optional"`
+	NestedPtr    *NestedDefaults            `pulumi:"nestedPtr"`
+	OptWithReq   *OptWithReq                `pulumi:"optWithReq,optional"`
 	ArrNested    []NestedDefaults           `pulumi:"arrNested,optional"`
 	ArrNestedPtr []*NestedDefaults          `pulumi:"arrNestedPtr,optional"`
 	MapNested    map[string]NestedDefaults  `pulumi:"mapNested,optional"`
 	MapNestedPtr map[string]*NestedDefaults `pulumi:"mapNestedPtr,optional"`
 
 	NoDefaultsPtr *NoDefaults `pulumi:"noDefaults,optional"`
+}
+
+type OptWithReq struct {
+	Required *string `pulumi:"req"`
+	Optional *string `pulumi:"opt,optional"`
+	Empty    *string `pulumi:"empty,optional"`
+}
+
+func (o *OptWithReq) Annotate(a infer.Annotator) {
+	a.SetDefault(&o.Optional, "default-value")
 }
 
 // We want to make sure we don't effect structs or maps that don't have default values.


### PR DESCRIPTION
Consider input with this type:

```go
type Note struct {
	Title string  `pulumi:"title"`
        Body  *Nested `pulumi:"body,optional"`
}

type Body struct {
	Color string `pulumi:"color,optional"`
	Text  string `pulumi:"text"`
}

func (b *Body) Annotate(a infer.Annotator) {
	a.SetDefault(&b.Color, "black")
}
```

A `Note` must have a title and it may have a body. If it does have a body, then the body must have text. `Body.Color` defaults to `"black"`.

Consider what `applyDefaults` looks like for these values (before this PR):

1.
```ts
applyDefaults({"title": "do thing", "body": {"text": "due by friday"}})
=
{"title": "do thing", "body": {"text": "due by friday", "color": "black"}}
```

2.
```ts
applyDefaults({"title": "do thing", "body": {"text": "due by friday", "color": "blue"}})
=
{"title": "do thing", "body": {"text": "due by friday", "color": "blue"}}
```

3.
```ts
applyDefaults({"title": "do thing"})
=
{"title": "do thing", "body": {"color": "black"}}
```

---

(1) and (2) are correct. Importantly, both the input and output of (1) and (2) are valid values for `Note`. (3) shows the bug that this PR fixes: we start with a *valid* input, but after `applyDefaults` we have an *invalid* result, since `text` is required for `Body` but not present.

This PR prevents us from applying (and thus hydrating) nil pointers to optional structs. After this PR, we get a valid result on (3):

```ts
applyDefaults({"title": "do thing"}) = {"title": "do thing"}
```