### PR TITLE
id/urn are allowed on nested types

### DIFF
--- a/infer/types_test.go
+++ b/infer/types_test.go
@@ -213,3 +213,21 @@ func TestCrawlTypes(t *testing.T) {
 						Value:       "bar"}}}},
 		m)
 }
+
+type outer struct {
+	Inner inner `pulumi:"inner"`
+}
+type inner struct {
+	ID string `pulumi:"id"`
+}
+
+func TestReservedFields(t *testing.T) {
+	reg := func(typ tokens.Type, spec pschema.ComplexTypeSpec) bool {
+		return true
+	}
+	err := registerTypes[outer](reg)
+	assert.NoError(t, err, "id isn't reserved on nested fields")
+
+	err = registerTypes[inner](reg)
+	assert.ErrorContains(t, err, `"id" is a reserved field name`)
+}

--- a/internal/introspect/introspect.go
+++ b/internal/introspect/introspect.go
@@ -112,7 +112,7 @@ func ParseTag(field reflect.StructField) (FieldTag, error) {
 	pulumiTag, hasPulumiTag := field.Tag.Lookup("pulumi")
 	providerTag, hasProviderTag := field.Tag.Lookup("provider")
 	if hasProviderTag && !hasPulumiTag {
-		return FieldTag{}, fmt.Errorf("you must put to the `pulumi` tag to use the `provider` tag")
+		return FieldTag{}, fmt.Errorf("`provider` requires a `pulumi` tag")
 	}
 	if !hasPulumiTag || !field.IsExported() {
 		return FieldTag{Internal: true}, nil
@@ -121,9 +121,6 @@ func ParseTag(field reflect.StructField) (FieldTag, error) {
 	pulumi := map[string]bool{}
 	pulumiArray := strings.Split(pulumiTag, ",")
 	name := pulumiArray[0]
-	if name == "id" || name == "urn" {
-		return FieldTag{}, fmt.Errorf("%q is a reserved field name", name)
-	}
 	for _, item := range pulumiArray[1:] {
 		pulumi[item] = true
 	}

--- a/internal/introspect/introspect_test.go
+++ b/internal/introspect/introspect_test.go
@@ -30,8 +30,6 @@ type MyStruct struct {
 	Foo     string `pulumi:"foo,optional" provider:"secret,output"`
 	Bar     int    `provider:"secret"`
 	Fizz    *int   `pulumi:"fizz"`
-	ID      string `pulumi:"id"`
-	URN     string `pulumi:"urn"`
 	ExtType string `pulumi:"typ" provider:"type=example@1.2.3:m1:m2"`
 }
 
@@ -61,7 +59,7 @@ func TestParseTag(t *testing.T) {
 		},
 		{
 			Field: "Bar",
-			Error: "you must put to the `pulumi` tag to use the `provider` tag",
+			Error: "`provider` requires a `pulumi` tag",
 		},
 		{
 			Field: "Fizz",
@@ -80,14 +78,6 @@ func TestParseTag(t *testing.T) {
 					Name:    "m2",
 				},
 			},
-		},
-		{
-			Field: "ID",
-			Error: `"id" is a reserved field name`,
-		},
-		{
-			Field: "URN",
-			Error: `"urn" is a reserved field name`,
 		},
 	}
 


### PR DESCRIPTION
https://github.com/pulumi/pulumi-go-provider/pull/160 had the unintended side effect of prohibiting "id" on _all_ types, but the engine only forbids those fields as outputs.

This PR changes our logic to only check top-level fields before drilling down. This still doesn't match the engine exactly, since technically these are allowed as inputs, but those edge cases seem unlikely.