### PR TITLE
Allow Context to handle nil methods

### DIFF
--- a/tests/context_test.go
+++ b/tests/context_test.go
@@ -1,0 +1,60 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/integration"
+	"github.com/pulumi/pulumi-go-provider/middleware/context"
+)
+
+// Regression test for https://github.com/pulumi/pulumi-go-provider/issues/224
+func TestContextCancel(t *testing.T) {
+	t.Run("no-cancel", func(t *testing.T) {
+		s := integration.NewServer("test", semver.Version{Major: 1},
+			context.Wrap(p.Provider{}, func(ctx p.Context) p.Context {
+				assert.Fail(t, "Cancel was not implemented, so the wrapper should not be called")
+				return ctx
+			}),
+		)
+
+		err := s.Cancel()
+		assert.ErrorContains(t, err, "rpc error: code = Unimplemented desc = Cancel is not implemented")
+	})
+
+	t.Run("cancel-called", func(t *testing.T) {
+		var wasCalled bool
+		type key struct{}
+		s := integration.NewServer("test", semver.Version{Major: 1},
+			context.Wrap(p.Provider{
+				Cancel: func(ctx p.Context) error {
+					assert.True(t, ctx.Value(key{}).(bool))
+					wasCalled = true
+					return nil
+				},
+			}, func(ctx p.Context) p.Context {
+				return p.CtxWithValue(ctx, key{}, true)
+			}),
+		)
+
+		assert.NoError(t, s.Cancel())
+		assert.True(t, wasCalled)
+	})
+}


### PR DESCRIPTION
Fixes #224 

The problem (as demonstrated by the stack trace in #224) was that `middleware/context.Wrap` delegates blindly to the relevant inner method, even if it doesn't exist. We are simply missing a `nil` check in `context`.