### PR TITLE
Tolerate unknowns in CheckConfig

### DIFF
--- a/infer/configuration.go
+++ b/infer/configuration.go
@@ -88,7 +88,7 @@ func (c *config[T]) checkConfig(ctx p.Context, req p.CheckRequest) (p.CheckRespo
 	if err != nil {
 		return p.CheckResponse{}, fmt.Errorf("could not get config secrets: %w", err)
 	}
-	encoder, decodeError := ende.Decode(req.News, &t)
+	encoder, decodeError := ende.DecodeConfig(req.News, &t)
 	if t, ok := ((interface{})(t)).(CustomCheck[T]); ok {
 		// The user implemented check manually, so call that
 		i, failures, err := t.Check(ctx, req.Urn.Name().String(), req.Olds, req.News)

--- a/infer/tests/check_config_test.go
+++ b/infer/tests/check_config_test.go
@@ -37,6 +37,7 @@ func TestCheckConfig(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	require.Len(t, resp.Failures, 0)
 
 	// By default, check simply ensures that we can decode cleanly. It removes unknown
 	// fields so that diff doesn't trigger on changes to unwatched arguments.


### PR DESCRIPTION
Fixes #108 

I attempted to fix this in #117, but I was missing one of the necessary asserts on the test, so this part slipped. This PR rectifies the mistake and the test.

I have confirmed that this fixes the example in #108.