### PR TITLE
Descriptive types for `infer.Annotator.AddAlias`

### DIFF
--- a/infer/resource.go
+++ b/infer/resource.go
@@ -279,16 +279,14 @@ type Annotator interface {
 	//
 	//	mypkg:mymodule:MyResource
 	//
-	SetToken(module, name string)
+	SetToken(module tokens.ModuleName, name tokens.TypeName)
 
-	// Add an [alias](https://www.pulumi.com/docs/using-pulumi/pulumi-packages/schema/#alias) for
+	// Add a type [alias](https://www.pulumi.com/docs/using-pulumi/pulumi-packages/schema/#alias) for
 	// this resource.
-	// The given module and name need to be valid
-	// [QNames](https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/common/tokens#QName)
-	// as defined by the Pulumi SDK.
-	// The module and the name will be assembled into a type specifier of the form `pkg:module:name`,
-	// in the same way `SetToken` does.
-	AddAlias(module, name string)
+	//
+	// The module and the name will be assembled into a type specifier of the form
+	// `mypkg:mymodule:MyResource`, in the same way `SetToken` does.
+	AddAlias(module tokens.ModuleName, name tokens.TypeName)
 
 	// Set a deprecation message for the resource, which officially marks it as deprecated.
 	SetResourceDeprecationMessage(message string)

--- a/internal/introspect/annotator.go
+++ b/internal/introspect/annotator.go
@@ -89,11 +89,11 @@ func (a *Annotator) SetDefault(i any, defaultValue any, env ...string) {
 	a.DefaultEnvs[field.Name] = append(a.DefaultEnvs[field.Name], env...)
 }
 
-func (a *Annotator) SetToken(module, token string) {
+func (a *Annotator) SetToken(module tokens.ModuleName, token tokens.TypeName) {
 	a.Token = formatToken(module, token)
 }
 
-func (a *Annotator) AddAlias(module, token string) {
+func (a *Annotator) AddAlias(module tokens.ModuleName, token tokens.TypeName) {
 	a.Aliases = append(a.Aliases, formatToken(module, token))
 }
 
@@ -101,14 +101,15 @@ func (a *Annotator) SetResourceDeprecationMessage(message string) {
 	a.DeprecationMessage = message
 }
 
-// Formates module and token into a valid token string.
+// formatToken formats a (module, token) pair into a valid token string.
+//
 // Panics when module or token are invalid.
-func formatToken(module, token string) string {
-	if !tokens.IsQName(module) {
+func formatToken(module tokens.ModuleName, token tokens.TypeName) string {
+	if !tokens.IsQName(module.String()) {
 		panic(fmt.Sprintf("Module (%q) must comply with %s, but does not", module, tokens.QNameRegexp))
 	}
-	if !tokens.IsName(token) {
+	if !tokens.IsName(token.String()) {
 		panic(fmt.Sprintf("Token (%q) must comply with %s, but does not", token, tokens.NameRegexp))
 	}
-	return fmt.Sprintf("pkg:%s:%s", module, token)
+	return tokens.NewTypeToken(tokens.NewModuleToken("pkg", module), token).String()
 }

--- a/internal/introspect/introspect_test.go
+++ b/internal/introspect/introspect_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+
 	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi-go-provider/internal/introspect"
 )
@@ -120,8 +122,9 @@ func TestSetTokenValidation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		module, name string
-		fail         bool
+		module tokens.ModuleName
+		name   tokens.TypeName
+		fail   bool
 	}{
 		{name: "foo"},
 		{name: "FOO"},
@@ -155,7 +158,7 @@ func TestSetTokenValidation(t *testing.T) {
 				assert.Panics(t, func() { f() })
 			} else {
 				a := f()
-				assert.Equal(t, a.Token, "pkg:"+tt.module+":"+tt.name)
+				assert.Equal(t, a.Token, "pkg:"+string(tt.module)+":"+string(tt.name))
 			}
 		})
 	}


### PR DESCRIPTION
Following up on #245, we specify the boundary requirements of `AddAlias` and `SetToken` with the types that they accept. This is a breaking change unless you are using untyped constants in `SetToken` and `AddAlias`, which I expected to be the common case.