### PR TITLE
Add a public resourcex.DecodeValue function

### DIFF
--- a/resourcex/README.md
+++ b/resourcex/README.md
@@ -5,7 +5,8 @@ for working with property values.
 
 1. `Unmarshal` - Extract structured values from a property map, with tracking of unknownness and secretness.
 2. `Decode` - Decode a property map into a JSON-like structure containing only values.
-3. `Traverse` - Traverse a property path, visiting each property value.
+3. `DecodeValue` - Decode a property value into its underlying value, recursively.
+4. `Traverse` - Traverse a property path, visiting each property value.
 
 ## Unmarshaling
 
@@ -198,6 +199,36 @@ assert.Equal(t, map[string]any{
     },
 }, decoded)
 ```
+
+Similarly, the `DecodeValue` function decodes a single property value into its pure value. Here's an example:
+
+```go
+prop := resource.NewArrayProperty([]resource.PropertyValue{
+    resource.NewObjectProperty(resource.PropertyMap{
+        "name":  resource.NewStringProperty("a"),
+        "value": resource.MakeSecret(resource.NewStringProperty("b")),
+    }),
+    resource.MakeComputed(resource.NewObjectProperty(resource.PropertyMap{})),
+    resource.NewObjectProperty(resource.PropertyMap{
+        "name":  resource.NewStringProperty("c"),
+        "value": resource.MakeSecret(resource.NewStringProperty("d")),
+    }),
+})
+
+decoded := DecodeValue(prop)
+assert.Equal(t, []any{
+    map[string]any{
+        "name":  "a",
+        "value": "b",
+    },
+    nil,
+    map[string]any{
+        "name":  "c",
+        "value": "d",
+    },
+}, decoded)
+```
+
 
 ## Traversal
 

--- a/resourcex/decode.go
+++ b/resourcex/decode.go
@@ -26,7 +26,14 @@ func Decode(props resource.PropertyMap) map[string]any {
 	return decodeM(props)
 }
 
-// decodeV returns a mapper-compatible object map, suitable for deserialization into structures.
+// DecodeValue decodes a property value into its underlying value, recursively.
+// Unknown values are decoded as nil, also in maps and arrays.
+// Secrets are collapsed into their underlying values.
+func DecodeValue(prop resource.PropertyValue) any {
+	return decodeV(prop)
+}
+
+// decodeM returns a mapper-compatible object map, suitable for deserialization into structures.
 func decodeM(props resource.PropertyMap) map[string]any {
 	obj := make(map[string]any)
 	for _, k := range props.StableKeys() {


### PR DESCRIPTION
I found `Decode` while re-implementing it in the AWS CC provider. (thank you @danielrbradley!)

I also need `DecodeValue` function there to be able to decode engine diffs. Therefore, adding it as a public member.