### PR TITLE
Allow override a Pulumi token by using SetToken of infer.Annotator

### DIFF
--- a/infer/component.go
+++ b/infer/component.go
@@ -16,6 +16,7 @@ package infer
 
 import (
 	"fmt"
+	"reflect"
 
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -75,6 +76,11 @@ func (rc *derivedComponentController[R, I, O]) GetSchema(reg schema.RegisterDeri
 
 func (rc *derivedComponentController[R, I, O]) GetToken() (tokens.Type, error) {
 	var r R
+	annotator := getAnnotated(reflect.TypeOf(r))
+	if annotator.Token != "" {
+		return fnToken(tokens.Type(annotator.Token)), nil
+	}
+
 	return introspect.GetToken("pkg", r)
 }
 

--- a/infer/component.go
+++ b/infer/component.go
@@ -16,7 +16,6 @@ package infer
 
 import (
 	"fmt"
-	"reflect"
 
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -75,13 +74,7 @@ func (rc *derivedComponentController[R, I, O]) GetSchema(reg schema.RegisterDeri
 }
 
 func (rc *derivedComponentController[R, I, O]) GetToken() (tokens.Type, error) {
-	var r R
-	annotator := getAnnotated(reflect.TypeOf(r))
-	if annotator.Token != "" {
-		return fnToken(tokens.Type(annotator.Token)), nil
-	}
-
-	return introspect.GetToken("pkg", r)
+	return getToken[R](nil)
 }
 
 func (rc *derivedComponentController[R, I, O]) Construct(

--- a/infer/function.go
+++ b/infer/function.go
@@ -57,9 +57,9 @@ func (*derivedInvokeController[F, I, O]) GetToken() (tokens.Type, error) {
 	//
 	//	pkg:index:FizzBuzz
 	//
-	// Functions use a different capitalization convection, so we need to convert:
+	// Functions use a different capitalization convention, so we need to convert:
 	//
-	//	pkg:index:FizzBuzz
+	//	pkg:index:fizzBuzz
 	//
 	return getToken[F](fnToken)
 }

--- a/infer/function.go
+++ b/infer/function.go
@@ -53,8 +53,12 @@ type derivedInvokeController[F Fn[I, O], I, O any] struct{}
 
 func (derivedInvokeController[F, I, O]) isInferredFunction() {}
 
-func (*derivedInvokeController[F, I, O]) GetToken() (tokens.Type, error) {
+func (c *derivedInvokeController[F, I, O]) GetToken() (tokens.Type, error) {
 	var f F
+	annotator := getAnnotated(reflect.TypeOf(f))
+	if annotator.Token != "" {
+		return fnToken(tokens.Type(annotator.Token)), nil
+	}
 	tk, err := introspect.GetToken("pkg", f)
 	if err != nil {
 		return "", err

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -140,7 +140,20 @@ type Annotator interface {
 	// type in the pulumi type system.
 	SetDefault(i any, defaultValue any, env ...string)
 
-	SetToken(i any, token string)
+	// Set the token of the annotated type.
+	//
+	// module and name should be valid Pulumi token segments. The package name will be
+	// inferred from the provider.
+	//
+	// For example:
+	//
+	//	a.SetToken("mymodule", "MyResource")
+	//
+	// On a provider created with the name "mypkg" will have the token:
+	//
+	//	mypkg:mymodule:MyResource
+	//
+	SetToken(module, name string)
 }
 
 // Annotated is used to describe the fields of an object or a resource. Annotated can be

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -138,6 +138,8 @@ type Annotator interface {
 	// Annotate a struct field with a default value. The default value must be a primitive
 	// type in the pulumi type system.
 	SetDefault(i any, defaultValue any, env ...string)
+
+	SetToken(i any, token string)
 }
 
 // Annotated is used to describe the fields of an object or a resource. Annotated can be
@@ -682,6 +684,11 @@ func (*derivedResourceController[R, I, O]) GetSchema(reg schema.RegisterDerivati
 
 func (*derivedResourceController[R, I, O]) GetToken() (tokens.Type, error) {
 	var r R
+	annotator := getAnnotated(reflect.TypeOf(r))
+	if annotator.Token != "" {
+		return fnToken(tokens.Type(annotator.Token)), nil
+	}
+
 	return introspect.GetToken("pkg", r)
 }
 

--- a/infer/schema.go
+++ b/infer/schema.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
 	"github.com/pulumi/pulumi-go-provider/internal/introspect"
@@ -336,16 +335,9 @@ func structReferenceToken(t reflect.Type, extTag *introspect.ExplicitType) (sche
 		return schema.TypeSpec{}, false, nil
 	}
 
-	var tk tokens.Type
-	annotator := getAnnotated(t)
-	if annotator.Token != "" {
-		tk = fnToken(tokens.Type(annotator.Token))
-	} else {
-		var err error
-		tk, err = introspect.GetToken("pkg", reflect.New(t).Interface())
-		if err != nil {
-			return schema.TypeSpec{}, true, err
-		}
+	tk, err := getTokenOf(t, nil)
+	if err != nil {
+		return schema.TypeSpec{}, true, err
 	}
 
 	return schema.TypeSpec{

--- a/infer/tests/token_test.go
+++ b/infer/tests/token_test.go
@@ -30,7 +30,7 @@ import (
 
 type CustomToken struct{}
 
-func (c *CustomToken) Annotate(a infer.Annotator) { a.SetToken(c, "pkg:overwritten:Tk") }
+func (c *CustomToken) Annotate(a infer.Annotator) { a.SetToken("overwritten", "Tk") }
 
 func (*CustomToken) Create(
 	ctx p.Context, name string, inputs TokenArgs, preview bool,
@@ -52,7 +52,7 @@ type TokenComponent struct{ pulumi.ResourceState }
 type ComponentToken struct{}
 
 // Check that we allow other capitalization schemes
-func (c *ComponentToken) Annotate(a infer.Annotator) { a.SetToken(c, "pkg:cmp:tK") }
+func (c *ComponentToken) Annotate(a infer.Annotator) { a.SetToken("cmp", "tK") }
 
 func (*ComponentToken) Construct(
 	ctx *pulumi.Context, name, typ string, inputs TokenArgs, opts pulumi.ResourceOption,
@@ -62,7 +62,7 @@ func (*ComponentToken) Construct(
 
 type FnToken struct{}
 
-func (c *FnToken) Annotate(a infer.Annotator) { a.SetToken(c, "pkg:fn:TK") }
+func (c *FnToken) Annotate(a infer.Annotator) { a.SetToken("fn", "TK") }
 
 func (*FnToken) Call(ctx p.Context, input TokenArgs) (output TokenResult, err error) {
 	panic("unimplemented")
@@ -72,7 +72,7 @@ type ObjectToken struct {
 	Value string `pulumi:"value"`
 }
 
-func (c *ObjectToken) Annotate(a infer.Annotator) { a.SetToken(c, "pkg:obj:Customized") }
+func (c *ObjectToken) Annotate(a infer.Annotator) { a.SetToken("obj", "Customized") }
 
 func TestTokens(t *testing.T) {
 	provider := infer.Provider(infer.Options{

--- a/infer/tests/token_test.go
+++ b/infer/tests/token_test.go
@@ -1,0 +1,198 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi-go-provider/integration"
+)
+
+type CustomToken struct{}
+
+func (c *CustomToken) Annotate(a infer.Annotator) { a.SetToken(c, "pkg:overwritten:Tk") }
+
+func (*CustomToken) Create(
+	ctx p.Context, name string, inputs TokenArgs, preview bool,
+) (string, TokenResult, error) {
+	panic("unimplemented")
+}
+
+type TokenArgs struct {
+	Array []ObjectToken `pulumi:"arr"`
+
+	Single ObjectToken `pulumi:"single"`
+}
+type TokenResult struct {
+	Map map[string]ObjectToken `pulumi:"m"`
+}
+
+type TokenComponent struct{ pulumi.ResourceState }
+
+type ComponentToken struct{}
+
+// Check that we allow other capitalization schemes
+func (c *ComponentToken) Annotate(a infer.Annotator) { a.SetToken(c, "pkg:cmp:tK") }
+
+func (*ComponentToken) Construct(
+	ctx *pulumi.Context, name, typ string, inputs TokenArgs, opts pulumi.ResourceOption,
+) (*TokenComponent, error) {
+	panic("unimplemented")
+}
+
+type FnToken struct{}
+
+func (c *FnToken) Annotate(a infer.Annotator) { a.SetToken(c, "pkg:fn:TK") }
+
+func (*FnToken) Call(ctx p.Context, input TokenArgs) (output TokenResult, err error) {
+	panic("unimplemented")
+}
+
+type ObjectToken struct {
+	Value string `pulumi:"value"`
+}
+
+func (c *ObjectToken) Annotate(a infer.Annotator) { a.SetToken(c, "pkg:obj:Customized") }
+
+func TestTokens(t *testing.T) {
+	provider := infer.Provider(infer.Options{
+		Resources: []infer.InferredResource{
+			infer.Resource[*CustomToken, TokenArgs, TokenResult](),
+		},
+		Components: []infer.InferredComponent{
+			infer.Component[*ComponentToken, TokenArgs, *TokenComponent](),
+		},
+		Functions: []infer.InferredFunction{
+			infer.Function[*FnToken, TokenArgs, TokenResult](),
+		},
+		ModuleMap: map[tokens.ModuleName]tokens.ModuleName{"overwritten": "index"},
+	})
+	server := integration.NewServer("test", semver.MustParse("1.0.0"), provider)
+
+	schema, err := server.GetSchema(p.GetSchemaRequest{})
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+  "name": "test",
+  "version": "1.0.0",
+  "config": {},
+  "types": {
+    "test:obj:Customized": {
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "value"
+      ]
+    }
+  },
+  "provider": {},
+  "resources": {
+    "test:cmp:tK": {
+      "inputProperties": {
+        "arr": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/test:obj:Customized"
+          }
+        },
+        "single": {
+          "$ref": "#/types/test:obj:Customized"
+        }
+      },
+      "requiredInputs": [
+        "arr",
+        "single"
+      ],
+      "isComponent": true
+    },
+    "test:index:Tk": {
+      "properties": {
+        "m": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/types/test:obj:Customized"
+          }
+        }
+      },
+      "required": [
+        "m"
+      ],
+      "inputProperties": {
+        "arr": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/test:obj:Customized"
+          }
+        },
+        "single": {
+          "$ref": "#/types/test:obj:Customized"
+        }
+      },
+      "requiredInputs": [
+        "arr",
+        "single"
+      ]
+    }
+  },
+  "functions": {
+    "test:fn:TK": {
+      "inputs": {
+        "properties": {
+          "arr": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/test:obj:Customized"
+            }
+          },
+          "single": {
+            "$ref": "#/types/test:obj:Customized"
+          }
+        },
+        "type": "object",
+        "required": [
+          "arr",
+          "single"
+        ]
+      },
+      "outputs": {
+        "properties": {
+          "m": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/types/test:obj:Customized"
+            }
+          }
+        },
+        "type": "object",
+        "required": [
+          "m"
+        ]
+      }
+    }
+  }
+}`, schema.Schema)
+}

--- a/infer/types.go
+++ b/infer/types.go
@@ -112,15 +112,8 @@ func isEnum(t reflect.Type) (enum, bool) {
 		}
 	}
 
-	var tk tokens.Type
-	annotator := getAnnotated(t)
-	if annotator.Token != "" {
-		tk = fnToken(tokens.Type(annotator.Token))
-	} else {
-		var err error
-		tk, err = introspect.GetToken("pkg", reflect.New(t).Elem().Interface())
-		contract.AssertNoErrorf(err, "failed to get token for enum: %s", t)
-	}
+	tk, err := getTokenOf(t, nil)
+	contract.AssertNoErrorf(err, "failed to get token for enum: %s", t)
 
 	return enum{
 		token:  tk.String(),
@@ -254,15 +247,9 @@ func registerTypes[T any](reg schema.RegisterDerivativeType) error {
 				return false, err
 			}
 
-			var tk tokens.Type
-			annotator := getAnnotated(t)
-			if annotator.Token != "" {
-				tk = fnToken(tokens.Type(annotator.Token))
-			} else {
-				tk, err = introspect.GetToken("pkg", reflect.New(t).Interface())
-				if err != nil {
-					return false, err
-				}
+			tk, err := getTokenOf(t, nil)
+			if err != nil {
+				return false, err
 			}
 
 			return reg(tk, pschema.ComplexTypeSpec{ObjectTypeSpec: *spec}), nil

--- a/internal/introspect/annotator.go
+++ b/internal/introspect/annotator.go
@@ -33,6 +33,7 @@ type Annotator struct {
 	Descriptions map[string]string
 	Defaults     map[string]any
 	DefaultEnvs  map[string][]string
+	Token        string
 
 	matcher FieldMatcher
 }
@@ -82,4 +83,22 @@ func (a *Annotator) SetDefault(i any, defaultValue any, env ...string) {
 	field := a.mustGetField(i)
 	a.Defaults[field.Name] = defaultValue
 	a.DefaultEnvs[field.Name] = append(a.DefaultEnvs[field.Name], env...)
+}
+
+func (a *Annotator) SetToken(i any, token string) {
+	_, ok, err := a.matcher.GetField(i)
+	if err != nil {
+		panic(fmt.Sprintf("Could not parse field tags: %s", err.Error()))
+	}
+	if !ok {
+		typ := reflect.TypeOf(i)
+		if typ.Kind() == reflect.Pointer && typ.Elem().Kind() == reflect.Pointer {
+			i = reflect.ValueOf(i).Elem().Interface()
+		}
+		if a.matcher.value.Addr().Interface() != i {
+			panic("A token can only be specified for a struct")
+		}
+	}
+
+	a.Token = token
 }

--- a/internal/introspect/annotator.go
+++ b/internal/introspect/annotator.go
@@ -85,20 +85,6 @@ func (a *Annotator) SetDefault(i any, defaultValue any, env ...string) {
 	a.DefaultEnvs[field.Name] = append(a.DefaultEnvs[field.Name], env...)
 }
 
-func (a *Annotator) SetToken(i any, token string) {
-	_, ok, err := a.matcher.GetField(i)
-	if err != nil {
-		panic(fmt.Sprintf("Could not parse field tags: %s", err.Error()))
-	}
-	if !ok {
-		typ := reflect.TypeOf(i)
-		if typ.Kind() == reflect.Pointer && typ.Elem().Kind() == reflect.Pointer {
-			i = reflect.ValueOf(i).Elem().Interface()
-		}
-		if a.matcher.value.Addr().Interface() != i {
-			panic("A token can only be specified for a struct")
-		}
-	}
-
-	a.Token = token
+func (a *Annotator) SetToken(module, token string) {
+	a.Token = fmt.Sprintf("pkg:%s:%s", module, token)
 }

--- a/internal/introspect/annotator.go
+++ b/internal/introspect/annotator.go
@@ -17,6 +17,8 @@ package introspect
 import (
 	"fmt"
 	"reflect"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
 func NewAnnotator(resource any) Annotator {
@@ -86,5 +88,11 @@ func (a *Annotator) SetDefault(i any, defaultValue any, env ...string) {
 }
 
 func (a *Annotator) SetToken(module, token string) {
+	if !tokens.IsQName(module) {
+		panic(fmt.Sprintf("Module (%q) must comply with %s, but does not", module, tokens.QNameRegexp))
+	}
+	if !tokens.IsName(token) {
+		panic(fmt.Sprintf("Token (%q) must comply with %s, but does not", token, tokens.NameRegexp))
+	}
 	a.Token = fmt.Sprintf("pkg:%s:%s", module, token)
 }

--- a/internal/introspect/introspect.go
+++ b/internal/introspect/introspect.go
@@ -17,7 +17,6 @@ package introspect
 import (
 	"fmt"
 	"reflect"
-	"runtime"
 	"strings"
 
 	"github.com/blang/semver"
@@ -79,8 +78,7 @@ func FindProperties(r any) (map[string]FieldTag, error) {
 }
 
 // Get the token that represents a struct.
-func GetToken(pkg tokens.Package, i any) (tokens.Type, error) {
-	typ := reflect.TypeOf(i)
+func GetToken(pkg tokens.Package, typ reflect.Type) (tokens.Type, error) {
 	if typ == nil {
 		return "", fmt.Errorf("cannot get token of nil type")
 	}
@@ -89,23 +87,14 @@ func GetToken(pkg tokens.Package, i any) (tokens.Type, error) {
 		typ = typ.Elem()
 	}
 
-	var name string
-	var mod string
-	if typ.Kind() == reflect.Func {
-		fn := runtime.FuncForPC(reflect.ValueOf(i).Pointer())
-		parts := strings.Split(fn.Name(), ".")
-		name = parts[len(parts)-1]
-		mod = strings.Join(parts[:len(parts)-1], "/")
-	} else {
-		name = typ.Name()
-		mod = strings.Trim(typ.PkgPath(), "*")
-	}
+	name := typ.Name()
+	mod := strings.Trim(typ.PkgPath(), "*")
 
 	if name == "" {
-		return "", fmt.Errorf("type %T has no name", i)
+		return "", fmt.Errorf("type %s has no name", typ)
 	}
 	if mod == "" {
-		return "", fmt.Errorf("type %T has no module path", i)
+		return "", fmt.Errorf("type %s has no module path", typ)
 	}
 	// Take off the pkg name, since that is supplied by `pkg`.
 	mod = mod[strings.LastIndex(mod, "/")+1:]

--- a/internal/introspect/introspect_test.go
+++ b/internal/introspect/introspect_test.go
@@ -36,7 +36,7 @@ func (m *MyStruct) Annotate(a infer.Annotator) {
 	a.Describe(&m, "This is MyStruct, but also your struct.")
 	a.Describe(&m.Fizz, "Fizz is not MyStruct.Foo.")
 	a.SetDefault(&m.Foo, "Fizz")
-	a.SetToken(&m, "MyToken")
+	a.SetToken("myMod", "MyToken")
 }
 
 func TestParseTag(t *testing.T) {
@@ -108,7 +108,7 @@ func TestAnnotate(t *testing.T) {
 	assert.Equal(t, "Fizz", a.Defaults["foo"])
 	assert.Equal(t, "Fizz is not MyStruct.Foo.", a.Descriptions["fizz"])
 	assert.Equal(t, "This is MyStruct, but also your struct.", a.Descriptions[""])
-	assert.Equal(t, "MyToken", a.Token)
+	assert.Equal(t, "pkg:myMod:MyToken", a.Token)
 }
 
 func TestAllFields(t *testing.T) {

--- a/internal/introspect/introspect_test.go
+++ b/internal/introspect/introspect_test.go
@@ -36,6 +36,7 @@ func (m *MyStruct) Annotate(a infer.Annotator) {
 	a.Describe(&m, "This is MyStruct, but also your struct.")
 	a.Describe(&m.Fizz, "Fizz is not MyStruct.Foo.")
 	a.SetDefault(&m.Foo, "Fizz")
+	a.SetToken(&m, "MyToken")
 }
 
 func TestParseTag(t *testing.T) {
@@ -107,6 +108,7 @@ func TestAnnotate(t *testing.T) {
 	assert.Equal(t, "Fizz", a.Defaults["foo"])
 	assert.Equal(t, "Fizz is not MyStruct.Foo.", a.Descriptions["fizz"])
 	assert.Equal(t, "This is MyStruct, but also your struct.", a.Descriptions[""])
+	assert.Equal(t, "MyToken", a.Token)
 }
 
 func TestAllFields(t *testing.T) {


### PR DESCRIPTION
This is a cleaned up version of https://github.com/pulumi/pulumi-go-provider/pull/128 (written by @tmeckel).