### PR TITLE
Fix linter deprecation warnings and enhance coverage

### DIFF
--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   lint:
-    container: golangci/golangci-lint:v1.54.2
+    container: golangci/golangci-lint:v1.59
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,13 +1,14 @@
 run:
   timeout: 10m
+issues:
   # Enable checking the by default skipped "examples" dirs
-  skip-dirs:
+  exclude-dirs-use-default: false
+  exclude-dirs:
     - vendor$
     - third_party$
     - testdata$
     - Godeps$
     - builtin$
-  skip-dirs-use-default: false
 linters:
   enable-all: false
   enable:
@@ -27,4 +28,3 @@ linters:
     - unused
   disable:
     - staticcheck # Disabled due to OOM errors in golangci-lint@v1.18.0
-    - megacheck # Disabled due to OOM errors in golangci-lint@v1.18.0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,7 +25,7 @@ linters:
     - nakedret
     - unconvert
     - paralleltest
+    - staticcheck
     - stylecheck
     - unused
   disable:
-    - staticcheck # Disabled due to OOM errors in golangci-lint@v1.18.0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,6 +17,7 @@ linters:
     - gofmt
     - revive
     - gosec
+    - gosimple
     - govet
     - ineffassign
     - lll

--- a/infer/provider.go
+++ b/infer/provider.go
@@ -80,19 +80,19 @@ func (o Options) dispatch() dispatch.Options {
 	functions := map[tokens.Type]t.Invoke{}
 	for _, r := range o.Functions {
 		typ, err := r.GetToken()
-		contract.AssertNoError(err)
+		contract.AssertNoErrorf(err, "failed to get token for function %v", r)
 		functions[typ] = r
 	}
 	customs := map[tokens.Type]t.CustomResource{}
 	for _, r := range o.Resources {
 		typ, err := r.GetToken()
-		contract.AssertNoError(err)
+		contract.AssertNoErrorf(err, "failed to get token for resource %v", r)
 		customs[typ] = r
 	}
 	components := map[tokens.Type]t.ComponentResource{}
 	for _, r := range o.Components {
 		typ, err := r.GetToken()
-		contract.AssertNoError(err)
+		contract.AssertNoErrorf(err, "failed to get token for component %v", r)
 		components[typ] = r
 	}
 	return dispatch.Options{

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -705,9 +705,7 @@ func (i *inputField) Computed() InputField {
 	input.kind = inputComputed
 	// Copy input fields
 	input.fields = make([]introspect.FieldTag, len(i.fields))
-	for i, f := range i.fields {
-		input.fields[i] = f
-	}
+	copy(input.fields, i.fields)
 	return input
 }
 
@@ -716,9 +714,7 @@ func (i *inputField) Secret() InputField {
 	input.kind = inputSecret
 	// Copy input fields
 	input.fields = make([]introspect.FieldTag, len(i.fields))
-	for i, f := range i.fields {
-		input.fields[i] = f
-	}
+	copy(input.fields, i.fields)
 	return input
 }
 

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -646,11 +646,11 @@ func (g *fieldGenerator) ensureDefaultSecrets() {
 
 	args, ok, err := g.argsMatcher.TargetStructFields(g.args)
 	contract.Assertf(ok, "we match by construction")
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "TargetStructFields on %v", g.args)
 
 	state, ok, err := g.stateMatcher.TargetStructFields(g.state)
 	contract.Assertf(ok, "we match by construction")
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "TargetStructFields on %v", g.state)
 
 	for _, f := range state {
 		if f.Internal {

--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -323,10 +323,14 @@ func (ctx testContext) RuntimeInformation() p.RunInfo {
 	return p.RunInfo{}
 }
 
+type contextKey string
+
+var migrationsKey = contextKey("migrations")
+
 type CustomHydrateFromState[O any] struct{}
 
 func (CustomHydrateFromState[O]) StateMigrations(ctx context.Context) []StateMigrationFunc[O] {
-	return ctx.Value("migrations").([]StateMigrationFunc[O])
+	return ctx.Value(migrationsKey).([]StateMigrationFunc[O])
 }
 
 func testHydrateFromState[O any](
@@ -338,7 +342,7 @@ func testHydrateFromState[O any](
 
 		ctx := testContext{
 			//nolint:revive
-			Context: context.WithValue(context.Background(), "migrations", migrations),
+			Context: context.WithValue(context.Background(), migrationsKey, migrations),
 		}
 
 		enc, actual, err := hydrateFromState[CustomHydrateFromState[O], struct{}, O](ctx, oldState)

--- a/infer/types_test.go
+++ b/infer/types_test.go
@@ -259,10 +259,6 @@ func TestInvalidOptionalProperty(t *testing.T) {
 	type invalidContainsOptionalEnum struct {
 		Foo MyEnum `pulumi:"name,optional"`
 	}
-	type validContainsEnum struct {
-		Foo MyEnum `pulumi:"name"`
-	}
-
 	type testInner struct {
 		Foo string `pulumi:"foo"`
 	}

--- a/middleware/schema/schema.go
+++ b/middleware/schema/schema.go
@@ -92,11 +92,6 @@ type state struct {
 	innerGetSchema func(ctx context.Context, req p.GetSchemaRequest) (p.GetSchemaResponse, error)
 }
 
-func (s *state) invalidateCache() {
-	s.schema = nil
-	s.combinedSchema = nil
-}
-
 type Options struct {
 	Metadata
 	// Resources from which to derive the schema

--- a/provider.go
+++ b/provider.go
@@ -482,9 +482,8 @@ func GetSchema(ctx context.Context, name, version string, provider Provider) (sc
 	if err != nil {
 		errs.Errors = append(errs.Errors, err)
 	}
-	for _, err := range collectingDiag.errs.Errors {
-		errs.Errors = append(errs.Errors, err)
-	}
+	errs.Errors = append(errs.Errors, collectingDiag.errs.Errors...)
+
 	spec := schema.PackageSpec{}
 	if err := errs.ErrorOrNil(); err != nil {
 		return spec, err


### PR DESCRIPTION
Fix some linter deprecation warnings and add the gosimple linter. Can be reviewed commit by commit.

- **Silence golangci-lint warnings**

> WARN [config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`. 
> WARN [config_reader] The configuration option `run.skip-dirs-use-default` is deprecated, please use `issues.exclude-dirs-use-default`. 
> WARN [lintersdb] The linter named "megacheck" is deprecated. It has been split into: gosimple, staticcheck, unused. 

- **Add gosimple linter. Enabled linters now add up to the previous megacheck.**
- **Fix gosimple warnings in the code base**
