### PR TITLE
Update description of Provider SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/pulumi/pulumi-go-provider)](https://goreportcard.com/report/github.com/pulumi/pulumi-go-provider)
 
-A framework for building Go Providers for Pulumi.
+A framework for building Providers for Pulumi in Go.
 
 **Library documentation can be found at** [![Go Reference](https://pkg.go.dev/badge/github.com/pulumi/pulumi-go-provider.svg)](https://pkg.go.dev/github.com/pulumi/pulumi-go-provider)
 


### PR DESCRIPTION
I think "Go Provider for Pulumi" as a noun phrase reminds me a lot of say, "AWS Provider for Pulumi". This SDK is for building providers for Pulumi _in_ Go, rather than a "Go Provider".