### PR TITLE
Interpret JSON Config values

### DIFF
--- a/infer/apply_secrets.go
+++ b/infer/apply_secrets.go
@@ -21,8 +21,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
-	"github.com/pulumi/pulumi-go-provider/infer/internal/ende"
 	"github.com/pulumi/pulumi-go-provider/internal/introspect"
+	"github.com/pulumi/pulumi-go-provider/internal/putil"
 )
 
 func applySecrets[I any](inputs resource.PropertyMap) resource.PropertyMap {
@@ -46,14 +46,14 @@ func (w *secretsWalker) walk(t reflect.Type, p resource.PropertyValue) (out reso
 
 	// Ensure we are working in raw value types for p
 
-	if ende.IsSecret(p) {
-		p = ende.MakePublic(p)
-		defer func() { out = ende.MakeSecret(p) }()
+	if putil.IsSecret(p) {
+		p = putil.MakePublic(p)
+		defer func() { out = putil.MakeSecret(p) }()
 	}
 
-	if ende.IsComputed(p) {
-		p = ende.MakeKnown(p)
-		defer func() { out = ende.MakeComputed(p) }()
+	if putil.IsComputed(p) {
+		p = putil.MakeKnown(p)
+		defer func() { out = putil.MakeComputed(p) }()
 	}
 
 	// Ensure we are working in raw value types for t
@@ -95,7 +95,7 @@ func (w *secretsWalker) walk(t reflect.Type, p resource.PropertyValue) (out reso
 			}
 			v = w.walk(field.Type, v)
 			if info.Secret {
-				v = ende.MakeSecret(v)
+				v = putil.MakeSecret(v)
 			}
 			obj[resource.PropertyKey(info.Name)] = v
 		}

--- a/infer/internal/ende/ende.go
+++ b/infer/internal/ende/ende.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pulumi/pulumi-go-provider/infer/types"
 	"github.com/pulumi/pulumi-go-provider/internal/introspect"
+	"github.com/pulumi/pulumi-go-provider/internal/putil"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
@@ -104,10 +105,10 @@ func (p change) apply(v resource.PropertyValue) resource.PropertyValue {
 		})
 	}
 	if p.computed {
-		v = MakeComputed(v)
+		v = putil.MakeComputed(v)
 	}
 	if p.secret {
-		v = MakeSecret(v)
+		v = putil.MakeSecret(v)
 	}
 	return v
 }
@@ -219,8 +220,8 @@ func (e *ende) walk(
 		}
 	}
 
-	contract.Assertf(!IsComputed(v), "failed to strip computed")
-	contract.Assertf(!IsSecret(v), "failed to strip secrets")
+	contract.Assertf(!putil.IsComputed(v), "failed to strip computed")
+	contract.Assertf(!putil.IsSecret(v), "failed to strip secrets")
 	contract.Assertf(!v.IsOutput(), "failed to strip outputs")
 
 	switch typ.Kind() {

--- a/infer/internal/ende/ende_test.go
+++ b/infer/internal/ende/ende_test.go
@@ -69,34 +69,6 @@ func TestRapidRoundTrip(t *testing.T) {
 	})
 }
 
-func TestRapidDeepEqual(t *testing.T) {
-	t.Parallel()
-	// Check that a value always equals itself
-	rapid.Check(t, func(t *rapid.T) {
-		value := rResource.PropertyValue(5).Draw(t, "value")
-
-		assert.True(t, DeepEquals(value, value))
-	})
-
-	// Check that "distinct" values never equal themselves.
-	rapid.Check(t, func(t *rapid.T) {
-		values := rapid.SliceOfNDistinct(rResource.PropertyValue(5), 2, 2,
-			func(v r.PropertyValue) string {
-				return v.String()
-			}).Draw(t, "distinct")
-		assert.False(t, DeepEquals(values[0], values[1]))
-	})
-
-	t.Run("folding", func(t *testing.T) {
-		assert.True(t, DeepEquals(
-			r.MakeComputed(r.MakeSecret(r.NewStringProperty("hi"))),
-			r.MakeSecret(r.MakeComputed(r.NewStringProperty("hi")))))
-		assert.False(t, DeepEquals(
-			r.MakeSecret(r.NewStringProperty("hi")),
-			r.MakeComputed(r.NewStringProperty("hi"))))
-	})
-}
-
 // Test that we round trip against our strongly typed interface.
 func TestRoundtripIn(t *testing.T) {
 	t.Parallel()

--- a/infer/provider.go
+++ b/infer/provider.go
@@ -21,6 +21,7 @@ import (
 	p "github.com/pulumi/pulumi-go-provider"
 	t "github.com/pulumi/pulumi-go-provider/middleware"
 	"github.com/pulumi/pulumi-go-provider/middleware/cancel"
+	"github.com/pulumi/pulumi-go-provider/middleware/complexconfig" //nolint:staticcheck
 	mContext "github.com/pulumi/pulumi-go-provider/middleware/context"
 	"github.com/pulumi/pulumi-go-provider/middleware/dispatch"
 	"github.com/pulumi/pulumi-go-provider/middleware/schema"
@@ -166,6 +167,8 @@ func Wrap(provider p.Provider, opts Options) p.Provider {
 			return context.WithValue(ctx, configKey, opts.Config)
 		})
 	}
+
+	provider = complexconfig.Wrap(provider)
 	return cancel.Wrap(provider)
 }
 

--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -29,8 +29,8 @@ import (
 	"pgregory.net/rapid"
 
 	p "github.com/pulumi/pulumi-go-provider"
-	"github.com/pulumi/pulumi-go-provider/infer/internal/ende"
 	"github.com/pulumi/pulumi-go-provider/infer/types"
+	"github.com/pulumi/pulumi-go-provider/internal/putil"
 	rRapid "github.com/pulumi/pulumi-go-provider/internal/rapid/resource"
 )
 
@@ -94,13 +94,13 @@ func TestDefaultDependencies(t *testing.T) {
 		if newInput.ContainsUnknowns() {
 			for k, v := range output {
 				if newV, ok := newInput[k]; ok &&
-					ende.DeepEquals(newV, v) {
+					putil.DeepEquals(newV, v) {
 					continue
 				}
-				assert.True(t, ende.IsComputed(v),
+				assert.True(t, putil.IsComputed(v),
 					"key: %q", string(k))
 			}
-		} else if !ende.DeepEquals(
+		} else if !putil.DeepEquals(
 			r.NewObjectProperty(oldInput),
 			r.NewObjectProperty(newInput)) {
 			// If there is a change, then every item item should be
@@ -108,10 +108,10 @@ func TestDefaultDependencies(t *testing.T) {
 			for k, v := range output {
 				newV, ok := newInput[k]
 				if !ok {
-					assert.True(t, ende.IsComputed(v),
+					assert.True(t, putil.IsComputed(v),
 						"key: %q", string(k))
-				} else if !ende.IsComputed(v) {
-					assert.True(t, ende.DeepEquals(v, newV))
+				} else if !putil.IsComputed(v) {
+					assert.True(t, putil.DeepEquals(v, newV))
 				}
 			}
 		}
@@ -119,7 +119,7 @@ func TestDefaultDependencies(t *testing.T) {
 		for k, v := range output {
 			// An input of the same name is secret, so this should be too.
 			if newInput[k].ContainsSecrets() {
-				assert.Truef(t, ende.IsSecret(v),
+				assert.Truef(t, putil.IsSecret(v),
 					"key: %q", string(k))
 			}
 		}

--- a/infer/tests/check_test.go
+++ b/infer/tests/check_test.go
@@ -54,7 +54,6 @@ func TestCheckDefaults(t *testing.T) {
 		return pMap{
 			"pi":        pInt(2),
 			"s":         pString("one"),
-			"nested":    defaultNestedMap(),
 			"nestedPtr": defaultNestedMap(),
 		}
 	}

--- a/infer/tests/create_test.go
+++ b/infer/tests/create_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	p "github.com/pulumi/pulumi-go-provider"
-	ende "github.com/pulumi/pulumi-go-provider/infer/internal/ende"
+	"github.com/pulumi/pulumi-go-provider/internal/putil"
 )
 
 func TestCreate(t *testing.T) {
@@ -148,7 +148,7 @@ func TestCreate(t *testing.T) {
 		prov := provider()
 		c := resource.MakeComputed
 		s := resource.NewStringProperty
-		sec := ende.MakeSecret
+		sec := putil.MakeSecret
 		resp, err := prov.Create(p.CreateRequest{
 			Urn: urn("Wired", "preview"),
 			Properties: resource.PropertyMap{

--- a/infer/tests/provider.go
+++ b/infer/tests/provider.go
@@ -194,7 +194,7 @@ type WithDefaultsArgs struct {
 	// NestedDefaults.
 	String       string                     `pulumi:"s,optional"`
 	IntPtr       *int                       `pulumi:"pi,optional"`
-	Nested       NestedDefaults             `pulumi:"nested,optional"`
+	Nested       *NestedDefaults            `pulumi:"nested,optional"`
 	NestedPtr    *NestedDefaults            `pulumi:"nestedPtr"`
 	OptWithReq   *OptWithReq                `pulumi:"optWithReq,optional"`
 	ArrNested    []NestedDefaults           `pulumi:"arrNested,optional"`
@@ -306,7 +306,7 @@ func (w *RecursiveArgs) Annotate(a infer.Annotator) {
 }
 
 type Config struct {
-	Value string `pulumi:"value,optional"`
+	Value *string `pulumi:"value,optional"`
 }
 
 type ReadConfig struct{}

--- a/internal/putil/putil.go
+++ b/internal/putil/putil.go
@@ -1,4 +1,4 @@
-// Copyright 2023, Pulumi Corporation.
+// Copyright 2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ende
+package putil
 
 import "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 

--- a/internal/putil/putil.go
+++ b/internal/putil/putil.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package putil contains utility functions for working with [resource.PropertyValue]s.
 package putil
 
 import "github.com/pulumi/pulumi/sdk/v3/go/common/resource"

--- a/internal/rapid/resource/resource.go
+++ b/internal/rapid/resource/resource.go
@@ -30,7 +30,7 @@ type Typed struct {
 
 // ValueOf annotates a [reflect.Type] with an appropriate random [resource.PropertyValue].
 //
-// A value is considered "appropriate" to a type if the vlaue can be safely unmarshaled
+// A value is considered "appropriate" to a type if the value can be safely unmarshaled
 // into the type.
 func ValueOf(typ *rapid.Generator[reflect.Type]) *rapid.Generator[Typed] {
 	// Note: we generate values from types instead of vice versa because the set of
@@ -161,6 +161,13 @@ func PropertyValue(maxDepth int) *rapid.Generator[resource.PropertyValue] {
 		Secret(maxDepth),
 		Computed(maxDepth),
 	)
+}
+
+func PropertyMap(maxDepth int) *rapid.Generator[resource.PropertyMap] {
+	return rapid.Map(MapOf(PropertyValue(maxDepth-1)),
+		func(v resource.PropertyValue) resource.PropertyMap {
+			return v.ObjectValue()
+		})
 }
 
 func Primitive() *rapid.Generator[resource.PropertyValue] {

--- a/internal/rapid/resource/resource.go
+++ b/internal/rapid/resource/resource.go
@@ -160,6 +160,7 @@ func PropertyValue(maxDepth int) *rapid.Generator[resource.PropertyValue] {
 		Object(maxDepth),
 		Secret(maxDepth),
 		Computed(maxDepth),
+		Output(maxDepth),
 	)
 }
 
@@ -267,6 +268,34 @@ func Computed(maxDepth int) *rapid.Generator[resource.PropertyValue] {
 	})
 }
 
+func Output(maxDepth int) *rapid.Generator[resource.PropertyValue] {
+	return rapid.Custom(func(t *rapid.T) resource.PropertyValue {
+		o := resource.Output{
+			Secret:       rapid.Bool().Draw(t, "is-secret"),
+			Dependencies: outputDependencies().Draw(t, "dependencies"),
+		}
+
+		// The wire doesn't transport elements unless they are known, so we don't
+		// generate non-round-trip-able values.
+		if rapid.Bool().Draw(t, "is-known") {
+			o.Element = PropertyValue(maxDepth-1).Draw(t, "V")
+			o.Known = true
+		}
+
+		return resource.NewProperty(o)
+	})
+}
+
+func outputDependencies() *rapid.Generator[[]resource.URN] {
+	return rapid.SliceOfN(urn(), 0, 10)
+}
+
+func urn() *rapid.Generator[resource.URN] {
+	return rapid.Custom(func(t *rapid.T) resource.URN {
+		return resource.URN(rapid.String().Draw(t, "urn-body"))
+	})
+}
+
 func makeComputed(t *rapid.T, v resource.PropertyValue) resource.PropertyValue {
 	// If a value is marker, we fold the computedness into it.
 	if v.IsComputed() {
@@ -285,10 +314,6 @@ func makeComputed(t *rapid.T, v resource.PropertyValue) resource.PropertyValue {
 		return resource.NewOutputProperty(o)
 	}
 
-	// Otherwise we pick between the two kinds of secretness we can accept.
-	if rapid.Bool().Draw(t, "isOutput") {
-		return resource.MakeOutput(v)
-	}
 	return resource.MakeComputed(v)
 
 }

--- a/middleware/complexconfig/provider.go
+++ b/middleware/complexconfig/provider.go
@@ -1,0 +1,227 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package complexconfig adds middleware for schema informed complex configuration
+// encoding/decoding as a work-around for https://github.com/pulumi/pulumi/pull/15032.
+//
+// The entry point for this package is [Wrap].
+//
+// Deprecated: This package will be removed after
+// https://github.com/pulumi/pulumi/pull/15032 merges.
+package complexconfig
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pulumi/pulumi-go-provider/internal/putil"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	p "github.com/pulumi/pulumi-go-provider"
+)
+
+func Wrap(provider p.Provider) p.Provider {
+	encoder := provider
+	contract.Assertf(provider.GetSchema != nil, "provider.GetSchema must be implemented")
+	encoder.CheckConfig = encodeCheckConfig(provider.CheckConfig, provider.GetSchema)
+	return encoder
+}
+
+type (
+	getSchema   = func(context.Context, p.GetSchemaRequest) (p.GetSchemaResponse, error)
+	checkConfig = func(context.Context, p.CheckRequest) (p.CheckResponse, error)
+)
+
+func encodeCheckConfig(check checkConfig, getSchema getSchema) checkConfig {
+	if check == nil {
+		check = func(_ context.Context, req p.CheckRequest) (p.CheckResponse, error) {
+			return p.CheckResponse{Inputs: req.News}, nil
+		}
+	}
+	return func(ctx context.Context, req p.CheckRequest) (p.CheckResponse, error) {
+		// Only req.News is from the engine. req.Olds (if it exists) is from state
+		// and thus went through a previous normalizing pass of CheckConfig.
+
+		// If there are no inputs, then we can just return.
+		if len(req.News) == 0 {
+			return check(ctx, req)
+		}
+
+		schemaResp, err := getSchema(ctx, p.GetSchemaRequest{})
+		if err != nil {
+			return p.CheckResponse{},
+				p.InternalErrorf("unable to decode config: no schema available: %w", err)
+		}
+		var spec schema.PackageSpec
+		if err := json.Unmarshal([]byte(schemaResp.Schema), &spec); err != nil {
+			return p.CheckResponse{},
+				p.InternalErrorf("unable to decode config: invalid schema: %w", err)
+		}
+
+		for k, spec := range spec.Config.Variables {
+			v, ok := req.News[resource.PropertyKey(k)]
+			if !ok {
+				continue
+			}
+
+			req.News[resource.PropertyKey(k)] = fixEncoding(v, spec)
+		}
+
+		// Attempt to decode any inputs that don't have a matching config schema.
+		for k, v := range req.News {
+			if _, ok := spec.Config.Variables[string(k)]; ok {
+				continue
+			}
+			req.News[k] = fixEncoding(v, schema.PropertySpec{})
+		}
+
+		return check(ctx, req)
+	}
+}
+
+func fixEncoding(v resource.PropertyValue, spec schema.PropertySpec) resource.PropertyValue {
+	// Ensure that v is unwrapped
+
+	switch {
+	case v.IsComputed():
+		return v
+	case v.IsSecret():
+		return resource.MakeSecret(fixEncoding(v.SecretValue().Element, spec))
+	case v.IsOutput():
+		o := v.OutputValue()
+		o.Element = fixEncoding(v, spec)
+		return resource.NewProperty(o)
+	}
+
+	// If the value is not a string, we assume that it is the correct type.
+	//
+	// If spec.Type is a string, we still need to attempt to decode it, since it may
+	// be secret or computed, and thus represented as a JSON encoded object.
+	if !v.IsString() {
+		return v
+	}
+
+	var target any
+	err := json.Unmarshal([]byte(v.StringValue()), &target)
+	if err != nil {
+		return v
+	}
+
+	// Instead of using resource.NewPropertyValue, specialize it to detect nested
+	// json-encoded secrets and computed values.
+	var replv func(encoded any) (resource.PropertyValue, bool)
+	replv = func(v any) (resource.PropertyValue, bool) {
+		if s, ok := v.(string); ok {
+			switch s {
+			case plugin.UnknownBoolValue:
+				return resource.MakeComputed(resource.NewProperty(false)), true
+			case plugin.UnknownNumberValue:
+				return resource.MakeComputed(resource.NewProperty(0.0)), true
+			case plugin.UnknownStringValue:
+				return resource.MakeComputed(resource.NewProperty("")), true
+			case plugin.UnknownArrayValue:
+				return resource.MakeComputed(resource.NewProperty([]resource.PropertyValue{})), true
+			case plugin.UnknownObjectValue:
+				return resource.MakeComputed(resource.NewProperty(resource.PropertyMap{})), true
+			case plugin.UnknownAssetValue:
+				return resource.MakeComputed(resource.NewProperty(&resource.Asset{})), true
+			case plugin.UnknownArchiveValue:
+				return resource.MakeComputed(resource.NewProperty(&resource.Archive{})), true
+			}
+		}
+		m, ok := v.(map[string]any)
+		if !ok {
+			return resource.PropertyValue{}, false
+		}
+
+		value, ok := m[sig.Key]
+		if !ok {
+			return resource.PropertyValue{}, false
+		}
+		sigValue, ok := value.(string)
+		if !ok {
+			return resource.PropertyValue{}, false
+		}
+
+		switch sigValue {
+		case sig.Secret:
+			return putil.MakeSecret(
+				resource.NewPropertyValueRepl(m["value"], nil, replv),
+			), true
+		case sig.OutputValue:
+			castBool := func(key string) bool {
+				v, ok := m[key]
+				if !ok {
+					return false
+				}
+				b, ok := v.(bool)
+				return ok && b
+			}
+
+			deps, _ := m["dependencies"].([]any)
+			var dependencies []resource.URN
+			if len(deps) > 0 {
+				dependencies = make([]resource.URN, 0, len(deps))
+			}
+			for _, d := range deps {
+				urn, ok := d.(string)
+				if !ok {
+					continue
+				}
+				dependencies = append(dependencies, resource.URN(urn))
+			}
+
+			elem, hasElem := m["value"]
+			return resource.NewProperty(resource.Output{
+				Secret:       castBool("secret"),
+				Dependencies: dependencies,
+				Known:        hasElem,
+				Element:      resource.NewPropertyValueRepl(elem, nil, replv),
+			}), true
+		default:
+			contract.Failf("Unknown sig value: %#v", sigValue)
+			return resource.PropertyValue{}, false
+		}
+	}
+
+	out := resource.NewPropertyValueRepl(target, nil, replv)
+
+	// If the expected type is a string and the raw underlying type is not a string,
+	// then don't use the JSON encoded value (since it might be a valid JSON value of
+	// a type other then string, for example: 42, a JSON number but a valid string
+	// value).
+	if spec.Type == "string" && !unwrap(out).IsString() {
+		return v
+	}
+	return out
+}
+
+func unwrap(v resource.PropertyValue) resource.PropertyValue {
+	for {
+		switch {
+		case v.IsSecret():
+			v = v.SecretValue().Element
+		case v.IsComputed():
+			v = v.V.(resource.Computed).Element
+		case v.IsOutput():
+			v = v.OutputValue().Element
+		default:
+			return v
+		}
+	}
+}

--- a/middleware/complexconfig/provider_test.go
+++ b/middleware/complexconfig/provider_test.go
@@ -1,0 +1,205 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package complexconfig_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/internal/putil"
+	rresource "github.com/pulumi/pulumi-go-provider/internal/rapid/resource"
+	"github.com/pulumi/pulumi-go-provider/middleware/complexconfig"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+func TestComplexConfigEncoding(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    resource.PropertyMap
+		schema   func() (schema.PackageSpec, error)
+		expected resource.PropertyMap
+	}{
+		{
+			name: "validate-unknown-config-keys",
+			input: resource.PropertyMap{
+				"$": resource.NewProperty(resource.PropertyMap{
+					"": resource.NewProperty([]resource.PropertyValue{
+						{V: resource.Output{
+							Element: resource.PropertyValue{
+								V: interface{}(nil)},
+							Known:  false,
+							Secret: true,
+						}},
+					}),
+				}),
+			},
+			schema: func() (schema.PackageSpec, error) {
+				return schema.PackageSpec{}, nil
+			},
+			expected: resource.PropertyMap{
+				"$": resource.NewProperty(resource.PropertyMap{
+					"": resource.NewProperty([]resource.PropertyValue{
+						{V: resource.Output{
+							Element: resource.PropertyValue{
+								V: interface{}(nil)},
+							Known:  false,
+							Secret: true,
+						}},
+					}),
+				}),
+			},
+		},
+		{
+			name: "numeric-looking-string-args",
+			input: resource.PropertyMap{
+				"$": resource.NewProperty("42"),
+			},
+			schema: func() (schema.PackageSpec, error) {
+				var p schema.PackageSpec
+				p.Config.Variables = map[string]schema.PropertySpec{
+					"$": {TypeSpec: schema.TypeSpec{
+						Type: "string",
+					}},
+				}
+
+				return p, nil
+
+			},
+			expected: resource.PropertyMap{
+				"$": resource.NewProperty("42"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			provider := complexconfig.Wrap(p.Provider{
+				GetSchema: func(context.Context, p.GetSchemaRequest) (p.GetSchemaResponse, error) {
+					spec, err := tt.schema()
+					if err != nil {
+						return p.GetSchemaResponse{}, nil
+					}
+					b, err := json.Marshal(spec)
+					require.NoError(t, err)
+					return p.GetSchemaResponse{
+						Schema: string(b),
+					}, err
+				},
+				CheckConfig: func(_ context.Context, req p.CheckRequest) (p.CheckResponse, error) {
+					if !putil.DeepEquals(
+						resource.NewProperty(req.News),
+						resource.NewProperty(tt.expected),
+					) {
+						assert.Equal(t, tt.expected, req.News)
+					}
+
+					return p.CheckResponse{}, nil
+				},
+			})
+
+			_, err := provider.CheckConfig(context.Background(), p.CheckRequest{
+				News: generateJSONEncoding(t, tt.input),
+			})
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestRapidComplexConfigEncoding(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		m := foldViaPluginMarshal(t, rresource.PropertyMap(5).Draw(t, "inputs"))
+		provider := complexconfig.Wrap(p.Provider{
+			GetSchema: func(context.Context, p.GetSchemaRequest) (p.GetSchemaResponse, error) {
+				vars := make(map[string]schema.PropertySpec, len(m))
+				for k, v := range m {
+					vars[string(k)] = schema.PropertySpec{
+						TypeSpec: schema.TypeSpec{
+							Type: v.TypeString(),
+						},
+					}
+				}
+				spec := schema.PackageSpec{
+					Config: schema.ConfigSpec{
+						Variables: vars,
+					},
+				}
+
+				b, err := json.Marshal(spec)
+				return p.GetSchemaResponse{
+					Schema: string(b),
+				}, err
+			},
+			CheckConfig: func(_ context.Context, req p.CheckRequest) (p.CheckResponse, error) {
+				assert.Equal(t, m, req.News)
+
+				return p.CheckResponse{}, nil
+			},
+		})
+
+		_, err := provider.CheckConfig(context.Background(), p.CheckRequest{
+			News: generateJSONEncoding(t, m.Copy()),
+		})
+		require.NoError(t, err)
+	})
+}
+
+func generateJSONEncoding(t require.TestingT, m resource.PropertyMap) resource.PropertyMap {
+	for k, v := range m {
+		if v.IsString() {
+			continue
+		}
+		enc, err := plugin.MarshalPropertyValue(k, v, plugin.MarshalOptions{
+			SkipNulls:        false,
+			KeepUnknowns:     true,
+			KeepSecrets:      true,
+			KeepResources:    true,
+			KeepOutputValues: true,
+		})
+		require.NoError(t, err)
+
+		json, err := enc.MarshalJSON()
+		require.NoError(t, err)
+		m[k] = resource.NewProperty(string(json))
+	}
+	return m
+}
+
+// foldViaPluginMarshal removes any information from m that is not preserved on the wire.
+func foldViaPluginMarshal(t require.TestingT, m resource.PropertyMap) resource.PropertyMap {
+	opts := plugin.MarshalOptions{
+		SkipNulls:        false,
+		KeepUnknowns:     true,
+		KeepSecrets:      true,
+		KeepResources:    true,
+		KeepOutputValues: true,
+	}
+	enc, err := plugin.MarshalProperties(m, opts)
+	require.NoError(t, err)
+
+	out, err := plugin.UnmarshalProperties(enc, opts)
+	require.NoError(t, err)
+	return out
+}

--- a/putil/putil_test.go
+++ b/putil/putil_test.go
@@ -1,0 +1,53 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package putil_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-go-provider/internal/putil"
+	rresource "github.com/pulumi/pulumi-go-provider/internal/rapid/resource"
+	r "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"pgregory.net/rapid"
+)
+
+func TestRapidDeepEqual(t *testing.T) {
+	t.Parallel()
+	// Check that a value always equals itself
+	rapid.Check(t, func(t *rapid.T) {
+		value := rresource.PropertyValue(5).Draw(t, "value")
+
+		assert.True(t, putil.DeepEquals(value, value))
+	})
+
+	// Check that "distinct" values never equal themselves.
+	rapid.Check(t, func(t *rapid.T) {
+		values := rapid.SliceOfNDistinct(rresource.PropertyValue(5), 2, 2,
+			func(v r.PropertyValue) string {
+				return v.String()
+			}).Draw(t, "distinct")
+		assert.False(t, putil.DeepEquals(values[0], values[1]))
+	})
+
+	t.Run("folding", func(t *testing.T) {
+		assert.True(t, putil.DeepEquals(
+			r.MakeComputed(r.MakeSecret(r.NewStringProperty("hi"))),
+			r.MakeSecret(r.MakeComputed(r.NewStringProperty("hi")))))
+		assert.False(t, putil.DeepEquals(
+			r.MakeSecret(r.NewStringProperty("hi")),
+			r.MakeComputed(r.NewStringProperty("hi"))))
+	})
+}

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -89,19 +89,21 @@ func TestInferConfigWrap(t *testing.T) {
 func TestInferCheckConfigSecrets(t *testing.T) {
 	t.Parallel()
 
+	type nestedElem struct {
+		Field string `pulumi:"field" provider:"secret"`
+	}
+
+	type nested struct {
+		Int       int    `pulumi:"int" provider:"secret"`
+		NotSecret string `pulumi:"not-nested"`
+	}
+
 	type config struct {
-		Field  string `pulumi:"field" provider:"secret"`
-		Nested struct {
-			Int       int    `pulumi:"int" provider:"secret"`
-			NotSecret string `pulumi:"not-nested"`
-		} `pulumi:"nested"`
-		NotSecret   string `pulumi:"not"`
-		ArrayNested []struct {
-			Field string `pulumi:"field" provider:"secret"`
-		} `pulumi:"arrayNested"`
-		MapNested map[string]struct {
-			Field string `pulumi:"field" provider:"secret"`
-		} `pulumi:"mapNested"`
+		Field       string                `pulumi:"field" provider:"secret"`
+		Nested      nested                `pulumi:"nested"`
+		NotSecret   string                `pulumi:"not"`
+		ArrayNested []nestedElem          `pulumi:"arrayNested"`
+		MapNested   map[string]nestedElem `pulumi:"mapNested"`
 	}
 
 	resp, err := integration.NewServer("test", semver.MustParse("0.0.0"), infer.Provider(infer.Options{


### PR DESCRIPTION
This PR adds a middleware to handle decoding JSON encoded config values. The middleware is marked as deprecated, since we would like to remove this functionality as soon as https://github.com/pulumi/pulumi/pull/15032 closes.

Fixes #171 