### PR TITLE
README and naming fixes

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,8 +5,8 @@ Each example folder contains:
 1. A complete and functional package, buildable with `go build ./...`.
 2. A `consumer/Pulumi.yaml` which will exercise the provider.
 
-You can build the provider and then run the `consumer/Pulumi.yaml` example against it with the folling 1-liner:
+You can build the provider and then run the `consumer/Pulumi.yaml` example against it with the following 1-liner:
 
 ```sh
-go build github.com/pulumi/pulumi-go-provider/examples/$(basename $PWD) && pulumi plugin install resource $(basename $PWD) v0.1.0 -f $(basename $PWD) --reinstall && (cd consumer && pulumi up)
+name=$(basename $PWD) && go build -o "pulumi-resource-$name" github.com/pulumi/pulumi-go-provider/examples/$name && pulumi plugin install resource $name v0.1.0 -f "pulumi-resource-$name" --reinstall && (cd consumer && pulumi up)
 ```

--- a/examples/file/consumer/Pulumi.yaml
+++ b/examples/file/consumer/Pulumi.yaml
@@ -1,4 +1,4 @@
-name: consume-random-login
+name: consume-file
 runtime: yaml
 
 plugins:


### PR DESCRIPTION
When I tried it just now, the instructions in examples/README only worked when the locally built plugin was named `pulumi-resource-$example`, else I'd get 

```
  pulumi:pulumi:Stack (consume-file-dev):
    Error: error resolving type of resource managedFile: internal error loading package "file": stat /Users/tkappler/pulumi/pulumi-go-provider/examples/file/pulumi-resource-file: no such file or directory
      on Pulumi.yaml line 11:
      11:     type: file:File
```