### PR TITLE
Disallow reserved "id" and "urn" fields

### DIFF
--- a/internal/introspect/introspect.go
+++ b/internal/introspect/introspect.go
@@ -121,6 +121,9 @@ func ParseTag(field reflect.StructField) (FieldTag, error) {
 	pulumi := map[string]bool{}
 	pulumiArray := strings.Split(pulumiTag, ",")
 	name := pulumiArray[0]
+	if name == "id" || name == "urn" {
+		return FieldTag{}, fmt.Errorf("%q is a reserved field name", name)
+	}
 	for _, item := range pulumiArray[1:] {
 		pulumi[item] = true
 	}

--- a/internal/introspect/introspect_test.go
+++ b/internal/introspect/introspect_test.go
@@ -30,6 +30,8 @@ type MyStruct struct {
 	Foo     string `pulumi:"foo,optional" provider:"secret,output"`
 	Bar     int    `provider:"secret"`
 	Fizz    *int   `pulumi:"fizz"`
+	ID      string `pulumi:"id"`
+	URN     string `pulumi:"urn"`
 	ExtType string `pulumi:"typ" provider:"type=example@1.2.3:m1:m2"`
 }
 
@@ -79,6 +81,14 @@ func TestParseTag(t *testing.T) {
 				},
 			},
 		},
+		{
+			Field: "ID",
+			Error: `"id" is a reserved field name`,
+		},
+		{
+			Field: "URN",
+			Error: `"urn" is a reserved field name`,
+		},
 	}
 
 	for _, c := range cases {
@@ -89,7 +99,7 @@ func TestParseTag(t *testing.T) {
 			assert.True(t, ok)
 			tag, err := introspect.ParseTag(field)
 			if c.Error != "" {
-				assert.Equal(t, c.Error, err.Error())
+				assert.ErrorContains(t, err, c.Error)
 			} else {
 				assert.Equal(t, c.Expected, tag)
 			}


### PR DESCRIPTION
Guards were added in https://github.com/pulumi/pulumi/pull/14637 to prevent resources from defining their own "urn" and "id" properties.

I ran into this because I mistakenly defined an ID property on my output state, and didn't realize until much later when trying generate the schema.