### PR TITLE
Allow testing and schema generation for a single example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,13 +14,7 @@
 # macOS
 .DS_Store
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
-
 **/sdk
-
-examples/**/pulumi-resource-*
-examples/**/schema-*.json
 
 /.vscode
 
@@ -31,3 +25,5 @@ go.work.sum
 
 # Code coverage reports
 **/coverage.txt
+
+bin

--- a/examples/assets/consumer/Pulumi.yaml
+++ b/examples/assets/consumer/Pulumi.yaml
@@ -4,7 +4,7 @@ runtime: yaml
 plugins:
   providers:
     - name: assets
-      path: ..
+      path: ../../../bin/examples
 
 resources:
   assetsResource:

--- a/examples/assets/schema.json
+++ b/examples/assets/schema.json
@@ -1,0 +1,40 @@
+{
+  "name": "assets",
+  "version": "0.1.0",
+  "meta": {
+    "moduleFormat": "(.*)"
+  },
+  "config": {},
+  "provider": {
+    "type": "object"
+  },
+  "resources": {
+    "assets:index:HasAssets": {
+      "properties": {
+        "a1": {
+          "$ref": "pulumi.json#/Asset"
+        },
+        "a2": {
+          "$ref": "pulumi.json#/Asset"
+        }
+      },
+      "type": "object",
+      "required": [
+        "a1",
+        "a2"
+      ],
+      "inputProperties": {
+        "a1": {
+          "$ref": "pulumi.json#/Asset"
+        },
+        "a2": {
+          "$ref": "pulumi.json#/Asset"
+        }
+      },
+      "requiredInputs": [
+        "a1",
+        "a2"
+      ]
+    }
+  }
+}

--- a/examples/auto-naming/consumer/Pulumi.yaml
+++ b/examples/auto-naming/consumer/Pulumi.yaml
@@ -4,7 +4,7 @@ runtime: yaml
 plugins:
   providers:
     - name: auto-naming
-      path: ..
+      path: ../../../bin/examples
 
 resources:
   auto-named:

--- a/examples/auto-naming/schema.json
+++ b/examples/auto-naming/schema.json
@@ -1,0 +1,26 @@
+{
+  "name": "auto-naming",
+  "version": "0.1.0",
+  "meta": {
+    "moduleFormat": "(.*)"
+  },
+  "config": {},
+  "provider": {
+    "type": "object"
+  },
+  "resources": {
+    "auto-naming:index:User": {
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "inputProperties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/examples/credentials/consumer/Pulumi.yaml
+++ b/examples/credentials/consumer/Pulumi.yaml
@@ -4,7 +4,7 @@ runtime: yaml
 plugins:
   providers:
     - name: credentials
-      path: ..
+      path: ../../../bin/examples
 
 variables:
   helloworld:

--- a/examples/credentials/schema.json
+++ b/examples/credentials/schema.json
@@ -1,0 +1,145 @@
+{
+  "name": "credentials",
+  "version": "0.1.0",
+  "meta": {
+    "moduleFormat": "(.*)"
+  },
+  "config": {
+    "variables": {
+      "hash": {
+        "$ref": "#/types/credentials:index:HashKind",
+        "description": "The (entirely uncryptographic) hash function used to encode the \"password\".",
+        "default": "Adler32"
+      },
+      "password": {
+        "type": "string",
+        "description": "The password. It is very secret.",
+        "default": "",
+        "defaultInfo": {
+          "environment": [
+            "FOO"
+          ]
+        },
+        "secret": true
+      },
+      "user": {
+        "type": "string",
+        "description": "The username. Its important but not secret."
+      }
+    },
+    "defaults": [
+      "hash",
+      "user"
+    ]
+  },
+  "types": {
+    "credentials:index:HashKind": {
+      "type": "string",
+      "enum": [
+        {
+          "description": "Adler32 implements the Adler-32 checksum.",
+          "value": "Adler32"
+        },
+        {
+          "description": "CRC32 implements the 32-bit cyclic redundancy check, or CRC-32, checksum.",
+          "value": "CRC32"
+        }
+      ]
+    }
+  },
+  "provider": {
+    "properties": {
+      "password": {
+        "type": "string",
+        "description": "The password. It is very secret.",
+        "default": "",
+        "defaultInfo": {
+          "environment": [
+            "FOO"
+          ]
+        },
+        "secret": true
+      },
+      "user": {
+        "type": "string",
+        "description": "The username. Its important but not secret."
+      }
+    },
+    "type": "object",
+    "required": [
+      "user"
+    ],
+    "inputProperties": {
+      "hash": {
+        "$ref": "#/types/credentials:index:HashKind",
+        "description": "The (entirely uncryptographic) hash function used to encode the \"password\".",
+        "default": "Adler32"
+      },
+      "password": {
+        "type": "string",
+        "description": "The password. It is very secret.",
+        "default": "",
+        "defaultInfo": {
+          "environment": [
+            "FOO"
+          ]
+        },
+        "secret": true
+      },
+      "user": {
+        "type": "string",
+        "description": "The username. Its important but not secret."
+      }
+    },
+    "requiredInputs": [
+      "hash",
+      "user"
+    ]
+  },
+  "resources": {
+    "credentials:index:User": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "password"
+      ]
+    }
+  },
+  "functions": {
+    "credentials:index:sign": {
+      "description": "Signs the message with the user name and returns the result as a secret.",
+      "inputs": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Message to sign."
+          }
+        },
+        "type": "object",
+        "required": [
+          "message"
+        ]
+      },
+      "outputs": {
+        "properties": {
+          "out": {
+            "secret": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "out"
+        ],
+        "type": "object"
+      }
+    }
+  }
+}

--- a/examples/dna-store/consumer/Pulumi.yaml
+++ b/examples/dna-store/consumer/Pulumi.yaml
@@ -3,7 +3,7 @@ runtime: yaml
 plugins:
   providers:
     - name: dna-store
-      path: ..
+      path: ../../../bin/examples
 
 
 resources:

--- a/examples/dna-store/schema.json
+++ b/examples/dna-store/schema.json
@@ -1,77 +1,116 @@
 {
-  "name": "schema-test",
+  "name": "dna-store",
   "version": "0.1.0",
+  "meta": {
+    "moduleFormat": "(.*)"
+  },
   "config": {},
   "types": {
-    "schema-test:index:Enum": {
-      "type": "integer",
-      "enum": [
-        {
-          "name": "A",
-          "value": 0
-        },
-        {
-          "name": "C",
-          "value": 1
-        },
-        {
-          "name": "T",
-          "value": 2
-        },
-        {
-          "name": "G",
-          "value": 3
-        }
-      ]
-    },
-    "schema-test:index:Strct": {
-      "description": "This is a holder for enums",
+    "dna-store:index:Metadata": {
       "properties": {
-        "enum": {
-          "$ref": "#/types/schema-test:index:Enum",
-          "default": 0
+        "sampleType": {
+          "$ref": "#/types/dna-store:index:SampleType",
+          "description": "sample type of the dna"
         },
-        "names": {
-          "type": "array",
-          "items": {
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
             "type": "string"
           },
-          "description": "Names for the default value"
+          "description": "optional tags associated with the dna sample"
         }
       },
       "type": "object",
       "required": [
-        "enum",
-        "names"
+        "sampleType"
+      ]
+    },
+    "dna-store:index:Molecule": {
+      "type": "integer",
+      "enum": [
+        {
+          "description": "adenine",
+          "value": 0
+        },
+        {
+          "description": "cytosine",
+          "value": 1
+        },
+        {
+          "description": "thymine",
+          "value": 2
+        },
+        {
+          "description": "guanine",
+          "value": 3
+        }
+      ]
+    },
+    "dna-store:index:SampleType": {
+      "type": "string",
+      "enum": [
+        {
+          "value": "human"
+        },
+        {
+          "value": "dog"
+        },
+        {
+          "value": "cat"
+        },
+        {
+          "value": "other"
+        }
       ]
     }
   },
-  "provider": {},
+  "provider": {
+    "type": "object"
+  },
   "resources": {
-    "schema-test:index:EnumStore": {
+    "dna-store:index:DNAStore": {
       "properties": {
-        "e": {
-          "$ref": "#/types/schema-test:index:Enum"
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/dna-store:index:Molecule"
+          },
+          "description": "molecule data"
         },
-        "filepath": {
+        "filedir": {
           "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/types/dna-store:index:Metadata",
+          "description": "stores information related to a particular dna"
         }
       },
+      "type": "object",
       "required": [
-        "e",
-        "filepath"
+        "data",
+        "filedir",
+        "metadata"
       ],
       "inputProperties": {
-        "e": {
-          "$ref": "#/types/schema-test:index:Enum"
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/dna-store:index:Molecule"
+          },
+          "description": "molecule data"
         },
-        "filepath": {
+        "filedir": {
           "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/types/dna-store:index:Metadata",
+          "description": "stores information related to a particular dna"
         }
       },
       "requiredInputs": [
-        "e",
-        "filepath"
+        "data",
+        "filedir",
+        "metadata"
       ]
     }
   }

--- a/examples/file/consumer/Pulumi.yaml
+++ b/examples/file/consumer/Pulumi.yaml
@@ -4,7 +4,7 @@ runtime: yaml
 plugins:
   providers:
     - name: file
-      path: ..
+      path: ../../../bin/examples
 
 resources:
   managedFile:

--- a/examples/file/schema.json
+++ b/examples/file/schema.json
@@ -1,0 +1,53 @@
+{
+  "name": "file",
+  "version": "0.1.0",
+  "meta": {
+    "moduleFormat": "(.*)"
+  },
+  "config": {},
+  "provider": {
+    "type": "object"
+  },
+  "resources": {
+    "file:index:File": {
+      "description": "A file projected into a pulumi resource",
+      "properties": {
+        "content": {
+          "type": "string",
+          "description": "The content of the file."
+        },
+        "force": {
+          "type": "boolean",
+          "description": "If an already existing file should be deleted if it exists."
+        },
+        "path": {
+          "type": "string",
+          "description": "The path of the file."
+        }
+      },
+      "type": "object",
+      "required": [
+        "content",
+        "force",
+        "path"
+      ],
+      "inputProperties": {
+        "content": {
+          "type": "string",
+          "description": "The content of the file."
+        },
+        "force": {
+          "type": "boolean",
+          "description": "If an already existing file should be deleted if it exists."
+        },
+        "path": {
+          "type": "string",
+          "description": "The path of the file. This defaults to the name of the pulumi resource."
+        }
+      },
+      "requiredInputs": [
+        "content"
+      ]
+    }
+  }
+}

--- a/examples/random-login/consumer/Pulumi.yaml
+++ b/examples/random-login/consumer/Pulumi.yaml
@@ -4,7 +4,7 @@ runtime: yaml
 plugins:
   providers:
     - name: random-login
-      path: ..
+      path: ../../../bin/examples
 
 resources:
   generator:

--- a/examples/random-login/schema.json
+++ b/examples/random-login/schema.json
@@ -1,0 +1,119 @@
+{
+  "name": "random-login",
+  "version": "0.1.0",
+  "meta": {
+    "moduleFormat": "(.*)"
+  },
+  "config": {
+    "variables": {
+      "itsasecret": {
+        "type": "boolean"
+      }
+    }
+  },
+  "provider": {
+    "type": "object",
+    "inputProperties": {
+      "itsasecret": {
+        "type": "boolean"
+      }
+    }
+  },
+  "resources": {
+    "random-login:index:MoreRandomPassword": {
+      "properties": {
+        "length": {
+          "$ref": "/random/v4.8.1/schema.json#/resources/random:index%2FrandomInteger:RandomInteger"
+        },
+        "password": {
+          "$ref": "/random/v4.8.1/schema.json#/resources/random:index%2FrandomPassword:RandomPassword"
+        }
+      },
+      "type": "object",
+      "required": [
+        "length",
+        "password"
+      ],
+      "inputProperties": {
+        "length": {
+          "$ref": "/random/v4.8.1/schema.json#/resources/random:index%2FrandomInteger:RandomInteger"
+        }
+      },
+      "requiredInputs": [
+        "length"
+      ],
+      "isComponent": true
+    },
+    "random-login:index:RandomLogin": {
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "passwordLength": {
+          "type": "integer"
+        },
+        "petName": {
+          "type": "boolean",
+          "plain": true
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "password",
+        "passwordLength",
+        "petName",
+        "username"
+      ],
+      "inputProperties": {
+        "passwordLength": {
+          "type": "integer"
+        },
+        "petName": {
+          "type": "boolean",
+          "plain": true
+        }
+      },
+      "requiredInputs": [
+        "passwordLength",
+        "petName"
+      ],
+      "isComponent": true
+    },
+    "random-login:index:RandomSalt": {
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "salt": {
+          "type": "string"
+        },
+        "saltedLength": {
+          "type": "integer"
+        },
+        "saltedPassword": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "password",
+        "salt",
+        "saltedPassword"
+      ],
+      "inputProperties": {
+        "password": {
+          "type": "string"
+        },
+        "saltedLength": {
+          "type": "integer"
+        }
+      },
+      "requiredInputs": [
+        "password"
+      ]
+    }
+  }
+}

--- a/examples/str/consumer/Pulumi.yaml
+++ b/examples/str/consumer/Pulumi.yaml
@@ -4,7 +4,7 @@ runtime: yaml
 plugins:
   providers:
     - name: str
-      path: ..
+      path: ../../../bin/examples
 
 variables:
   replaced:

--- a/examples/str/schema.json
+++ b/examples/str/schema.json
@@ -1,24 +1,32 @@
 {
   "name": "str",
   "version": "0.1.0",
+  "meta": {
+    "moduleFormat": "(.*)"
+  },
   "config": {},
-  "provider": {},
+  "provider": {
+    "type": "object"
+  },
   "functions": {
-    "str:index:GiveMeAString": {
+    "str:index:giveMeAString": {
       "description": "Return a string, withing any inputs",
+      "inputs": {
+        "type": "object"
+      },
       "outputs": {
         "properties": {
           "out": {
             "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "out"
-        ]
+        ],
+        "type": "object"
       }
     },
-    "str:index:Print": {
+    "str:index:print": {
       "description": "Print to stdout",
       "inputs": {
         "properties": {
@@ -30,27 +38,36 @@
         "required": [
           "s"
         ]
+      },
+      "outputs": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "type": "object"
       }
     },
-    "str:index:Replace": {
+    "str:index:replace": {
       "description": "Replace returns a copy of the string s with all\nnon-overlapping instances of old replaced by new.\nIf old is empty, it matches at the beginning of the string\nand after each UTF-8 sequence, yielding up to k+1 replacements\nfor a k-rune string.",
       "inputs": {
         "properties": {
           "new": {
-            "type": "string"
+            "type": "string",
+            "description": "The string to replace `Old` with."
           },
           "old": {
-            "type": "string"
+            "type": "string",
+            "description": "The string to replace."
           },
           "s": {
-            "type": "string"
+            "type": "string",
+            "description": "The string where the replacement takes place."
           }
         },
         "type": "object",
         "required": [
-          "s",
+          "new",
           "old",
-          "new"
+          "s"
         ]
       },
       "outputs": {
@@ -59,20 +76,20 @@
             "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "out"
-        ]
+        ],
+        "type": "object"
       }
     },
-    "str:regex:Replace": {
+    "str:regex:replace": {
       "description": "Replace returns a copy of `s`, replacing matches of the `old`\nwith the replacement string `new`.",
       "inputs": {
         "properties": {
           "new": {
             "type": "string"
           },
-          "old": {
+          "pattern": {
             "type": "string"
           },
           "s": {
@@ -81,9 +98,9 @@
         },
         "type": "object",
         "required": [
-          "s",
-          "old",
-          "new"
+          "new",
+          "pattern",
+          "s"
         ]
       },
       "outputs": {
@@ -92,10 +109,10 @@
             "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "out"
-        ]
+        ],
+        "type": "object"
       }
     }
   }

--- a/tests/grpc/config/consumer/Pulumi.yaml
+++ b/tests/grpc/config/consumer/Pulumi.yaml
@@ -4,7 +4,7 @@ runtime: yaml
 plugins:
   providers:
     - name: config
-      path: ..
+      path: ../../../bin/examples
 
 resources:
   provider:


### PR DESCRIPTION
This is a Makefile change to allow running 2 commands:

```sh
$ make examples/<example-name>/schema.json # Generate the schema for an example
$ make examples/<example-name>/test        # Run the tests for an example
```

The performance of running `make test_examples` has been improved by reusing example provider binaries who's inputs have not changed.

To simplify cleanup and the Makefile, example provider binaries are now all downloaded into a top level `bin` folder, this is why each example needed it's `plugins.providers[*].path` updated.

Some schemas have not been updated recently, so this PR updates them.