### PR TITLE
Inject secrets from `provider:"secret"` tags

### DIFF
--- a/infer/apply_defaults.go
+++ b/infer/apply_defaults.go
@@ -278,7 +278,6 @@ func applyDefaults[T any](value *T) error {
 	contract.Assertf(v.CanSet(), "Cannot accept an un-editable pointer")
 
 	var walker defaultsWalker
-
 	_, err := walker.walk(v)
 	return err
 }

--- a/infer/apply_secrets.go
+++ b/infer/apply_secrets.go
@@ -1,0 +1,107 @@
+// Copyright 2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infer
+
+import (
+	"reflect"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi-go-provider/infer/internal/ende"
+	"github.com/pulumi/pulumi-go-provider/internal/introspect"
+)
+
+// The object that controls default application.
+type secretsWalker struct{ errs []error }
+
+func (w *secretsWalker) walk(t reflect.Type, p resource.PropertyValue) (out resource.PropertyValue) {
+	// If v is untyped, we have no information, so return.
+	if t == nil {
+		return p
+	}
+
+	// Ensure we are working in raw value types for p
+
+	if ende.IsSecret(p) {
+		p = ende.MakePublic(p)
+		defer func() { out = ende.MakeSecret(p) }()
+	}
+
+	if ende.IsComputed(p) {
+		p = ende.MakeKnown(p)
+		defer func() { out = ende.MakeComputed(p) }()
+	}
+
+	// Ensure we are working in raw value types for t
+
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	switch t.Kind() {
+	// Structs can carry secret information, so this is where we add secrets.
+	case reflect.Struct:
+		if !p.IsObject() {
+			return p // p and t mismatch, so return early
+		}
+		obj := p.ObjectValue()
+
+		for _, field := range reflect.VisibleFields(t) {
+			info, err := introspect.ParseTag(field)
+			if err != nil {
+				w.errs = append(w.errs, err)
+				continue
+			}
+
+			v, ok := obj[resource.PropertyKey(info.Name)]
+			if !ok {
+				continue
+			}
+			field, ok := t.FieldByName(field.Name)
+			contract.Assertf(ok,
+				"fieldName must exist in t because introspect.FindProperties only returns fields in t")
+			v = w.walk(field.Type, v)
+			if info.Secret {
+				v = ende.MakeSecret(v)
+			}
+			obj[resource.PropertyKey(info.Name)] = v
+		}
+		return resource.NewProperty(obj)
+	// Collection types
+	case reflect.Slice, reflect.Array:
+		if !p.IsArray() {
+			return p // p and t mismatch, so return early
+		}
+		arr := p.ArrayValue()
+		for i, v := range arr {
+			arr[i] = w.walk(t.Elem(), v)
+		}
+		return resource.NewProperty(arr)
+	case reflect.Map:
+		if !p.IsObject() {
+			return p // p and t mismatch, so return early
+		}
+		m := p.ObjectValue()
+		for k, v := range m {
+			m[k] = w.walk(t.Elem(), v)
+		}
+		return resource.NewProperty(m)
+	// Primitive types
+	default:
+		return p
+	}
+
+}

--- a/infer/apply_secrets.go
+++ b/infer/apply_secrets.go
@@ -27,7 +27,7 @@ import (
 
 func applySecrets[I any](inputs resource.PropertyMap) resource.PropertyMap {
 	var walker secretsWalker
-	result := walker.walk(reflect.TypeFor[I](), resource.NewProperty(inputs))
+	result := walker.walk(typeFor[I](), resource.NewProperty(inputs))
 	contract.AssertNoErrorf(errors.Join(walker.errs...),
 		`secretsWalker only produces errors when the type it walks has invalid property tags
 I can't have invalid property tags because we have gotten to runtime, and it would have failed at

--- a/infer/apply_secrets_test.go
+++ b/infer/apply_secrets_test.go
@@ -1,0 +1,213 @@
+// Copyright 2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infer
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplySecrets(t *testing.T) {
+	t.Parallel()
+
+	type nested struct {
+		F1 string `pulumi:"f1"`
+	}
+
+	tests := []struct {
+		name            string
+		input, expected resource.PropertyMap
+		typ             reflect.Type
+	}{
+		{
+			name: "no-secrets",
+			typ: typeFor[struct {
+				F1 string            `pulumi:"f1"`
+				F2 map[string]string `pulumi:"f2"`
+				F3 map[string]nested `pulumi:"F3"`
+				F4 []string          `pulumi:"F4"`
+				F5 []nested          `pulumi:"F5"`
+			}](),
+			input: resource.NewPropertyMapFromMap(map[string]any{
+				"f1": "v1",
+				"f2": map[string]any{
+					"n1": "v2",
+				},
+				"f3": map[string]any{
+					"k1": map[string]any{"f1": "v3"},
+				},
+				"f4": []any{
+					"v4",
+					"v5",
+				},
+				"f5": []any{
+					map[string]any{
+						"k1": map[string]any{
+							"f1": "v3",
+						},
+					},
+				},
+			}),
+			expected: resource.PropertyMap{
+				"f1": resource.NewProperty("v1"),
+				"f2": resource.NewProperty(resource.PropertyMap{
+					"n1": resource.NewProperty("v2"),
+				}),
+				"f3": resource.NewProperty(resource.PropertyMap{
+					"k1": resource.NewProperty(resource.PropertyMap{
+						"f1": resource.NewProperty("v3"),
+					}),
+				}),
+				"f4": resource.NewProperty([]resource.PropertyValue{
+					resource.NewProperty("v4"),
+					resource.NewProperty("v5"),
+				}),
+				"f5": resource.NewProperty([]resource.PropertyValue{
+					resource.NewProperty(resource.PropertyMap{
+						"k1": resource.NewProperty(resource.PropertyMap{
+							"f1": resource.NewProperty("v3"),
+						}),
+					}),
+				}),
+			},
+		},
+		{
+			name: "nested-secrets",
+			typ: typeFor[struct {
+				F1 struct {
+					F1 string `pulumi:"f1" provider:"secret"`
+				} `pulumi:"f1"`
+				F2 []struct {
+					F1 string `pulumi:"f1" provider:"secret"`
+				} `pulumi:"f2"`
+				F3 map[string]struct {
+					F1 string `pulumi:"f1" provider:"secret"`
+				} `pulumi:"f3"`
+				F4 struct {
+					F1 struct {
+						F1 string `pulumi:"f1" provider:"secret"`
+					} `pulumi:"f1"`
+				} `pulumi:"f4"`
+			}](),
+			input: resource.NewPropertyMapFromMap(map[string]any{
+				"f1": map[string]any{
+					"f1": "secret1",
+				},
+				"f2": []any{
+					map[string]any{
+						"f1": "secret2",
+					},
+				},
+				"f3": map[string]any{
+					"key1": map[string]any{
+						"f1": "secret3",
+					},
+				},
+				"f4": map[string]any{
+					"f1": map[string]any{
+						"f1": "secret4",
+					},
+				},
+			}),
+			expected: resource.PropertyMap{
+				"f1": resource.NewProperty(resource.PropertyMap{
+					"f1": resource.MakeSecret(resource.NewProperty("secret1")),
+				}),
+				"f2": resource.NewProperty([]resource.PropertyValue{
+					resource.NewProperty(resource.PropertyMap{
+						"f1": resource.MakeSecret(resource.NewProperty("secret2")),
+					}),
+				}),
+				"f3": resource.NewProperty(resource.PropertyMap{
+					"key1": resource.NewProperty(resource.PropertyMap{
+						"f1": resource.MakeSecret(resource.NewProperty("secret3")),
+					}),
+				}),
+				"f4": resource.NewProperty(resource.PropertyMap{
+					"f1": resource.NewProperty(resource.PropertyMap{
+						"f1": resource.MakeSecret(resource.NewProperty("secret4")),
+					}),
+				}),
+			},
+		},
+		{
+			name: "already-secret",
+			typ: typeFor[struct {
+				F1 string `pulumi:"f1" provider:"secret"`
+				F2 string `pulumi:"f2"`
+			}](),
+			input: resource.PropertyMap{
+				"f1": resource.MakeSecret(resource.NewProperty("v1")),
+				"f2": resource.MakeSecret(resource.NewProperty("v2")),
+			},
+			expected: resource.PropertyMap{
+				"f1": resource.MakeSecret(resource.NewProperty("v1")),
+				"f2": resource.MakeSecret(resource.NewProperty("v2")),
+			},
+		},
+		{
+			name: "computed-input",
+			typ: typeFor[struct {
+				F1 string `pulumi:"f1" provider:"secret"`
+			}](),
+			input: resource.PropertyMap{
+				"f1": resource.MakeComputed(resource.NewProperty("")),
+			},
+			expected: resource.PropertyMap{
+				"f1": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty(""),
+					Secret:  true,
+					Known:   false,
+				}),
+			},
+		},
+		{
+			name: "mismatched-types",
+			typ: typeFor[struct {
+				F1 string `pulumi:"f1" provider:"secret"`
+				F2 []struct {
+					F1 string `pulumi:"f1" provider:"secret"`
+				} `pulumi:"f2"`
+			}](),
+			input: resource.PropertyMap{
+				"f2": resource.NewProperty([]resource.PropertyValue{
+					resource.NewProperty("v2"),
+				}),
+				"f3": resource.NewProperty("v3"),
+			},
+			expected: resource.PropertyMap{
+				"f2": resource.NewProperty([]resource.PropertyValue{
+					resource.NewProperty("v2"),
+				}),
+				"f3": resource.NewProperty("v3"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var walker secretsWalker
+			result := walker.walk(tt.typ, resource.NewProperty(tt.input))
+			require.Empty(t, walker.errs)
+			assert.Equal(t, tt.expected, result.ObjectValue())
+		})
+	}
+}

--- a/infer/configuration.go
+++ b/infer/configuration.go
@@ -91,7 +91,7 @@ func (c *config[T]) checkConfig(ctx context.Context, req p.CheckRequest) (p.Chec
 		// We don't apply defaults, but [DefaultCheck] does.
 		var name string
 		if req.Urn != "" {
-			req.Urn.Name()
+			name = req.Urn.Name()
 		}
 		i, failures, err := t.Check(ctx, name, req.Olds, req.News)
 		if err != nil {

--- a/infer/configuration.go
+++ b/infer/configuration.go
@@ -88,9 +88,12 @@ func (c *config[T]) checkConfig(ctx context.Context, req p.CheckRequest) (p.Chec
 	if t, ok := ((interface{})(t)).(CustomCheck[T]); ok {
 		// The user implemented check manually, so call that.
 		//
-		// We don't apply defaults or secrets if the user has implemented
-		// Check. [DefaultCheck] does both.
-		i, failures, err := t.Check(ctx, req.Urn.Name(), req.Olds, req.News)
+		// We don't apply defaults, but [DefaultCheck] does.
+		var name string
+		if req.Urn != "" {
+			req.Urn.Name()
+		}
+		i, failures, err := t.Check(ctx, name, req.Olds, req.News)
 		if err != nil {
 			return p.CheckResponse{}, err
 		}
@@ -100,7 +103,7 @@ func (c *config[T]) checkConfig(ctx context.Context, req p.CheckRequest) (p.Chec
 			return p.CheckResponse{}, err
 		}
 		return p.CheckResponse{
-			Inputs:   inputs,
+			Inputs:   applySecrets[T](inputs),
 			Failures: failures,
 		}, nil
 	}

--- a/infer/internal/ende/util.go
+++ b/infer/internal/ende/util.go
@@ -89,7 +89,7 @@ func MakeKnown(v resource.PropertyValue) resource.PropertyValue {
 		}
 		return resource.NewOutputProperty(o)
 	case v.IsComputed():
-		return v.SecretValue().Element
+		return v.V.(resource.Computed).Element
 	default:
 		return v
 	}

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -98,9 +98,12 @@ type CustomCreate[I, O any] interface {
 
 // CustomCheck describes a resource that understands how to check its inputs.
 //
-// By default, infer handles checks by ensuring that a inputs de-serialize correctly. This
-// is where you can extend that behavior. The returned input is given to subsequent calls
-// to `Create` and `Update`.
+// By default, infer handles checks by ensuring that a inputs de-serialize correctly,
+// applying default values and secrets. If to build on the default version of Check, you
+// can delegate to [DefaultCheck].
+//
+// This is where you can extend that behavior. The
+// returned input is given to subsequent calls to `Create` and `Update`.
 //
 // Example:
 // TODO - Maybe a resource that has a regex. We could reject invalid regex before the up

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -884,8 +884,8 @@ func (rc *derivedResourceController[R, I, O]) Check(ctx context.Context, req p.C
 	if r, ok := ((interface{})(r)).(CustomCheck[I]); ok {
 		// The user implemented check manually, so call that.
 		//
-		// We do not apply defaults or secrets if the user has implemented Check
-		// themselves. Both are applied by [DefaultCheck].
+		// We do not apply defaults if the user has implemented Check
+		// themselves. Defaults are applied by [DefaultCheck].
 		i, failures, err := r.Check(ctx, req.Urn.Name(), req.Olds, req.News)
 		if err != nil {
 			return p.CheckResponse{}, err

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -230,13 +230,6 @@ type MigrationResult[T any] struct {
 
 type stateMigrationFunc[Old, New any, F func(context.Context, Old) (MigrationResult[New], error)] struct{ f F }
 
-// typeFor returns the [Type] that represents the type argument T.
-//
-// reflect.TypeFor is included in go1.22.
-func typeFor[T any]() reflect.Type {
-	return reflect.TypeOf((*T)(nil)).Elem()
-}
-
 func (stateMigrationFunc[O, N, F]) isStateMigrationFunc()        {}
 func (stateMigrationFunc[O, N, F]) oldShape() reflect.Type       { return typeFor[O]() }
 func (stateMigrationFunc[O, N, F]) newShape() reflect.Type       { return typeFor[N]() }
@@ -1008,7 +1001,7 @@ func diff[R, I, O any](
 		return diff, nil
 	}
 
-	inputProps, err := introspect.FindProperties(reflect.TypeFor[I]())
+	inputProps, err := introspect.FindProperties(typeFor[I]())
 	if err != nil {
 		return p.DiffResponse{}, err
 	}

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -99,8 +99,8 @@ type CustomCreate[I, O any] interface {
 // CustomCheck describes a resource that understands how to check its inputs.
 //
 // By default, infer handles checks by ensuring that a inputs de-serialize correctly,
-// applying default values and secrets. If to build on the default version of Check, you
-// can delegate to [DefaultCheck].
+// applying default values and secrets. You can wrap the default behavior of Check by
+// calling [DefaultCheck] inside of your custom Check implementation.
 //
 // This is where you can extend that behavior. The
 // returned input is given to subsequent calls to `Create` and `Update`.

--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -518,7 +518,7 @@ func TestCheck(t *testing.T) {
 			checkResp, err := res.Check(context.Background(), p.CheckRequest{
 				Urn:  "a:b:c",
 				Olds: r.PropertyMap{},
-				News: tc.input,
+				News: tc.input.Copy(),
 			})
 			require.NoError(t, err)
 			assert.Empty(t, checkResp.Failures)
@@ -528,7 +528,7 @@ func TestCheck(t *testing.T) {
 
 		t.Run("DefaultCheck "+tcName, func(t *testing.T) {
 			t.Parallel()
-			in, failures, err := DefaultCheck[checkResource](tc.input)
+			in, failures, err := DefaultCheck[checkResource](tc.input.Copy())
 			require.NoError(t, err)
 			assert.Empty(t, failures)
 			assert.Equal(t, tc.expected, in.P1)

--- a/infer/util.go
+++ b/infer/util.go
@@ -1,0 +1,24 @@
+// Copyright 2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infer
+
+import "reflect"
+
+// typeFor returns the [reflect.Type] that represents the type argument T.
+//
+// [reflect.TypeFor] is included in go1.22.
+func typeFor[T any]() reflect.Type {
+	return reflect.TypeOf((*T)(nil)).Elem()
+}

--- a/internal/introspect/introspect.go
+++ b/internal/introspect/introspect.go
@@ -60,12 +60,11 @@ type ToPropertiesOptions struct {
 	ComputedKeys []string
 }
 
-func FindProperties(r any) (map[string]FieldTag, error) {
-	typ := reflect.TypeOf(r)
+func FindProperties(typ reflect.Type) (map[string]FieldTag, error) {
 	for typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
-	contract.Assertf(typ.Kind() == reflect.Struct, "Expected struct, found %s (%T)", typ.Kind(), r)
+	contract.Assertf(typ.Kind() == reflect.Struct, "Expected struct, found %s (%s)", typ.Kind(), typ.String())
 	m := map[string]FieldTag{}
 	for _, f := range reflect.VisibleFields(typ) {
 		info, err := ParseTag(f)

--- a/tests/resource_test.go
+++ b/tests/resource_test.go
@@ -1,0 +1,65 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi-go-provider/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+type res struct{}
+
+type resInput struct {
+	Field string `pulumi:"field" provider:"secret"`
+}
+
+type resOutput struct{ resInput }
+
+func (c res) Create(context.Context, string, resInput, bool) (string, resOutput, error) {
+	panic("unimplemented")
+}
+
+var _ infer.Annotated = res{}
+
+func (c res) Annotate(a infer.Annotator) { a.SetToken("index", "res") }
+
+func TestInferCheckSecrets(t *testing.T) {
+	t.Parallel()
+
+	resp, err := integration.NewServer("test", semver.MustParse("0.0.0"), infer.Provider(infer.Options{
+		Resources: []infer.InferredResource{
+			infer.Resource[res, resInput, resOutput](),
+		},
+	})).Check(p.CheckRequest{
+		Urn: resource.CreateURN("name", "test:index:res", "", "proj", "stack"),
+		News: map[resource.PropertyKey]resource.PropertyValue{
+			"field": resource.NewProperty("value"),
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.Failures)
+	assert.Equal(t, resource.PropertyMap{
+		"field": resource.MakeSecret(resource.NewProperty("value")),
+	}, resp.Inputs)
+}


### PR DESCRIPTION
This PR add explicit secret injection to `infer`. This is necessary for explicit providers in YAML, which does not correctly apply schema based secrets to provider config. This is what the bridge does.

To guard against misbehaved or partially implemented SDKs, I have also added explicit secret injection to resources.

Fixes #251 