### PR TITLE
Add `func rpc.Provider(pulumirpc.ResourceProviderServer) p.Provider`

### DIFF
--- a/middleware/rpc/provider.go
+++ b/middleware/rpc/provider.go
@@ -1,0 +1,354 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"errors"
+
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	p "github.com/pulumi/pulumi-go-provider"
+)
+
+// Provider projects a [rpc.ResourceProviderServer] into a [p.Provider].
+//
+// It is intended that Provider is used to wrap legacy native provider implementations
+// while they are gradually transferred over to pulumi-go-provider based implementations.
+//
+// Construct, Call and StreamInvoke are not supported and will always return
+// unimplemented.
+func Provider(server rpc.ResourceProviderServer) p.Provider {
+	var runtime runtime // the runtime configuration of the server
+	return p.Provider{
+		GetSchema: func(ctx p.Context, req p.GetSchemaRequest) (p.GetSchemaResponse, error) {
+			s, err := server.GetSchema(ctx, &rpc.GetSchemaRequest{
+				Version: int32(req.Version),
+			})
+			return p.GetSchemaResponse{
+				Schema: s.GetSchema(),
+			}, err
+		},
+		Cancel: func(ctx p.Context) error {
+			_, err := server.Cancel(ctx, &emptypb.Empty{})
+			return err
+		},
+		CheckConfig: func(ctx p.Context, req p.CheckRequest) (p.CheckResponse, error) {
+			olds, err := runtime.propertyToRPC(req.Olds)
+			if err != nil {
+				return p.CheckResponse{}, err
+			}
+
+			news, err := runtime.propertyToRPC(req.News)
+			if err != nil {
+				return p.CheckResponse{}, err
+			}
+
+			return checkResponse(server.CheckConfig(ctx, &rpc.CheckRequest{
+				Urn:        string(req.Urn),
+				Olds:       olds,
+				News:       news,
+				RandomSeed: req.RandomSeed,
+			}))
+		},
+		DiffConfig: func(ctx p.Context, req p.DiffRequest) (p.DiffResponse, error) {
+			ignoreChanges := make([]string, len(req.IgnoreChanges))
+			for i, v := range req.IgnoreChanges {
+				ignoreChanges[i] = string(v)
+			}
+			olds, err := runtime.propertyToRPC(req.Olds)
+			if err != nil {
+				return p.DiffResponse{}, err
+			}
+			news, err := runtime.propertyToRPC(req.News)
+			if err != nil {
+				return p.DiffResponse{}, err
+			}
+
+			return diffResponse(server.DiffConfig(ctx, &rpc.DiffRequest{
+				Id:            req.ID,
+				Urn:           string(req.Urn),
+				Olds:          olds,
+				News:          news,
+				IgnoreChanges: ignoreChanges,
+			}))
+		},
+		Configure: func(ctx p.Context, req p.ConfigureRequest) error {
+			args, err := runtime.propertyToRPC(req.Args)
+			if err != nil {
+				return err
+			}
+
+			runtime.configuration, err = server.Configure(ctx, &rpc.ConfigureRequest{
+				Variables:       req.Variables,
+				Args:            args,
+				AcceptSecrets:   true,
+				AcceptResources: true,
+			})
+			return err
+		},
+		Invoke: func(ctx p.Context, req p.InvokeRequest) (p.InvokeResponse, error) {
+
+			args, err := runtime.propertyToRPC(req.Args)
+			if err != nil {
+				return p.InvokeResponse{}, err
+			}
+
+			resp, err := server.Invoke(ctx, &rpc.InvokeRequest{
+				Tok:  string(req.Token),
+				Args: args,
+			})
+			ret, err := rpcToProperty(resp.GetReturn(), err)
+			return p.InvokeResponse{
+				Return:   ret,
+				Failures: checkFailures(resp.GetFailures()),
+			}, err
+		},
+		Check: func(ctx p.Context, req p.CheckRequest) (p.CheckResponse, error) {
+			olds, err := runtime.propertyToRPC(req.Olds)
+			if err != nil {
+				return p.CheckResponse{}, err
+			}
+
+			news, err := runtime.propertyToRPC(req.News)
+			if err != nil {
+				return p.CheckResponse{}, err
+			}
+
+			return checkResponse(server.Check(ctx, &rpc.CheckRequest{
+				Urn:        string(req.Urn),
+				Olds:       olds,
+				News:       news,
+				RandomSeed: req.RandomSeed,
+			}))
+		},
+		Diff: func(ctx p.Context, req p.DiffRequest) (p.DiffResponse, error) {
+			ignoreChanges := make([]string, len(req.IgnoreChanges))
+			for i, v := range req.IgnoreChanges {
+				ignoreChanges[i] = string(v)
+			}
+			olds, err := runtime.propertyToRPC(req.Olds)
+			if err != nil {
+				return p.DiffResponse{}, err
+			}
+
+			news, err := runtime.propertyToRPC(req.News)
+			if err != nil {
+				return p.DiffResponse{}, err
+			}
+
+			return diffResponse(server.Diff(ctx, &rpc.DiffRequest{
+				Id:            req.ID,
+				Urn:           string(req.Urn),
+				Olds:          olds,
+				News:          news,
+				IgnoreChanges: ignoreChanges,
+			}))
+		},
+		Create: func(ctx p.Context, req p.CreateRequest) (p.CreateResponse, error) {
+			if req.Preview && runtime.configuration != nil && !runtime.configuration.SupportsPreview {
+				return p.CreateResponse{}, nil
+			}
+
+			inProperties, err := runtime.propertyToRPC(req.Properties)
+			if err != nil {
+				return p.CreateResponse{}, err
+			}
+
+			resp, err := server.Create(ctx, &rpc.CreateRequest{
+				Urn:        string(req.Urn),
+				Properties: inProperties,
+				Timeout:    req.Timeout,
+				Preview:    req.Preview,
+			})
+			properties, err := rpcToProperty(resp.GetProperties(), err)
+			return p.CreateResponse{
+				ID:         resp.GetId(),
+				Properties: properties,
+			}, err
+		},
+		Read: func(ctx p.Context, req p.ReadRequest) (p.ReadResponse, error) {
+			inProperties, err := runtime.propertyToRPC(req.Properties)
+			if err != nil {
+				return p.ReadResponse{}, err
+			}
+			inInputs, err := runtime.propertyToRPC(req.Inputs)
+			if err != nil {
+				return p.ReadResponse{}, err
+			}
+
+			resp, err := server.Read(ctx, &rpc.ReadRequest{
+				Id:         req.ID,
+				Urn:        string(req.Urn),
+				Properties: inProperties,
+				Inputs:     inInputs,
+			})
+			properties, err := rpcToProperty(resp.GetProperties(), err)
+			inputs, err := rpcToProperty(resp.GetInputs(), err)
+			return p.ReadResponse{
+				ID:         resp.GetId(),
+				Properties: properties,
+				Inputs:     inputs,
+			}, err
+		},
+		Update: func(ctx p.Context, req p.UpdateRequest) (p.UpdateResponse, error) {
+			if req.Preview && runtime.configuration != nil && !runtime.configuration.SupportsPreview {
+				return p.UpdateResponse{}, nil
+			}
+			ignoreChanges := make([]string, len(req.IgnoreChanges))
+			for i, v := range req.IgnoreChanges {
+				ignoreChanges[i] = string(v)
+			}
+
+			inOlds, err := runtime.propertyToRPC(req.Olds)
+			if err != nil {
+				return p.UpdateResponse{}, err
+			}
+
+			inNews, err := runtime.propertyToRPC(req.News)
+			if err != nil {
+				return p.UpdateResponse{}, err
+			}
+
+			resp, err := server.Update(ctx, &rpc.UpdateRequest{
+				Id:            req.ID,
+				Urn:           string(req.Urn),
+				Olds:          inOlds,
+				News:          inNews,
+				Timeout:       req.Timeout,
+				IgnoreChanges: ignoreChanges,
+				Preview:       req.Preview,
+			})
+
+			properties, err := rpcToProperty(resp.GetProperties(), err)
+			return p.UpdateResponse{
+				Properties: properties,
+			}, err
+		},
+		Delete: func(ctx p.Context, req p.DeleteRequest) error {
+			properties, err := runtime.propertyToRPC(req.Properties)
+			if err != nil {
+				return err
+			}
+			_, err = server.Delete(ctx, &rpc.DeleteRequest{
+				Id:         req.ID,
+				Urn:        string(req.Urn),
+				Properties: properties,
+				Timeout:    req.Timeout,
+			})
+			return err
+		},
+	}
+}
+
+func checkResponse(resp *rpc.CheckResponse, err error) (p.CheckResponse, error) {
+	inputs, err := rpcToProperty(resp.GetInputs(), err)
+	return p.CheckResponse{
+		Inputs:   inputs,
+		Failures: checkFailures(resp.GetFailures()),
+	}, err
+}
+
+func diffResponse(resp *rpc.DiffResponse, err error) (p.DiffResponse, error) {
+	detailedDiff := make(map[string]p.PropertyDiff, len(resp.GetDetailedDiff()))
+	if resp.GetHasDetailedDiff() {
+		for k, v := range resp.GetDetailedDiff() {
+			var kind p.DiffKind
+			switch v.Kind {
+			case rpc.PropertyDiff_ADD:
+				kind = p.Add
+			case rpc.PropertyDiff_ADD_REPLACE:
+				kind = p.AddReplace
+			case rpc.PropertyDiff_DELETE:
+				kind = p.Delete
+			case rpc.PropertyDiff_DELETE_REPLACE:
+				kind = p.DeleteReplace
+			case rpc.PropertyDiff_UPDATE:
+				kind = p.Update
+			case rpc.PropertyDiff_UPDATE_REPLACE:
+				kind = p.UpdateReplace
+			}
+			detailedDiff[k] = p.PropertyDiff{
+				Kind:      kind,
+				InputDiff: v.InputDiff,
+			}
+		}
+	} else {
+		// We need to emulate support for a non-detailed diff
+
+		for _, update := range resp.GetDiffs() {
+			detailedDiff[update] = p.PropertyDiff{Kind: p.Update}
+		}
+		for _, replace := range resp.GetReplaces() {
+			detailedDiff[replace] = p.PropertyDiff{Kind: p.UpdateReplace}
+		}
+	}
+	if len(detailedDiff) == 0 {
+		detailedDiff = nil
+	}
+	return p.DiffResponse{
+		DeleteBeforeReplace: resp.GetDeleteBeforeReplace(),
+		HasChanges:          resp.GetChanges() == rpc.DiffResponse_DIFF_SOME,
+		DetailedDiff:        detailedDiff,
+	}, err
+}
+
+func checkFailures(resp []*rpc.CheckFailure) []p.CheckFailure {
+	if resp == nil {
+		return nil
+	}
+	arr := make([]p.CheckFailure, len(resp))
+	for i, v := range resp {
+		arr[i] = p.CheckFailure{
+			Property: v.Property,
+			Reason:   v.Reason,
+		}
+	}
+	return arr
+}
+
+type runtime struct {
+	configuration *rpc.ConfigureResponse
+}
+
+func (r runtime) propertyToRPC(m resource.PropertyMap) (*structpb.Struct, error) {
+	if r.configuration == nil {
+		r.configuration = &rpc.ConfigureResponse{}
+	}
+	s, err := plugin.MarshalProperties(m, plugin.MarshalOptions{
+		KeepUnknowns:     r.configuration.SupportsPreview,
+		KeepSecrets:      r.configuration.AcceptSecrets,
+		KeepResources:    r.configuration.AcceptResources,
+		KeepOutputValues: r.configuration.AcceptOutputs,
+	})
+	return s, err
+}
+
+func rpcToProperty(s *structpb.Struct, previousError error) (resource.PropertyMap, error) {
+	if s == nil {
+		return nil, previousError
+	}
+	m, err := plugin.UnmarshalProperties(s, plugin.MarshalOptions{
+		SkipNulls:        false,
+		KeepUnknowns:     true,
+		KeepSecrets:      true,
+		KeepResources:    true,
+		KeepOutputValues: true,
+	})
+	return m, errors.Join(err, previousError)
+}

--- a/provider.go
+++ b/provider.go
@@ -48,9 +48,10 @@ type GetSchemaResponse struct {
 }
 
 type CheckRequest struct {
-	Urn  presource.URN
-	Olds presource.PropertyMap
-	News presource.PropertyMap
+	Urn        presource.URN
+	Olds       presource.PropertyMap
+	News       presource.PropertyMap
+	RandomSeed []byte
 }
 
 type CheckFailure struct {
@@ -660,9 +661,10 @@ func (p *provider) CheckConfig(ctx context.Context, req *rpc.CheckRequest) (*rpc
 		return nil, err
 	}
 	r, err := p.client.CheckConfig(p.ctx(ctx, presource.URN(req.GetUrn())), CheckRequest{
-		Urn:  presource.URN(req.GetUrn()),
-		Olds: olds,
-		News: news,
+		Urn:        presource.URN(req.GetUrn()),
+		Olds:       olds,
+		News:       news,
+		RandomSeed: req.RandomSeed,
 	})
 
 	if err != nil {

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -1,0 +1,926 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/integration"
+	wraprpc "github.com/pulumi/pulumi-go-provider/middleware/rpc"
+)
+
+func TestRPCGetSchema(t *testing.T) {
+	t.Run("no-error", func(t *testing.T) {
+		resp, err := rpcServer(rpcTestServer{
+			onGetSchema: func(_ context.Context, req *rpc.GetSchemaRequest) (*rpc.GetSchemaResponse, error) {
+				assert.Equal(t, int32(4), req.Version)
+				return &rpc.GetSchemaResponse{
+					Schema: "some-schema",
+				}, nil
+			},
+		}).GetSchema(p.GetSchemaRequest{
+			Version: 4,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, p.GetSchemaResponse{
+			Schema: "some-schema",
+		}, resp)
+	})
+	t.Run("error", func(t *testing.T) {
+		_, err := rpcServer(rpcTestServer{
+			onGetSchema: func(_ context.Context, req *rpc.GetSchemaRequest) (*rpc.GetSchemaResponse, error) {
+				assert.Equal(t, int32(0), req.Version)
+				return &rpc.GetSchemaResponse{}, fmt.Errorf("no schema found")
+			},
+		}).GetSchema(p.GetSchemaRequest{
+			Version: 0,
+		})
+		assert.ErrorContains(t, err, "no schema found")
+	})
+}
+
+func TestRPCCancel(t *testing.T) {
+	t.Run("no-error", func(t *testing.T) {
+		var wasCalled bool
+		err := rpcServer(rpcTestServer{
+			onCancel: func(context.Context, *emptypb.Empty) (*emptypb.Empty, error) {
+				wasCalled = true
+				return &emptypb.Empty{}, nil
+			},
+		}).Cancel()
+		assert.NoError(t, err)
+		assert.True(t, wasCalled)
+	})
+	t.Run("error", func(t *testing.T) {
+		err := rpcServer(rpcTestServer{
+			onCancel: func(context.Context, *emptypb.Empty) (*emptypb.Empty, error) {
+				return &emptypb.Empty{}, fmt.Errorf("cancel failed")
+			},
+		}).Cancel()
+		assert.ErrorContains(t, err, "cancel failed")
+	})
+}
+
+func TestRPCCheckConfig(t *testing.T) {
+	t.Parallel()
+	testRPCCheck(t, func(
+		f func(context.Context, *rpc.CheckRequest) (*rpc.CheckResponse, error),
+	) func(p.CheckRequest) (p.CheckResponse, error) {
+		s := rpcServer(rpcTestServer{onCheckConfig: f})
+		return s.CheckConfig
+	})
+}
+
+func TestRPCDiffConfig(t *testing.T) {
+	t.Parallel()
+	testRPCDiff(t, func(
+		f func(context.Context, *rpc.DiffRequest) (*rpc.DiffResponse, error),
+	) func(p.DiffRequest) (p.DiffResponse, error) {
+		s := rpcServer(rpcTestServer{onDiffConfig: f})
+		return s.DiffConfig
+	})
+}
+
+func TestRPCConfigure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("args", func(t *testing.T) {
+		t.Parallel()
+		args, expectedArgs := exampleOlds()
+		var didRun bool
+		s := rpcServer(rpcTestServer{
+			onConfigure: func(
+				_ context.Context, req *rpc.ConfigureRequest,
+			) (*rpc.ConfigureResponse, error) {
+				assert.Equal(t, expectedArgs, req.GetArgs().AsMap())
+				didRun = true
+
+				return &rpc.ConfigureResponse{}, nil
+			},
+		})
+		err := s.Configure(p.ConfigureRequest{Args: args})
+		require.NoError(t, err)
+		assert.True(t, didRun)
+	})
+
+	t.Run("variables", func(t *testing.T) {
+		t.Parallel()
+		vars := map[string]string{
+			"f1":     "v1",
+			"f2":     "123",
+			"nested": `{"foo": "bar"}`,
+		}
+		var didRun bool
+		s := rpcServer(rpcTestServer{
+			onConfigure: func(
+				_ context.Context, req *rpc.ConfigureRequest,
+			) (*rpc.ConfigureResponse, error) {
+				assert.Equal(t, vars, req.GetVariables())
+				didRun = true
+
+				return &rpc.ConfigureResponse{}, nil
+			},
+		})
+		err := s.Configure(p.ConfigureRequest{Variables: vars})
+		require.NoError(t, err)
+		assert.True(t, didRun)
+	})
+
+	configureResult := func(
+		ret *rpc.ConfigureResponse,
+	) func(context.Context, *rpc.ConfigureRequest) (*rpc.ConfigureResponse, error) {
+		return func(context.Context, *rpc.ConfigureRequest) (*rpc.ConfigureResponse, error) {
+			return ret, nil
+		}
+	}
+
+	// Check that we elide secretes when secrets are not supported.
+	t.Run("secrets", func(t *testing.T) {
+		t.Parallel()
+		for _, acceptSecrets := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%v", acceptSecrets), func(t *testing.T) {
+				s := rpcServer(rpcTestServer{
+					onConfigure: configureResult(&rpc.ConfigureResponse{
+						AcceptSecrets: acceptSecrets,
+					}),
+					onCreate: func(
+						_ context.Context, req *rpc.CreateRequest,
+					) (*rpc.CreateResponse, error) {
+						m, err := plugin.UnmarshalProperties(
+							req.GetProperties(), plugin.MarshalOptions{
+								KeepSecrets: true,
+							})
+						require.NoError(t, err)
+						if acceptSecrets {
+							assert.Equal(t, resource.PropertyMap{
+								"secret": resource.MakeSecret(
+									resource.NewProperty("v")),
+							}, m)
+						} else {
+							assert.Equal(t, resource.PropertyMap{
+								"secret": resource.NewProperty("v"),
+							}, m)
+						}
+
+						return &rpc.CreateResponse{Id: "some-id"}, nil
+					},
+				})
+
+				require.NoError(t, s.Configure(p.ConfigureRequest{}))
+				resp, err := s.Create(p.CreateRequest{
+					Properties: resource.PropertyMap{
+						"secret": resource.MakeSecret(resource.NewProperty("v")),
+					},
+				})
+				require.NoError(t, err)
+				assert.Equal(t, p.CreateResponse{ID: "some-id"}, resp)
+			})
+		}
+	})
+
+	// Check that we elide output values when outputs are not supported.
+	t.Run("outputs", func(t *testing.T) {
+		t.Parallel()
+		for _, acceptOutputs := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%v", acceptOutputs), func(t *testing.T) {
+				s := rpcServer(rpcTestServer{
+					onConfigure: configureResult(&rpc.ConfigureResponse{
+						AcceptOutputs: acceptOutputs,
+					}),
+					onCreate: func(
+						_ context.Context, req *rpc.CreateRequest,
+					) (*rpc.CreateResponse, error) {
+						m, err := plugin.UnmarshalProperties(
+							req.GetProperties(), plugin.MarshalOptions{
+								KeepUnknowns:     true,
+								KeepOutputValues: true,
+							})
+						require.NoError(t, err)
+						if acceptOutputs {
+							assert.Equal(t, resource.PropertyMap{
+								"output": resource.NewOutputProperty(resource.Output{
+									Known:  false,
+									Secret: true,
+								}),
+								"known": resource.NewOutputProperty(resource.Output{
+									Known:   true,
+									Element: resource.NewProperty("v1"),
+								}),
+							}, m)
+						} else {
+							assert.Equal(t, resource.PropertyMap{
+								"known": resource.NewProperty("v1"),
+							}, m)
+						}
+
+						return &rpc.CreateResponse{Id: "some-id"}, nil
+					},
+				})
+
+				require.NoError(t, s.Configure(p.ConfigureRequest{}))
+				resp, err := s.Create(p.CreateRequest{
+					Properties: resource.PropertyMap{
+						"output": resource.NewOutputProperty(resource.Output{
+							Known:  false,
+							Secret: true,
+						}),
+						"known": resource.NewOutputProperty(resource.Output{
+							Known:   true,
+							Element: resource.NewProperty("v1"),
+						}),
+						"unknown": resource.MakeComputed(resource.NewProperty("v2")),
+					},
+				})
+				require.NoError(t, err)
+				assert.Equal(t, p.CreateResponse{ID: "some-id"}, resp)
+			})
+		}
+	})
+
+	// Check that we only call preview functions when a server supports preview, but
+	// that we always call non-preview functions.
+	t.Run("preview", func(t *testing.T) {
+		t.Parallel()
+		for _, preview := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%v", preview), func(t *testing.T) {
+				s := rpcServer(rpcTestServer{
+					onConfigure: configureResult(&rpc.ConfigureResponse{
+						SupportsPreview: preview,
+					}),
+					onCreate: func(
+						_ context.Context, req *rpc.CreateRequest,
+					) (*rpc.CreateResponse, error) {
+						if !preview && req.GetPreview() {
+							assert.Fail(t, "preview should not be called when no preview")
+						}
+						id := "some-id"
+						if req.GetPreview() {
+							id = "preview-id"
+						}
+						return &rpc.CreateResponse{Id: id}, nil
+					},
+				})
+
+				require.NoError(t, s.Configure(p.ConfigureRequest{}))
+				resp, err := s.Create(p.CreateRequest{
+					Preview: true,
+				})
+				require.NoError(t, err)
+				if preview {
+					assert.Equal(t, p.CreateResponse{ID: "preview-id"}, resp)
+				}
+				resp, err = s.Create(p.CreateRequest{})
+				require.NoError(t, err)
+				assert.Equal(t, p.CreateResponse{ID: "some-id"}, resp)
+			})
+		}
+	})
+}
+
+func TestRPCInvoke(t *testing.T) {
+	t.Parallel()
+	t.Run("inputs", func(t *testing.T) {
+		t.Parallel()
+
+		args, expectedArgs := exampleNews()
+		_, err := rpcServer(rpcTestServer{
+			onInvoke: func(_ context.Context, req *rpc.InvokeRequest) (*rpc.InvokeResponse, error) {
+				assert.Equal(t, "some-token", req.GetTok())
+				assert.Equal(t, expectedArgs, req.GetArgs().AsMap())
+
+				return nil, fmt.Errorf("success")
+			},
+		}).Invoke(p.InvokeRequest{
+			Token: "some-token",
+			Args:  args,
+		})
+		assert.ErrorContains(t, err, "success")
+	})
+
+	t.Run("return", func(t *testing.T) {
+		t.Parallel()
+
+		args, expectedArgs := exampleNews()
+		resp, err := rpcServer(rpcTestServer{
+			onInvoke: func(context.Context, *rpc.InvokeRequest) (*rpc.InvokeResponse, error) {
+				return &rpc.InvokeResponse{
+					Return: must(structpb.NewStruct(expectedArgs)),
+				}, nil
+			},
+		}).Invoke(p.InvokeRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, args, resp.Return)
+	})
+
+	t.Run("failures", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := rpcServer(rpcTestServer{
+			onInvoke: func(context.Context, *rpc.InvokeRequest) (*rpc.InvokeResponse, error) {
+				return &rpc.InvokeResponse{
+					Failures: []*rpc.CheckFailure{
+						{Property: "my-prop", Reason: "some-reason"},
+						{Property: "my-other-prop", Reason: "some-other-reason"},
+					},
+				}, nil
+			},
+		}).Invoke(p.InvokeRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, p.InvokeResponse{
+			Failures: []p.CheckFailure{
+				{Property: "my-prop", Reason: "some-reason"},
+				{Property: "my-other-prop", Reason: "some-other-reason"},
+			},
+		}, resp)
+	})
+}
+
+func TestRPCCheck(t *testing.T) {
+	t.Parallel()
+	testRPCCheck(t, func(
+		f func(context.Context, *rpc.CheckRequest) (*rpc.CheckResponse, error),
+	) func(p.CheckRequest) (p.CheckResponse, error) {
+		return rpcServer(rpcTestServer{onCheck: f}).Check
+	})
+}
+
+func TestRPCDiff(t *testing.T) {
+	t.Parallel()
+	testRPCDiff(t, func(
+		f func(context.Context, *rpc.DiffRequest) (*rpc.DiffResponse, error),
+	) func(p.DiffRequest) (p.DiffResponse, error) {
+		s := rpcServer(rpcTestServer{onDiff: f})
+		return s.Diff
+	})
+}
+
+func TestRPCCreate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inputs", func(t *testing.T) {
+		t.Parallel()
+
+		args, expectedArgs := exampleNews()
+
+		resp, err := rpcServer(rpcTestServer{
+			onCreate: func(_ context.Context, req *rpc.CreateRequest) (*rpc.CreateResponse, error) {
+
+				assert.Equal(t, "some-urn", req.GetUrn())
+				assert.Equal(t, 123.0, req.GetTimeout())
+				assert.Equal(t, true, req.GetPreview())
+				assert.Equal(t, expectedArgs, req.GetProperties().AsMap())
+
+				return &rpc.CreateResponse{Id: "some-id"}, nil
+			},
+		}).Create(p.CreateRequest{
+			Urn:        "some-urn",
+			Properties: args,
+			Timeout:    123,
+			Preview:    true,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, p.CreateResponse{ID: "some-id"}, resp)
+	})
+
+	t.Run("properties", func(t *testing.T) {
+		t.Parallel()
+		props, mapProps := exampleOlds()
+
+		resp, err := rpcServer(rpcTestServer{
+			onCreate: func(context.Context, *rpc.CreateRequest) (*rpc.CreateResponse, error) {
+				return &rpc.CreateResponse{
+					Id:         "some-id",
+					Properties: must(structpb.NewStruct(mapProps)),
+				}, nil
+			},
+		}).Create(p.CreateRequest{})
+
+		require.NoError(t, err)
+		assert.Equal(t, p.CreateResponse{
+			ID:         "some-id",
+			Properties: props,
+		}, resp)
+	})
+}
+
+func TestRPCRead(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inputs", func(t *testing.T) {
+		t.Parallel()
+
+		props, expectedProps := exampleOlds()
+		inputs, expectedInputs := exampleNews()
+
+		wasCalled := false
+
+		_, err := rpcServer(rpcTestServer{
+			onRead: func(_ context.Context, req *rpc.ReadRequest) (*rpc.ReadResponse, error) {
+				assert.Equal(t, "some-id", req.GetId())
+				assert.Equal(t, "some-urn", req.GetUrn())
+				assert.Equal(t, expectedProps, req.GetProperties().AsMap())
+				assert.Equal(t, expectedInputs, req.GetInputs().AsMap())
+				wasCalled = true
+				return &rpc.ReadResponse{}, nil
+			},
+		}).Read(p.ReadRequest{
+			ID:         "some-id",
+			Urn:        "some-urn",
+			Properties: props,
+			Inputs:     inputs,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, wasCalled)
+	})
+
+	t.Run("outputs", func(t *testing.T) {
+		t.Parallel()
+
+		props, expectedProps := exampleOlds()
+		inputs, expectedInputs := exampleNews()
+
+		resp, err := rpcServer(rpcTestServer{
+			onRead: func(context.Context, *rpc.ReadRequest) (*rpc.ReadResponse, error) {
+				return &rpc.ReadResponse{
+					Id:         "some-id",
+					Properties: must(structpb.NewStruct(expectedProps)),
+					Inputs:     must(structpb.NewStruct(expectedInputs)),
+				}, nil
+			},
+		}).Read(p.ReadRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, p.ReadResponse{
+			ID:         "some-id",
+			Properties: props,
+			Inputs:     inputs,
+		}, resp)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := rpcServer(rpcTestServer{
+			onRead: func(context.Context, *rpc.ReadRequest) (*rpc.ReadResponse, error) {
+				return nil, fmt.Errorf("on-error")
+			},
+		}).Read(p.ReadRequest{})
+
+		assert.ErrorContains(t, err, "on-error")
+	})
+
+}
+
+func TestRPCUpdate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inputs", func(t *testing.T) {
+		t.Parallel()
+
+		olds, expectedOlds := exampleOlds()
+		news, expectedNews := exampleNews()
+
+		wasCalled := false
+
+		_, err := rpcServer(rpcTestServer{
+			onUpdate: func(_ context.Context, req *rpc.UpdateRequest) (*rpc.UpdateResponse, error) {
+				assert.Equal(t, "some-id", req.GetId())
+				assert.Equal(t, "some-urn", req.GetUrn())
+				assert.Equal(t, expectedOlds, req.GetOlds().AsMap())
+				assert.Equal(t, expectedNews, req.GetNews().AsMap())
+				assert.Equal(t, 1.23, req.GetTimeout())
+				assert.Equal(t, []string{"f1"}, req.GetIgnoreChanges())
+				assert.Equal(t, true, req.GetPreview())
+				wasCalled = true
+				return &rpc.UpdateResponse{}, nil
+			},
+		}).Update(p.UpdateRequest{
+			ID:            "some-id",
+			Urn:           "some-urn",
+			Olds:          olds,
+			News:          news,
+			Timeout:       1.23,
+			IgnoreChanges: []resource.PropertyKey{"f1"},
+			Preview:       true,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, wasCalled)
+	})
+
+	t.Run("outputs", func(t *testing.T) {
+		t.Parallel()
+
+		props, propsMap := exampleOlds()
+
+		resp, err := rpcServer(rpcTestServer{
+			onUpdate: func(context.Context, *rpc.UpdateRequest) (*rpc.UpdateResponse, error) {
+				return &rpc.UpdateResponse{
+					Properties: must(structpb.NewStruct(propsMap)),
+				}, nil
+			},
+		}).Update(p.UpdateRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, p.UpdateResponse{
+			Properties: props,
+		}, resp)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := rpcServer(rpcTestServer{
+			onUpdate: func(context.Context, *rpc.UpdateRequest) (*rpc.UpdateResponse, error) {
+				return nil, fmt.Errorf("on-error")
+			},
+		}).Update(p.UpdateRequest{})
+
+		assert.ErrorContains(t, err, "on-error")
+	})
+}
+
+func TestRPCDelete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no-error", func(t *testing.T) {
+		t.Parallel()
+		props, expectedProps := exampleOlds()
+		wasCalled := false
+
+		err := rpcServer(rpcTestServer{
+			onDelete: func(_ context.Context, req *rpc.DeleteRequest) (*emptypb.Empty, error) {
+				assert.Equal(t, "my-id", req.GetId())
+				assert.Equal(t, "my-urn", req.GetUrn())
+				assert.Equal(t, expectedProps, req.GetProperties().AsMap())
+				assert.Equal(t, 7.3, req.GetTimeout())
+				wasCalled = true
+				return &emptypb.Empty{}, nil
+			},
+		}).Delete(p.DeleteRequest{
+			ID:         "my-id",
+			Urn:        "my-urn",
+			Properties: props,
+			Timeout:    7.3,
+		})
+
+		assert.NoError(t, err)
+		assert.True(t, wasCalled)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+		err := rpcServer(rpcTestServer{
+			onDelete: func(_ context.Context, req *rpc.DeleteRequest) (*emptypb.Empty, error) {
+				return &emptypb.Empty{}, fmt.Errorf("my-error")
+			},
+		}).Delete(p.DeleteRequest{})
+
+		assert.ErrorContains(t, err, "my-error")
+	})
+}
+
+// TestRPCConstruct shows that Construct returns unimplemented in all cases.
+//
+// TODO[pulumi/pulumi-go-provider#219] to support construct calls.
+func TestRPCConstruct(t *testing.T) {
+	_, err := rpcServer(rpcTestServer{}).
+		Construct(p.ConstructRequest{})
+	assert.ErrorContains(t, err, "rpc error: code = Unimplemented desc = Construct is not implemented")
+}
+
+func must[T any](t T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func exampleOlds() (resource.PropertyMap, map[string]any) {
+	return resource.PropertyMap{
+			"f1": resource.NewProperty("s1"),
+			"f2": resource.NewProperty(1.0),
+			"f3": resource.NewProperty(resource.PropertyMap{
+				"n1": resource.NewProperty("nv1"),
+				"n2": resource.NewProperty(true),
+			}),
+		}, map[string]any{
+			"f1": "s1",
+			"f2": 1.0,
+			"f3": map[string]any{
+				"n1": "nv1",
+				"n2": true,
+			},
+		}
+}
+
+func exampleNews() (resource.PropertyMap, map[string]any) {
+	return resource.PropertyMap{
+			"f1": resource.NewProperty("s1"),
+			"f3": resource.NewProperty(resource.PropertyMap{
+				"n1": resource.NewProperty("nv1"),
+				"n2": resource.NewProperty(true),
+			}),
+			"f4": resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty(2.0),
+				resource.NewProperty("e1"),
+			}),
+		}, map[string]any{
+			"f1": "s1",
+			"f3": map[string]any{
+				"n1": "nv1",
+				"n2": true,
+			},
+			"f4": []any{
+				2.0,
+				"e1",
+			},
+		}
+}
+
+// testRPCCheck tests a check function against a series of inputs.
+func testRPCCheck(
+	t *testing.T,
+	setup func(
+		func(context.Context, *rpc.CheckRequest) (*rpc.CheckResponse, error),
+	) func(p.CheckRequest) (p.CheckResponse, error),
+) {
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+		olds, expectedOlds := exampleOlds()
+		news, expectedNews := exampleNews()
+		resp, err := setup(func(_ context.Context, req *rpc.CheckRequest) (*rpc.CheckResponse, error) {
+			assert.Equal(t, "some-urn", req.GetUrn())
+			assert.Equal(t, []byte("12345"), req.GetRandomSeed())
+			assert.Equal(t, expectedOlds, req.GetOlds().AsMap())
+			assert.Equal(t, expectedNews, req.GetNews().AsMap())
+			return &rpc.CheckResponse{
+				Inputs: must(structpb.NewStruct(map[string]any{
+					"r1": []any{
+						"e1",
+						"e2",
+					},
+					"r2": false,
+				})),
+			}, nil
+		})(p.CheckRequest{
+			Urn:        "some-urn",
+			Olds:       olds,
+			News:       news,
+			RandomSeed: []byte("12345"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, p.CheckResponse{
+			Inputs: resource.PropertyMap{
+				"r1": resource.NewProperty([]resource.PropertyValue{
+					resource.NewProperty("e1"),
+					resource.NewProperty("e2"),
+				}),
+				"r2": resource.NewProperty(false),
+			},
+		}, resp)
+	})
+	t.Run("failures", func(t *testing.T) {
+		t.Parallel()
+		resp, err := setup(func(context.Context, *rpc.CheckRequest) (*rpc.CheckResponse, error) {
+			return &rpc.CheckResponse{
+				Failures: []*rpc.CheckFailure{
+					{Property: "some-prop", Reason: "some-reason"},
+					{Property: "another", Reason: "second"},
+					{Property: "empty"}, {Reason: "empty"},
+				},
+			}, nil
+		})(p.CheckRequest{
+			Urn: "some-urn",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, p.CheckResponse{
+			Failures: []p.CheckFailure{
+				{Property: "some-prop", Reason: "some-reason"},
+				{Property: "another", Reason: "second"},
+				{Property: "empty"}, {Reason: "empty"},
+			},
+		}, resp)
+	})
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+		_, err := setup(func(context.Context, *rpc.CheckRequest) (*rpc.CheckResponse, error) {
+			return nil, fmt.Errorf("check didn't work")
+		})(p.CheckRequest{
+			Urn: "some-urn",
+		})
+		assert.ErrorContains(t, err, "check didn't work")
+	})
+}
+
+// testRPCDiff tests a check function against a series of inputs.
+func testRPCDiff(
+	t *testing.T,
+	setup func(
+		func(context.Context, *rpc.DiffRequest) (*rpc.DiffResponse, error),
+	) func(p.DiffRequest) (p.DiffResponse, error),
+) {
+	t.Run("translate-inputs", func(t *testing.T) {
+		t.Parallel()
+
+		olds, expectedOlds := exampleOlds()
+		news, expectedNews := exampleNews()
+
+		resp, err := setup(func(_ context.Context, req *rpc.DiffRequest) (*rpc.DiffResponse, error) {
+			assert.Equal(t, "some-id", req.GetId())
+			assert.Equal(t, "my-urn", req.GetUrn())
+			assert.Equal(t, expectedOlds, req.GetOlds().AsMap())
+			assert.Equal(t, expectedNews, req.GetNews().AsMap())
+			assert.Equal(t, []string{"field1", "field2"}, req.GetIgnoreChanges())
+
+			return &rpc.DiffResponse{DeleteBeforeReplace: true}, nil
+		})(p.DiffRequest{
+			ID:            "some-id",
+			Urn:           "my-urn",
+			Olds:          olds,
+			News:          news,
+			IgnoreChanges: []resource.PropertyKey{"field1", "field2"},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, p.DiffResponse{
+			DeleteBeforeReplace: true,
+		}, resp)
+	})
+
+	t.Run("detailed-diff", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := setup(func(context.Context, *rpc.DiffRequest) (*rpc.DiffResponse, error) {
+			return &rpc.DiffResponse{
+				HasDetailedDiff: true,
+				Changes:         rpc.DiffResponse_DIFF_SOME,
+				DetailedDiff: map[string]*rpc.PropertyDiff{
+					"add":            {Kind: rpc.PropertyDiff_ADD, InputDiff: true},
+					"add_replace":    {Kind: rpc.PropertyDiff_ADD_REPLACE},
+					"delete":         {Kind: rpc.PropertyDiff_DELETE},
+					"delete_replace": {Kind: rpc.PropertyDiff_DELETE_REPLACE},
+					"update":         {Kind: rpc.PropertyDiff_UPDATE},
+					"update_replace": {Kind: rpc.PropertyDiff_UPDATE_REPLACE},
+					"nested.field":   {Kind: rpc.PropertyDiff_UPDATE, InputDiff: true},
+				},
+			}, nil
+		})(p.DiffRequest{})
+
+		require.NoError(t, err)
+		assert.Equal(t, p.DiffResponse{
+			HasChanges: true,
+			DetailedDiff: map[string]p.PropertyDiff{
+				"add":            {Kind: p.Add, InputDiff: true},
+				"add_replace":    {Kind: p.AddReplace},
+				"delete":         {Kind: p.Delete},
+				"delete_replace": {Kind: p.DeleteReplace},
+				"update":         {Kind: p.Update},
+				"update_replace": {Kind: p.UpdateReplace},
+				"nested.field":   {Kind: p.Update, InputDiff: true},
+			},
+		}, resp)
+	})
+
+	t.Run("no-diff", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := setup(func(context.Context, *rpc.DiffRequest) (*rpc.DiffResponse, error) {
+			return &rpc.DiffResponse{
+				Stables: []string{"f1", "f2"},
+				Changes: rpc.DiffResponse_DIFF_NONE,
+			}, nil
+		})(p.DiffRequest{})
+
+		require.NoError(t, err)
+		assert.Equal(t, p.DiffResponse{
+			HasChanges: false,
+		}, resp)
+
+	})
+	t.Run("simple-diff", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := setup(func(context.Context, *rpc.DiffRequest) (*rpc.DiffResponse, error) {
+			return &rpc.DiffResponse{
+				Replaces:        []string{"r1", "r2"},
+				Stables:         []string{"f1", "f2"},
+				Changes:         rpc.DiffResponse_DIFF_SOME,
+				Diffs:           []string{"r1", "r2", "f3"},
+				HasDetailedDiff: false,
+			}, nil
+		})(p.DiffRequest{})
+
+		require.NoError(t, err)
+		assert.Equal(t, p.DiffResponse{
+			HasChanges: true,
+			DetailedDiff: map[string]p.PropertyDiff{
+				"r1": {Kind: p.UpdateReplace},
+				"r2": {Kind: p.UpdateReplace},
+				"f3": {Kind: p.Update},
+			},
+		}, resp)
+	})
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := setup(func(context.Context, *rpc.DiffRequest) (*rpc.DiffResponse, error) {
+			return nil, fmt.Errorf("the diff went wrong")
+		})(p.DiffRequest{})
+
+		assert.ErrorContains(t, err, "the diff went wrong")
+	})
+}
+
+type rpcTestServer struct {
+	rpc.UnimplementedResourceProviderServer
+	onGetSchema   func(context.Context, *rpc.GetSchemaRequest) (*rpc.GetSchemaResponse, error)
+	onCancel      func(context.Context, *emptypb.Empty) (*emptypb.Empty, error)
+	onCheckConfig func(context.Context, *rpc.CheckRequest) (*rpc.CheckResponse, error)
+	onCheck       func(context.Context, *rpc.CheckRequest) (*rpc.CheckResponse, error)
+	onDiffConfig  func(context.Context, *rpc.DiffRequest) (*rpc.DiffResponse, error)
+	onDiff        func(context.Context, *rpc.DiffRequest) (*rpc.DiffResponse, error)
+	onConfigure   func(context.Context, *rpc.ConfigureRequest) (*rpc.ConfigureResponse, error)
+	onCreate      func(context.Context, *rpc.CreateRequest) (*rpc.CreateResponse, error)
+	onInvoke      func(context.Context, *rpc.InvokeRequest) (*rpc.InvokeResponse, error)
+	onDelete      func(context.Context, *rpc.DeleteRequest) (*emptypb.Empty, error)
+	onRead        func(context.Context, *rpc.ReadRequest) (*rpc.ReadResponse, error)
+	onUpdate      func(context.Context, *rpc.UpdateRequest) (*rpc.UpdateResponse, error)
+}
+
+func (r rpcTestServer) GetSchema(ctx context.Context, req *rpc.GetSchemaRequest) (*rpc.GetSchemaResponse, error) {
+	return r.onGetSchema(ctx, req)
+}
+
+func (r rpcTestServer) Cancel(ctx context.Context, e *emptypb.Empty) (*emptypb.Empty, error) {
+	return r.onCancel(ctx, e)
+}
+
+func (r rpcTestServer) CheckConfig(ctx context.Context, req *rpc.CheckRequest) (*rpc.CheckResponse, error) {
+	return r.onCheckConfig(ctx, req)
+}
+
+func (r rpcTestServer) Check(ctx context.Context, req *rpc.CheckRequest) (*rpc.CheckResponse, error) {
+	return r.onCheck(ctx, req)
+}
+
+func (r rpcTestServer) DiffConfig(ctx context.Context, req *rpc.DiffRequest) (*rpc.DiffResponse, error) {
+	return r.onDiffConfig(ctx, req)
+}
+
+func (r rpcTestServer) Diff(ctx context.Context, req *rpc.DiffRequest) (*rpc.DiffResponse, error) {
+	return r.onDiff(ctx, req)
+}
+
+func (r rpcTestServer) Configure(ctx context.Context, req *rpc.ConfigureRequest) (*rpc.ConfigureResponse, error) {
+	return r.onConfigure(ctx, req)
+}
+
+func (r rpcTestServer) Create(ctx context.Context, req *rpc.CreateRequest) (*rpc.CreateResponse, error) {
+	return r.onCreate(ctx, req)
+}
+
+func (r rpcTestServer) Invoke(ctx context.Context, req *rpc.InvokeRequest) (*rpc.InvokeResponse, error) {
+	return r.onInvoke(ctx, req)
+}
+
+func (r rpcTestServer) Delete(ctx context.Context, req *rpc.DeleteRequest) (*emptypb.Empty, error) {
+	return r.onDelete(ctx, req)
+}
+
+func (r rpcTestServer) Read(ctx context.Context, req *rpc.ReadRequest) (*rpc.ReadResponse, error) {
+	return r.onRead(ctx, req)
+}
+func (r rpcTestServer) Update(ctx context.Context, req *rpc.UpdateRequest) (*rpc.UpdateResponse, error) {
+	return r.onUpdate(ctx, req)
+}
+
+func rpcServer(server rpcTestServer) integration.Server {
+	return integration.NewServer("test",
+		semver.Version{Major: 1},
+		wraprpc.Provider(server))
+}


### PR DESCRIPTION
`rpc.Provider` provides a thunking layer to allow a pulumi-go-provider based provider to wrap a `pulumirpc.ResourceProviderServer`. This will allow piece-wise transfer of native providers to the pulumi-go-provider framework.

Unlike the pulumi-terraform-bridge's
[muxer](https://github.com/pulumi/pulumi-terraform-bridge/tree/master/x/muxer), `rpc.Provider` does not split at the RPC level directly. Instead it converts the shim layer provided by https://github.com/pulumi/pulumi-go-provider back into "github.com/pulumi/pulumi/sdk/v3/proto/go". This makes wrapped rpc providers able to interact with `integration` based tests and to benefit from intercepting middleware (like `cancel` and `schema`).

Fixes https://github.com/pulumi/pulumi-go-provider/issues/216