### PR TITLE
`DefaultCheck` with `context.Context`

### DIFF
--- a/examples/auto-naming/main.go
+++ b/examples/auto-naming/main.go
@@ -47,7 +47,7 @@ func (*User) Check(
 	ctx context.Context, name string, oldInputs, newInputs resource.PropertyMap,
 ) (UserArgs, []p.CheckFailure, error) {
 	// Apply default arguments
-	args, failures, err := infer.DefaultCheck[UserArgs](newInputs)
+	args, failures, err := infer.DefaultCheck[UserArgs](ctx, newInputs)
 	if err != nil {
 		return args, failures, err
 	}

--- a/examples/file/main.go
+++ b/examples/file/main.go
@@ -112,7 +112,7 @@ func (*File) Check(ctx context.Context, name string, oldInputs, newInputs resour
 	if _, ok := newInputs["path"]; !ok {
 		newInputs["path"] = resource.NewStringProperty(name)
 	}
-	return infer.DefaultCheck[FileArgs](newInputs)
+	return infer.DefaultCheck[FileArgs](ctx, newInputs)
 }
 
 func (*File) Update(ctx context.Context, id string, olds FileState, news FileArgs, preview bool) (FileState, error) {

--- a/infer/README.md
+++ b/infer/README.md
@@ -231,7 +231,7 @@ func (*File) Check(ctx context.Context, name string, oldInputs, newInputs resour
 	if _, ok := newInputs["path"]; !ok {
 		newInputs["path"] = resource.NewStringProperty(name)
 	}
-	return infer.DefaultCheck[FileArgs](newInputs)
+	return infer.DefaultCheck[FileArgs](ctx, newInputs)
 }
 ```
 

--- a/infer/configuration.go
+++ b/infer/configuration.go
@@ -93,9 +93,13 @@ func (c *config[T]) checkConfig(ctx context.Context, req p.CheckRequest) (p.Chec
 		if req.Urn != "" {
 			name = req.Urn.Name()
 		}
-		i, failures, err := t.Check(ctx, name, req.Olds, req.News)
+		defCheckEnc, i, failures, err := callCustomCheck(ctx, t, name, req.Olds, req.News)
 		if err != nil {
 			return p.CheckResponse{}, err
+		}
+
+		if defCheckEnc != nil {
+			encoder = *defCheckEnc
 		}
 
 		inputs, err := encoder.Encode(i)
@@ -103,7 +107,7 @@ func (c *config[T]) checkConfig(ctx context.Context, req p.CheckRequest) (p.Chec
 			return p.CheckResponse{}, err
 		}
 		return p.CheckResponse{
-			Inputs:   applySecrets[T](inputs),
+			Inputs:   inputs,
 			Failures: failures,
 		}, nil
 	}

--- a/infer/internal/ende/ende.go
+++ b/infer/internal/ende/ende.go
@@ -33,6 +33,12 @@ const AssetSignature = "a9e28acb8ab501f883219e7c9f624fb6"
 // ArchiveSignature is a unique key for use for archives in the AssetOrArchive union type.
 const ArchiveSignature = "195f3948f6769324d4661e1e245f3a4d"
 
+// Encoder holds a look-aside table of information that can be encoded into a
+// [resource.PropertyMap] but cannot be encoded into a plain Go struct.
+//
+// Encoder is a byproduct of [Decode], and a non-zero Encoder should be used whenever
+// possible. If it is not possible to derive an Encoder, it safe to use the zero value of
+// Encoder.
 type Encoder struct{ *ende }
 
 // Decode a property map to a `pulumi:"x"` annotated struct.

--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -528,7 +528,7 @@ func TestCheck(t *testing.T) {
 
 		t.Run("DefaultCheck "+tcName, func(t *testing.T) {
 			t.Parallel()
-			in, failures, err := DefaultCheck[checkResource](tc.input.Copy())
+			in, failures, err := DefaultCheck[checkResource](context.Background(), tc.input.Copy())
 			require.NoError(t, err)
 			assert.Empty(t, failures)
 			assert.Equal(t, tc.expected, in.P1)


### PR DESCRIPTION
Following up on #252, this allows `DefaultCheck` to safely and accurately handle secrets application. The new signature for `DefaultCheck` is easier to extend without additional breaking changes. The downside to this design is that this makes `DefaultCheck` special. I think it's worth living with that until #212 is resolved.

I'd like to merge shortly after #252 (and before #252 is released) so that user's don't rely on #252 injecting secrets when `CustomCheck` is implemented and `DefaultCheck` is not called.