### PR TITLE
Add support for state migrations in `infer`

### DIFF
--- a/infer/function.go
+++ b/infer/function.go
@@ -122,8 +122,7 @@ func objectSchema(t reflect.Type) (*pschema.ObjectTypeSpec, error) {
 }
 
 func (r *derivedInvokeController[F, I, O]) Invoke(ctx p.Context, req p.InvokeRequest) (p.InvokeResponse, error) {
-	var i I
-	encoder, mapErr := ende.Decode(req.Args, &i)
+	encoder, i, mapErr := ende.Decode[I](req.Args)
 	mapFailures, err := checkFailureFromMapError(mapErr)
 	if err != nil {
 		return p.InvokeResponse{}, err

--- a/infer/internal/ende/ende_test.go
+++ b/infer/internal/ende/ende_test.go
@@ -32,9 +32,8 @@ import (
 func testRoundTrip[T any](t *testing.T, pMap func() r.PropertyMap) {
 	t.Run("", func(t *testing.T) {
 		t.Parallel()
-		var typeInfo T
 		toDecode := pMap()
-		encoder, err := Decode(toDecode, &typeInfo)
+		encoder, typeInfo, err := Decode[T](toDecode)
 		require.NoError(t, err)
 
 		assert.Equalf(t, pMap(), toDecode, "mutated decode map")

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -35,8 +35,8 @@ import (
 	"github.com/pulumi/pulumi-go-provider/middleware/schema"
 )
 
-// A resource that understands how to create itself. This is the minimum requirement for
-// defining a new custom resource.
+// A [custom resource](https://www.pulumi.com/docs/concepts/resources/) inferred from code. This is the
+// minimum requirement for defining a new custom resource.
 //
 // This interface should be implemented by the resource controller, with `I` the resource
 // inputs and `O` the full set of resource fields. It is recommended that `O` is a
@@ -45,17 +45,52 @@ import (
 // `pulumi.IntOutput`.
 //
 // The behavior of a CustomResource resource can be extended by implementing any of the
-// following traits:
-// - CustomCheck
-// - CustomDiff
-// - CustomUpdate
-// - CustomRead
-// - CustomDelete
+// following interfaces on the resource controller:
+//
+// - [CustomCheck]
+// - [CustomDiff]
+// - [CustomUpdate]
+// - [CustomRead]
+// - [CustomDelete]
+// - [CustomStateMigrations]
+// - [Annotated]
 //
 // Example:
-// TODO
-type CustomResource[I any, O any] interface {
-	Create(ctx p.Context, name string, input I, preview bool) (id string, output O, err error)
+//
+//	type MyResource struct{}
+//
+//	type MyResourceInputs struct {
+//		MyString string `pulumi:"myString"`
+//		OptionalInt *int `pulumi:"myInt,optional"`
+//	}
+//
+//	type MyResourceOutputs struct {
+//		MyResourceInputs
+//		Result string `pulumi:"result"`
+//	}
+//
+//	func (*MyResource) Create(
+//		ctx p.Context, name string, inputs MyResourceInputs, preview bool,
+//	) (string, MyResourceOutputs, error) {
+//		id := input.MyString + ".id"
+//		if preview {
+//			return id, MyResourceOutputs{MyResourceInputs: inputs}, nil
+//		}
+//
+//		result := input.MyString
+//		if inputs.OptionalInt != nil {
+//			result = fmt.Sprintf("%s.%d", result, *inputs.OptionalInt)
+//		}
+//
+//		return id, MyResourceOutputs{inputs, result}, nil
+//	}
+type CustomResource[I, O any] interface {
+	// All custom resources must be able to be created.
+	CustomCreate[I, O]
+}
+
+type CustomCreate[I, O any] interface {
+	Create(ctx p.Context, name string, inputs I, preview bool) (id string, output O, err error)
 }
 
 // A resource that understands how to check its inputs.
@@ -120,6 +155,92 @@ type CustomRead[I, O any] interface {
 type CustomDelete[O any] interface {
 	// Delete is called before a resource is removed from pulumi state.
 	Delete(ctx p.Context, id string, props O) error
+}
+
+// StateMigrationFunc represents a stateless mapping from an old state shape to a new
+// state shape. Each StateMigrationFunc is parameterized by the shape of the type it
+// produces, ensuring that all successful migrations end up in a valid state.
+//
+// To create a StateMigrationFunc, use [StateMigration].
+type StateMigrationFunc[New any] interface {
+	isStateMigrationFunc()
+
+	oldShape() reflect.Type
+	newShape() reflect.Type
+	migrateFunc() reflect.Value
+}
+
+// StateMigration creates a mapping from an old state shape (type Old) to a new state
+// shape (type New).
+//
+// If Old = [resource.PropertyMap], then the migration is always run.
+//
+// Example:
+//
+//	type MyResource struct{}
+//
+//	type MyInput struct{}
+//
+//	type MyStateV1 struct {
+//		SomeInt *int `pulumi:"someInt,optional"`
+//	}
+//
+//	type MyStateV2 struct {
+//		AString string `pulumi:"aString"`
+//		AInt    *int   `pulumi:"aInt,optional"`
+//	}
+//
+//	func migrateFromV1(ctx p.Context, v1 StateV1) (infer.MigrationResult[MigrateStateV2], error) {
+//		return infer.MigrationResult[MigrateStateV2]{
+//			Result: &MigrateStateV2{
+//				AString: "default-string", // Add a new required field
+//				AInt: v1.SomeInt, // Rename an existing field
+//			},
+//		}, nil
+//	}
+//
+//	// Associate your migration with the resource it encapsulates.
+//	func (*MyResource) StateMigrations(p.Context) []infer.StateMigrationFunc[MigrateStateV2] {
+//		return []infer.StateMigrationFunc[MigrateStateV2]{
+//			infer.StateMigration(migrateFromV1),
+//		}
+//	}
+func StateMigration[Old, New any, F func(p.Context, Old) (MigrationResult[New], error)](f F) StateMigrationFunc[New] {
+	return stateMigrationFunc[Old, New, F]{f}
+}
+
+// MigrationResult represents the result of a migration.
+type MigrationResult[T any] struct {
+	// Result is the result of the migration.
+	//
+	// If Result is nil, then the migration is considered to have been unnecessary.
+	//
+	// If Result is non-nil, then the migration is considered to have completed and
+	// the new value state value will be *Result.
+	Result *T
+}
+
+type stateMigrationFunc[Old, New any, F func(p.Context, Old) (MigrationResult[New], error)] struct{ f F }
+
+// typeFor returns the [Type] that represents the type argument T.
+//
+// reflect.TypeFor is included in go1.22.
+func typeFor[T any]() reflect.Type {
+	return reflect.TypeOf((*T)(nil)).Elem()
+}
+
+func (stateMigrationFunc[O, N, F]) isStateMigrationFunc()        {}
+func (stateMigrationFunc[O, N, F]) oldShape() reflect.Type       { return typeFor[O]() }
+func (stateMigrationFunc[O, N, F]) newShape() reflect.Type       { return typeFor[N]() }
+func (m stateMigrationFunc[O, N, F]) migrateFunc() reflect.Value { return reflect.ValueOf(m.f) }
+
+type CustomStateMigrations[O any] interface {
+	// StateMigrations is the list of know migrations.
+	//
+	// Each migration should return a valid State object.
+	//
+	// The first migration to return a non-nil Result will be used.
+	StateMigrations(ctx p.Context) []StateMigrationFunc[O]
 }
 
 // The methods of Annotator must be called on pointers to fields of their receivers, or on
@@ -726,8 +847,7 @@ func (*derivedResourceController[R, I, O]) getInstance() *R {
 
 func (rc *derivedResourceController[R, I, O]) Check(ctx p.Context, req p.CheckRequest) (p.CheckResponse, error) {
 	var r R
-	var i I
-	encoder, err := ende.Decode(req.News, &i)
+	encoder, i, err := ende.Decode[I](req.News)
 	if r, ok := ((interface{})(r)).(CustomCheck[I]); ok {
 		// The user implemented check manually, so call that
 		i, failures, err := r.Check(ctx, req.Urn.Name(), req.Olds, req.News)
@@ -768,8 +888,7 @@ func (rc *derivedResourceController[R, I, O]) Check(ctx p.Context, req p.CheckRe
 
 // Ensure that `inputs` can deserialize cleanly into `I`.
 func DefaultCheck[I any](inputs resource.PropertyMap) (I, []p.CheckFailure, error) {
-	var i I
-	_, err := ende.Decode(inputs, &i)
+	_, i, err := ende.Decode[I](inputs)
 	if err == nil {
 		return i, nil, nil
 	}
@@ -827,14 +946,11 @@ func diff[R, I, O any](ctx p.Context, req p.DiffRequest, r *R, forceReplace func
 	}
 
 	if r, ok := ((interface{})(*r)).(CustomDiff[I, O]); ok {
-		var olds O
-		var news I
-		var err error
-		_, err = ende.Decode(req.Olds, &olds)
+		_, olds, err := hydrateFromState[R, I, O](ctx, req.Olds) // TODO
 		if err != nil {
 			return p.DiffResponse{}, err
 		}
-		_, err = ende.Decode(req.News, &news)
+		_, news, err := ende.Decode[I](req.News)
 		if err != nil {
 			return p.DiffResponse{}, err
 		}
@@ -897,9 +1013,8 @@ func diff[R, I, O any](ctx p.Context, req p.DiffRequest, r *R, forceReplace func
 func (rc *derivedResourceController[R, I, O]) Create(ctx p.Context, req p.CreateRequest) (p.CreateResponse, error) {
 	r := rc.getInstance()
 
-	var input I
 	var err error
-	encoder, err := ende.Decode(req.Properties, &input)
+	encoder, input, err := ende.Decode[I](req.Properties)
 	if err != nil {
 		return p.CreateResponse{}, fmt.Errorf("invalid inputs: %w", err)
 	}
@@ -932,16 +1047,38 @@ func (rc *derivedResourceController[R, I, O]) Create(ctx p.Context, req p.Create
 func (rc *derivedResourceController[R, I, O]) Read(ctx p.Context, req p.ReadRequest) (p.ReadResponse, error) {
 	r := rc.getInstance()
 	var inputs I
-	var state O
 	var err error
 	inputEncoder, err := ende.DecodeTolerateMissing(req.Inputs, &inputs)
 	if err != nil {
 		return p.ReadResponse{}, err
 	}
-	stateEncoder, err := ende.DecodeTolerateMissing(req.Properties, &state)
-	if err != nil {
-		return p.ReadResponse{}, err
+
+	// We decode the resource state.
+	//
+	// The state can come from 2 places:
+	//
+	// 1. From the actual stack state.
+	//
+	// 2. From the state field for an import.
+	//
+	// Unfortunately, we are unable to distinguish between (1) and (2). We try (1), which has stricter
+	// requirements, then try (2).
+	var stateEncoder ende.Encoder
+	var state O
+
+	// If (1), then we expect that the state is complete and may need to be upgraded.
+	if enc, s, err := hydrateFromState[R, I, O](ctx, req.Properties); err == nil {
+		stateEncoder = enc
+		state = s
+	} else {
+		// That didn't work, so maybe we can get by decoding without state migration but by tolerating
+		// missing fields.
+		stateEncoder, err = ende.DecodeTolerateMissing(req.Properties, &state)
+		if err != nil {
+			return p.ReadResponse{}, err
+		}
 	}
+
 	read, ok := ((interface{})(*r)).(CustomRead[I, O])
 	if !ok {
 		// Default read implementation:
@@ -981,17 +1118,15 @@ func (rc *derivedResourceController[R, I, O]) Update(ctx p.Context, req p.Update
 		return p.UpdateResponse{}, status.Errorf(codes.Unimplemented,
 			"Update is not implemented for resource %s", req.Urn)
 	}
-	var news I
-	var olds O
-	var err error
 	for _, ignoredChange := range req.IgnoreChanges {
 		req.News[ignoredChange] = req.Olds[ignoredChange]
 	}
-	_, err = ende.Decode(req.Olds, &olds)
+
+	_, olds, err := hydrateFromState[R, I, O](ctx, req.Olds)
 	if err != nil {
 		return p.UpdateResponse{}, err
 	}
-	encoder, err := ende.Decode(req.News, &news)
+	encoder, news, err := ende.Decode[I](req.News)
 	if err != nil {
 		return p.UpdateResponse{}, err
 	}
@@ -1018,8 +1153,7 @@ func (rc *derivedResourceController[R, I, O]) Delete(ctx p.Context, req p.Delete
 	r := rc.getInstance()
 	del, ok := ((interface{})(*r)).(CustomDelete[O])
 	if ok {
-		var olds O
-		_, err := ende.Decode(req.Properties, &olds)
+		_, olds, err := hydrateFromState[R, I, O](ctx, req.Properties)
 		if err != nil {
 			return err
 		}
@@ -1067,4 +1201,91 @@ func getDependenciesRaw(
 	contract.AssertNoErrorf(fg.err.ErrorOrNil(), "Default dependency wiring failed")
 
 	return fg.MarkMap(isCreate, isPreview), nil
+}
+
+// hydrateFromState takes a blob from state and hydrates it for user consumption, running any relevant state
+// migrations.
+func hydrateFromState[R, I, O any](
+	ctx p.Context, state resource.PropertyMap,
+) (ende.Encoder, O, error) {
+	var r R
+	if r, ok := ((interface{})(r)).(CustomStateMigrations[O]); ok {
+		enc, newState, didMigrate, err := migrateState[O](ctx, r, state)
+		if err != nil || didMigrate {
+			return enc, newState, err
+		}
+	}
+
+	return ende.Decode[O](state)
+}
+
+func migrateState[O any](
+	ctx p.Context, r CustomStateMigrations[O], state resource.PropertyMap,
+) (ende.Encoder, O, bool, error) {
+	var o O
+	for _, upgrader := range r.StateMigrations(ctx) {
+		oldType := upgrader.oldShape()
+		f := upgrader.migrateFunc()
+
+		// If the old type is a resource.PropertyMap, we always run the migration
+		// func.
+
+		var results []reflect.Value
+		var enc ende.Encoder
+		if oldType == reflect.TypeOf(resource.PropertyMap{}) {
+			results = f.Call([]reflect.Value{
+				reflect.ValueOf(ctx), reflect.ValueOf(state),
+			})
+		} else {
+			oldValue := reflect.New(oldType)
+
+			var err error
+			enc, err = ende.DecodeAny(state, oldValue.Interface())
+			if err != nil {
+				// If we couldn't encode cleanly, then state doesn't fit into the migrator.
+				continue
+			}
+
+			results = f.Call([]reflect.Value{reflect.ValueOf(ctx), oldValue.Elem()})
+
+		}
+
+		contract.Assertf(len(results) == 2,
+			"upgrader.migrateFunc() returned an invalid value %#v (%[1]T)", f,
+		)
+
+		contract.Assertf(f.Type().Out(1).Name() == "error",
+			"The signature guarantees of f mandate the second argument is an error, found %s",
+			f.Type().Out(1))
+		err, _ := results[1].Interface().(error)
+		if err != nil {
+			return ende.Encoder{}, o, true, err
+		}
+		result, ok := results[0].Interface().(MigrationResult[O])
+		contract.Assertf(ok,
+			"The signature guarantees of f mandate the second argument is an %T, found %T",
+			result, results[0].Interface())
+
+		if result.Result == nil {
+			continue
+		}
+
+		// The migration succeeded, so we are done
+		//
+		// NOTE: This design throws away all secrets from the state when deserializing from raw, and
+		// doesn't move secrets with path changes when deserializing from non-raw.
+		//
+		// Should we warn if state contains secrets.
+		//
+		// Without a richer value representation
+		// (https://github.com/pulumi/pulumi-go-provider/issues/212), this is inevitable for any
+		// strongly typed design.
+		//
+		// We could allow an escape hatch by allowing MigrationResult[O] to be a union of O and
+		// resource.PropertyMap where resource.PropertyMap guarantees that it encodes into O safely.
+		return enc, *result.Result, true, nil
+	}
+
+	// No migration was run
+	return ende.Encoder{}, o, false, nil
 }

--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -17,6 +17,7 @@ package infer
 import (
 	"context"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -25,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 
-	provider "github.com/pulumi/pulumi-go-provider"
+	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer/internal/ende"
 	rRapid "github.com/pulumi/pulumi-go-provider/internal/rapid/resource"
 )
@@ -219,7 +220,7 @@ func (c Context) Log(_ diag.Severity, _ string)                  {}
 func (c Context) Logf(_ diag.Severity, _ string, _ ...any)       {}
 func (c Context) LogStatus(_ diag.Severity, _ string)            {}
 func (c Context) LogStatusf(_ diag.Severity, _ string, _ ...any) {}
-func (c Context) RuntimeInformation() provider.RunInfo           { return provider.RunInfo{} }
+func (c Context) RuntimeInformation() p.RunInfo                  { return p.RunInfo{} }
 
 func TestDiff(t *testing.T) {
 	t.Parallel()
@@ -229,7 +230,7 @@ func TestDiff(t *testing.T) {
 	tests := []struct {
 		olds r.PropertyMap
 		news r.PropertyMap
-		diff map[string]provider.DiffKind
+		diff map[string]p.DiffKind
 	}{
 		{
 			olds: r.PropertyMap{
@@ -242,7 +243,7 @@ func TestDiff(t *testing.T) {
 					"FOO": r.NewStringProperty("bar"),
 				}),
 			},
-			diff: map[string]provider.DiffKind{"environment.FOO": "update"},
+			diff: map[string]p.DiffKind{"environment.FOO": "update"},
 		},
 		{
 			olds: r.PropertyMap{},
@@ -251,7 +252,7 @@ func TestDiff(t *testing.T) {
 					"FOO": r.NewStringProperty("bar"),
 				}),
 			},
-			diff: map[string]provider.DiffKind{"environment": "add"},
+			diff: map[string]p.DiffKind{"environment": "add"},
 		},
 		{
 			olds: r.PropertyMap{
@@ -260,7 +261,7 @@ func TestDiff(t *testing.T) {
 				}),
 			},
 			news: r.PropertyMap{},
-			diff: map[string]provider.DiffKind{"environment": "delete"},
+			diff: map[string]p.DiffKind{"environment": "delete"},
 		},
 		{
 			olds: r.PropertyMap{
@@ -270,7 +271,7 @@ func TestDiff(t *testing.T) {
 				"output": r.NewNumberProperty(42),
 			},
 			news: r.PropertyMap{},
-			diff: map[string]provider.DiffKind{"environment": "delete"},
+			diff: map[string]p.DiffKind{"environment": "delete"},
 		},
 		{
 			olds: r.PropertyMap{
@@ -281,12 +282,12 @@ func TestDiff(t *testing.T) {
 					"FOO": r.NewStringProperty("bar"),
 				}),
 			},
-			diff: map[string]provider.DiffKind{"environment": "add"},
+			diff: map[string]p.DiffKind{"environment": "add"},
 		},
 	}
 
 	for _, test := range tests {
-		diffRequest := provider.DiffRequest{
+		diffRequest := p.DiffRequest{
 			ID:   "foo",
 			Urn:  r.CreateURN("foo", "a:b:c", "", "proj", "stack"),
 			Olds: test.olds,
@@ -304,4 +305,147 @@ func TestDiff(t *testing.T) {
 			assert.Equal(t, test.diff[k], v.Kind)
 		}
 	}
+}
+
+type testContext struct {
+	context.Context
+
+	t *testing.T
+}
+
+func (testContext) Log(diag.Severity, string)                {}
+func (testContext) Logf(diag.Severity, string, ...any)       {}
+func (testContext) LogStatus(diag.Severity, string)          {}
+func (testContext) LogStatusf(diag.Severity, string, ...any) {}
+func (ctx testContext) RuntimeInformation() p.RunInfo {
+	ctx.t.Logf("No RuntimeInformation on a test context")
+	ctx.t.FailNow()
+	return p.RunInfo{}
+}
+
+type CustomHydrateFromState[O any] struct{}
+
+func (CustomHydrateFromState[O]) StateMigrations(ctx p.Context) []StateMigrationFunc[O] {
+	return ctx.Value("migrations").([]StateMigrationFunc[O])
+}
+
+func testHydrateFromState[O any](
+	oldState, expected r.PropertyMap, expectedError error,
+	migrations ...StateMigrationFunc[O],
+) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testContext{
+			//nolint:revive
+			Context: context.WithValue(context.Background(), "migrations", migrations),
+		}
+
+		enc, actual, err := hydrateFromState[CustomHydrateFromState[O], struct{}, O](ctx, oldState)
+		if expectedError != nil {
+			assert.ErrorIs(t, err, expectedError)
+			return
+		}
+		m, err := enc.Encode(actual)
+		require.NoErrorf(t, err, "We should be able to encode the result to a p.Map")
+		assert.Equal(t, expected, m)
+	}
+}
+
+// False positives on t.Run(name, testHydrateFromState[T](...))
+//
+//nolint:paralleltest
+func TestHydrateFromState(t *testing.T) {
+	t.Parallel()
+
+	type numberMigrateTarget struct {
+		Number int `pulumi:"number"`
+	}
+	type numberMigrateSource struct {
+		Number string `pulumi:"number"`
+	}
+
+	t.Run("migrate type", testHydrateFromState[numberMigrateTarget](
+		r.PropertyMap{
+			"number": r.NewProperty("42"),
+		},
+		r.PropertyMap{
+			"number": r.NewProperty(42.0),
+		},
+		nil,
+		StateMigration(func(_ p.Context, old numberMigrateSource) (MigrationResult[numberMigrateTarget], error) {
+			n, err := strconv.ParseInt(old.Number, 10, 64)
+			if err != nil {
+				return MigrationResult[numberMigrateTarget]{}, err
+			}
+			return MigrationResult[numberMigrateTarget]{
+				Result: &numberMigrateTarget{
+					Number: int(n),
+				},
+			}, nil
+		}),
+	))
+
+	t.Run("migrate-raw", testHydrateFromState[numberMigrateTarget](
+		r.PropertyMap{
+			"number": r.NewProperty("42"),
+		},
+		r.PropertyMap{
+			"number": r.NewProperty(42.0),
+		},
+		nil,
+		StateMigration(func(_ p.Context, old r.PropertyMap) (MigrationResult[numberMigrateTarget], error) {
+			n, err := strconv.ParseInt(old["number"].StringValue(), 10, 64)
+			if err != nil {
+				return MigrationResult[numberMigrateTarget]{}, err
+			}
+			return MigrationResult[numberMigrateTarget]{
+				Result: &numberMigrateTarget{
+					Number: int(n),
+				},
+			}, nil
+		}),
+	))
+
+	t.Run("ordering-success", testHydrateFromState[numberMigrateTarget](
+		r.PropertyMap{
+			"number": r.NewProperty("0"),
+		},
+		r.PropertyMap{
+			"number": r.NewProperty(1.0),
+		},
+		nil,
+		StateMigration(func(p.Context, r.PropertyMap) (MigrationResult[numberMigrateTarget], error) {
+			return MigrationResult[numberMigrateTarget]{
+				Result: &numberMigrateTarget{
+					Number: int(1),
+				},
+			}, nil
+		}),
+		StateMigration(func(p.Context, r.PropertyMap) (MigrationResult[numberMigrateTarget], error) {
+			panic("Should never be called")
+		}),
+	))
+
+	t.Run("ordering", testHydrateFromState[numberMigrateTarget](
+		r.PropertyMap{
+			"number": r.NewProperty("0"),
+		},
+		r.PropertyMap{
+			"number": r.NewProperty(2.0),
+		},
+		nil,
+		StateMigration(func(p.Context, r.PropertyMap) (MigrationResult[numberMigrateTarget], error) {
+			return MigrationResult[numberMigrateTarget]{
+				Result: nil,
+			}, nil
+		}),
+		StateMigration(func(p.Context, r.PropertyMap) (MigrationResult[numberMigrateTarget], error) {
+			return MigrationResult[numberMigrateTarget]{
+				Result: &numberMigrateTarget{
+					Number: int(2),
+				},
+			}, nil
+		}),
+	))
 }

--- a/infer/tests/migrate_test.go
+++ b/infer/tests/migrate_test.go
@@ -1,0 +1,276 @@
+// Copyright 2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi-go-provider/integration"
+)
+
+var (
+	_ infer.CustomResource[MigrateStateInput, MigrateStateV2] = (*MigrateR)(nil)
+	_ infer.CustomStateMigrations[MigrateStateV2]             = (*MigrateR)(nil)
+	_ infer.CustomUpdate[MigrateStateInput, MigrateStateV2]   = (*MigrateR)(nil)
+	_ infer.CustomDelete[MigrateStateV2]                      = (*MigrateR)(nil)
+	_ infer.CustomRead[MigrateStateInput, MigrateStateV2]     = (*MigrateR)(nil)
+	_ infer.CustomDiff[MigrateStateInput, MigrateStateV2]     = (*MigrateR)(nil)
+)
+
+type MigrateR struct{}
+
+func (*MigrateR) StateMigrations(p.Context) []infer.StateMigrationFunc[MigrateStateV2] {
+	return []infer.StateMigrationFunc[MigrateStateV2]{
+		infer.StateMigration(migrateFromRaw),
+		infer.StateMigration(migrateFromV0),
+		infer.StateMigration(migrateFromV1),
+	}
+}
+
+func migrateFromRaw(_ p.Context, m resource.PropertyMap) (infer.MigrationResult[MigrateStateV2], error) {
+	inputs, ok := m["__inputs"]
+	if !ok || !inputs.IsObject() {
+		return infer.MigrationResult[MigrateStateV2]{}, nil
+	}
+	m = inputs.ObjectValue()
+
+	return infer.MigrationResult[MigrateStateV2]{
+		Result: &MigrateStateV2{
+			AString: m["aString"].StringValue(),
+			AInt:    int(m["aInt"].NumberValue()),
+		},
+	}, nil
+}
+
+func migrateFromV0(ctx p.Context, v0 MigrateStateV0) (infer.MigrationResult[MigrateStateV2], error) {
+	aString := "default-string"
+	if v0.AString != nil {
+		aString = *v0.AString
+	}
+	return migrateFromV1(ctx, MigrateStateV1{
+		AString: aString,
+	})
+}
+
+type MigrateStateV0 struct {
+	AString *string `pulumi:"aString,optional"`
+}
+
+func migrateFromV1(_ p.Context, v1 MigrateStateV1) (infer.MigrationResult[MigrateStateV2], error) {
+	aInt := -7
+	if v1.SomeInt != nil {
+		aInt = *v1.SomeInt
+	}
+	return infer.MigrationResult[MigrateStateV2]{
+		Result: &MigrateStateV2{
+			AString: v1.AString,
+			AInt:    aInt,
+		},
+	}, nil
+}
+
+type MigrateStateV1 struct {
+	AString string `pulumi:"aString"`
+	SomeInt *int   `pulumi:"someInt,optional"`
+}
+
+type MigrateStateV2 struct {
+	AString string `pulumi:"aString"`
+	AInt    int    `pulumi:"aInt"`
+}
+
+type MigrateStateInput struct{}
+
+func migrationServer() integration.Server {
+	return integration.NewServer("test",
+		semver.MustParse("1.0.0"),
+		infer.Provider(infer.Options{
+			Resources: []infer.InferredResource{
+				infer.Resource[*MigrateR, MigrateStateInput, MigrateStateV2](),
+			},
+			ModuleMap: map[tokens.ModuleName]tokens.ModuleName{"tests": "index"},
+		}))
+}
+
+// Test f on some old states that should be equivalent after upgrades.
+func testMigrationEquivalentStates(t *testing.T, f func(t *testing.T, state, v2State resource.PropertyMap)) {
+	t.Run("defaults", func(t *testing.T) {
+
+		v2 := func() resource.PropertyMap {
+			return resource.PropertyMap{
+				"aString": resource.NewProperty("default-string"),
+				"aInt":    resource.NewProperty(-7.0),
+			}
+		}
+
+		t.Run("raw", func(t *testing.T) {
+			f(t, resource.PropertyMap{
+				"__inputs": resource.NewProperty(resource.PropertyMap{
+					"aString": resource.NewProperty("default-string"),
+					"aInt":    resource.NewProperty(-7.0),
+				}),
+			}, v2())
+		})
+
+		t.Run("v0", func(t *testing.T) {
+			f(t, resource.PropertyMap{}, v2())
+		})
+
+		t.Run("v1", func(t *testing.T) {
+			f(t, resource.PropertyMap{
+				"aString": resource.NewProperty("default-string"),
+			}, v2())
+		})
+
+		t.Run("v2", func(t *testing.T) {
+			f(t, v2(), v2())
+		})
+	})
+
+	t.Run("all-fields", func(t *testing.T) {
+		const (
+			aString = "some-string"
+			aInt    = 33.0
+		)
+
+		v2 := func() resource.PropertyMap {
+			return resource.PropertyMap{
+				"aString": resource.NewProperty(aString),
+				"aInt":    resource.NewProperty(aInt),
+			}
+		}
+
+		t.Run("raw", func(t *testing.T) {
+			f(t, resource.PropertyMap{
+				"__inputs": resource.NewProperty(resource.PropertyMap{
+					"aString": resource.NewProperty(aString),
+					"aInt":    resource.NewProperty(aInt),
+				}),
+			}, v2())
+		})
+
+		t.Run("v1", func(t *testing.T) {
+			f(t, resource.PropertyMap{
+				"aString": resource.NewProperty(aString),
+				"someInt": resource.NewProperty(aInt),
+			}, v2())
+		})
+
+		t.Run("v2", func(t *testing.T) {
+			f(t, v2(), v2())
+		})
+	})
+}
+
+func TestMigrateUpdate(t *testing.T) {
+	t.Parallel()
+
+	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State resource.PropertyMap) {
+		resp, err := migrationServer().Update(p.UpdateRequest{
+			ID:   "some-id",
+			Urn:  urn("MigrateR", "update"),
+			Olds: state,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, v2State, resp.Properties)
+	})
+}
+
+func TestMigrateDiff(t *testing.T) {
+	t.Parallel()
+
+	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State resource.PropertyMap) {
+		_, err := migrationServer().Diff(p.DiffRequest{
+			ID:   "some-id",
+			Urn:  urn("MigrateR", "diff"),
+			Olds: state,
+		})
+		var via viaError[MigrateStateV2]
+		require.ErrorAs(t, err, &via)
+		assert.Equal(t, v2State, resource.PropertyMap{
+			"aString": resource.NewProperty(via.t.AString),
+			"aInt":    resource.NewProperty(float64(via.t.AInt)),
+		})
+	})
+}
+
+func TestMigrateDelete(t *testing.T) {
+	t.Parallel()
+
+	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State resource.PropertyMap) {
+		err := migrationServer().Delete(p.DeleteRequest{
+			ID:         "some-id",
+			Urn:        urn("MigrateR", "delete"),
+			Properties: state,
+		})
+		var via viaError[MigrateStateV2]
+		require.ErrorAs(t, err, &via)
+		assert.Equal(t, v2State, resource.PropertyMap{
+			"aString": resource.NewProperty(via.t.AString),
+			"aInt":    resource.NewProperty(float64(via.t.AInt)),
+		})
+	})
+}
+
+func TestMigrateRead(t *testing.T) {
+	t.Parallel()
+
+	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State resource.PropertyMap) {
+		resp, err := migrationServer().Read(p.ReadRequest{
+			ID:         "some-id",
+			Urn:        urn("MigrateR", "read"),
+			Properties: state,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, v2State, resp.Properties)
+	})
+}
+
+func (*MigrateR) Create(p.Context, string, MigrateStateInput, bool) (string, MigrateStateV2, error) {
+	panic("CANNOT CREATE; ONLY MIGRATE")
+}
+
+// Just return the old state so it is visible to tests.
+func (*MigrateR) Update(
+	_ p.Context, _ string, s MigrateStateV2, _ MigrateStateInput, _ bool,
+) (MigrateStateV2, error) {
+	return s, nil
+}
+
+func (*MigrateR) Read(
+	_ p.Context, id string, input MigrateStateInput, output MigrateStateV2,
+) (string, MigrateStateInput, MigrateStateV2, error) {
+	return id, input, output, nil
+}
+
+func (*MigrateR) Delete(_ p.Context, _ string, s MigrateStateV2) error {
+	return viaError[MigrateStateV2]{s}
+}
+
+func (*MigrateR) Diff(_ p.Context, _ string, s MigrateStateV2, _ MigrateStateInput) (p.DiffResponse, error) {
+	return p.DiffResponse{}, viaError[MigrateStateV2]{s}
+}
+
+type viaError[T any] struct{ t T }
+
+func (viaError[T]) Error() string { panic("NOT FOR DISPLAY") }


### PR DESCRIPTION
Adds support for state migrations in the `infer` provider. Resources opt into state migrations when they implement the `infer.CustomStateMigrations[O]` interface:

```go
type CustomStateMigrations[O any] interface {
	// StateMigrations is the list of know migrations.
	//
	// Each migration should return a valid State object.
	//
	// The first migration to return a non-nil Result will be used.
	StateMigrations(ctx p.Context) []StateMigrationFunc[O]
}

// StateMigrationFunc represents a stateless mapping from an old state shape to a new
// state shape. Each StateMigrationFunc is parameterized by the shape of the type it
// produces, ensuring that all successful migrations end up in a valid state.
//
// To create a StateMigrationFunc, use [StateMigration].
type StateMigrationFunc[New any] interface {} // Sealed

// StateMigration creates a mapping from an old state shape (type Old) to a new state
// shape (type New).
//
// If Old = [resource.PropertyMap], then the migration is always run.
//
// Example:
//
//	type MyResource struct{}
//
//	type MyInput struct{}
//
//	type MyStateV1 struct {
//		SomeInt *int `pulumi:"someInt,optional"`
//	}
//
//	type MyStateV2 struct {
//		AString string `pulumi:"aString"`
//		AInt    *int   `pulumi:"aInt,optional"`
//	}
//
//	func migrateFromV1(ctx p.Context, v1 StateV1) (infer.MigrationResult[MigrateStateV2], error) {
//		return infer.MigrationResult[MigrateStateV2]{
//			Result: &MigrateStateV2{
//				AString: "default-string", // Add a new required field
//				AInt: v1.SomeInt, // Rename an existing field
//			},
//		}, nil
//	}
//
//	// Associate your migration with the resource it encapsulates.
//	func (*MyResource) StateMigrations(p.Context) []infer.StateMigrationFunc[MigrateStateV2] {
//		return []infer.StateMigrationFunc[MigrateStateV2]{
//			infer.StateMigration(migrateFromV1),
//		}
//	}
func StateMigration[Old, New any, F func(p.Context, Old) (MigrationResult[New], error)](f F) StateMigrationFunc[New] { ... }


// MigrationResult represents the result of a migration.
type MigrationResult[T any] struct {
	// Result is the result of the migration.
	//
	// If Result is nil, then the migration is considered to have been unnecessary.
	//
	// If Result is non-nil, then the migration is considered to have completed and
	// the new value state value will be *Result.
	Result *T
}
```

This allows each resource to define a list of (possibly typed) migrations from old to new state. This design makes the common case of migrating from StateV1 to StateV2 fully typed, but permits an untyped to typed escape hatch.

Fixes #193