### PR TITLE
Enable attaching RawServer to existing HostClient

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -383,16 +383,13 @@ func RunProvider(name, version string, provider Provider) error {
 	return pprovider.Main(name, newProvider(name, version, provider.WithDefaults()))
 }
 
-// RawServer converts the Provider into a gRPC server.
+// RawServer converts the Provider into a factory for gRPC servers.
 //
 // If you are trying to set up a standard main function, see RunProvider.
-func RawServer(name, version string, provider Provider) (rpc.ResourceProviderServer, error) {
-	return RawServerFactory(name, version, provider)(nil)
-}
-
-// RawServerFactory allows attaching a ResourceProviderServer to an existing
-// HostClient.
-func RawServerFactory(name, version string, provider Provider) func(*pprovider.HostClient) (rpc.ResourceProviderServer, error) {
+func RawServer(
+	name, version string,
+	provider Provider,
+) func(*pprovider.HostClient) (rpc.ResourceProviderServer, error) {
 	return newProvider(name, version, provider.WithDefaults())
 }
 

--- a/provider.go
+++ b/provider.go
@@ -387,7 +387,13 @@ func RunProvider(name, version string, provider Provider) error {
 //
 // If you are trying to set up a standard main function, see RunProvider.
 func RawServer(name, version string, provider Provider) (rpc.ResourceProviderServer, error) {
-	return newProvider(name, version, provider.WithDefaults())(nil)
+	return RawServerFactory(name, version, provider)(nil)
+}
+
+// RawServerFactory allows attaching a ResourceProviderServer to an existing
+// HostClient.
+func RawServerFactory(name, version string, provider Provider) func(*pprovider.HostClient) (rpc.ResourceProviderServer, error) {
+	return newProvider(name, version, provider.WithDefaults())
 }
 
 // A context which prints its diagnostics, collecting all errors

--- a/tests/grpc/config_test.go
+++ b/tests/grpc/config_test.go
@@ -472,7 +472,7 @@ func TestConfigWithSecrets(t *testing.T) {
 }
 
 func replayConfig(t *testing.T, jsonLog string) {
-	s, err := p.RawServer("config", "1.0.0", config.Provider())
+	s, err := p.RawServer("config", "1.0.0", config.Provider())(nil)
 	require.NoError(t, err)
 	replay.ReplaySequence(t, s, jsonLog)
 }


### PR DESCRIPTION
I've been debugging panics in my logging and realized this is because `[RawServer](https://github.com/pulumi/pulumi-docker/pull/890/files#diff-cd386c4a0740a8677267cb5b3c15dd286eb87638949f649e5b0750803a2b7e48R30)` was initializing with a `nil` `HostClient`.

This essentially exposes `newProvider` so we can attach an existing `HostClient` to it. I only see this used in one test, so I opted for a breaking change instead of adding another function.

Refs https://github.com/pulumi/pulumi-docker/pull/890