### PR TITLE
[infer] Delegate Configure to the wrapped provider

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -1,0 +1,73 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi-go-provider/integration"
+	"github.com/pulumi/pulumi-go-provider/middleware/context"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+type testConfig struct {
+	Field *string `pulumi:"field,optional"`
+}
+
+type ctxKey struct{}
+
+func (c *testConfig) Configure(ctx p.Context) error {
+	if *c.Field != "foo" {
+		panic("Unexpected field value")
+	}
+	*ctx.Value(ctxKey{}).(*bool) = true
+	return nil
+}
+
+func TestInferConfigWrap(t *testing.T) {
+	t.Parallel()
+	var baseConfigureWasCalled bool
+	var inferConfigureWasCalled bool
+
+	err := integration.NewServer("test", semver.MustParse("1.2.3"),
+		// Use context.Wrap to inject a reference to inferConfigureWasCalled into
+		// the context.
+		context.Wrap(
+			infer.Wrap(p.Provider{
+				Configure: func(ctx p.Context, req p.ConfigureRequest) error {
+					assert.Equal(t, "foo", req.Args["field"].StringValue())
+					baseConfigureWasCalled = true
+					return nil
+				},
+			}, infer.Options{
+				Config: infer.Config[*testConfig](),
+			}),
+			func(ctx p.Context) p.Context {
+				return p.CtxWithValue(ctx, ctxKey{}, &inferConfigureWasCalled)
+			}),
+	).Configure(p.ConfigureRequest{
+		Args: resource.PropertyMap{"field": resource.NewProperty("foo")},
+	})
+	require.NoError(t, err)
+
+	assert.True(t, baseConfigureWasCalled)
+	assert.True(t, inferConfigureWasCalled)
+}


### PR DESCRIPTION
Fixes #221

Delegate `Configure` calls to an underlying provider if any. Right now, this PR only delegates `Configure` calls, not `DiffConfig` or `CheckConfig`.