### PR TITLE
Extend code coverage to be more meaningful

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build build_examples install_examples lint lint-copyright lint-golang
 
-GO_TEST_FLAGS=-race -coverprofile="coverage.txt"
+GO_TEST_FLAGS=-race -coverprofile="coverage.txt" -coverpkg=github.com/pulumi/pulumi-go-provider/...
 GO_TEST=go test ${GO_TEST_FLAGS}
 
 build:

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,6 @@ coverage:
     patch:
       default:
         informational: true
+ignore:
+  # Examples implementation code should not count against coverage.
+  - "examples/"


### PR DESCRIPTION
I noticed two issues with existing code coverage stats:

1. Only in-module data are collected, e.g. tests in the `github.com/pulumi/pulumi-go-provider/tests` module don't output coverage data for `github.com/pulumi/pulumi-go-provider`
2. The `examples` and `tests` folders have coverage data for its resource implementation code.

This PR changes the arguments to collect data for all submodules of `github.com/pulumi/pulumi-go-provider` but to exclude `examples` and `tests/grpc` in codecov itself.