### PR TITLE
Alternative simple component experience

### DIFF
--- a/examples/component-program/main.go
+++ b/examples/component-program/main.go
@@ -12,27 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package main shows how a simple comoponent provider can be created using existing
+// package main shows how a simple component provider can be created using existing
 // Pulumi programs that contain components.
 package main
 
 import (
-	"github.com/pulumi/pulumi-go-provider/component"
+	"fmt"
+	"os"
+
 	"github.com/pulumi/pulumi-go-provider/examples/component-program/nested"
+	"github.com/pulumi/pulumi-go-provider/infer"
 )
 
 func main() {
-	err := component.ProviderHost(
-		component.WithName("go-components"),
-		component.WithVersion("v0.0.1"),
-		component.WithResources(
-			component.ProgramComponent(
-				component.ComponentFn[RandomComponentArgs, *RandomComponent](NewMyComponent)),
-			component.ProgramComponent(
-				component.ComponentFn[nested.NestedRandomComponentArgs, *nested.NestedRandomComponent](nested.CreateNestedRandomComponent))),
-	)
+	err := infer.Default().
+		WithName("go-components").
+		WithVersion("v0.0.1").
+		WithComponent(
+			infer.ProgramComponent(NewMyComponent),
+			infer.ProgramComponent(nested.CreateNestedRandomComponent),
+		).BuildAndRun()
 
 	if err != nil {
-		panic(err)
+		fmt.Fprintln(os.Stderr, "Error: "+err.Error())
+		os.Exit(1)
 	}
 }

--- a/infer/default.go
+++ b/infer/default.go
@@ -1,0 +1,90 @@
+// Copyright 2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infer
+
+import (
+	"fmt"
+	"slices"
+
+	provider "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/middleware/schema"
+)
+
+// Default creates an inferred provider which applies as many defaults as possible.
+func Default() DefaultProvider {
+	return DefaultProvider{}
+}
+
+type DefaultProvider struct {
+	name, version string
+	components    []InferredComponent
+}
+
+func (p DefaultProvider) WithComponent(components ...InferredComponent) DefaultProvider {
+	p.components = append(slices.Clone(p.components), components...)
+	return p
+}
+
+func (p DefaultProvider) WithName(name string) DefaultProvider {
+	p.name = name
+	return p
+}
+
+func (p DefaultProvider) WithVersion(version string) DefaultProvider {
+	p.version = version
+	return p
+}
+
+func (p DefaultProvider) BuildAndRun() error {
+	if p.name == "" {
+		// We can relax this when Pulumi supports injecting the name into the
+		// provider, but we shouldn't do so until then, since the rest of Pulumi
+		// can't handle a schema with an empty name.
+		return fmt.Errorf("Default provider names are not yet supported, please call WithName to add a name")
+	}
+	if len(p.components) == 0 {
+		// This error message will need to be adjusted if DefaultProvider supports
+		// more then just components.
+		return fmt.Errorf("Default providers must be given at least one component")
+	}
+	inferOpts := Options{
+		Metadata: schema.Metadata{
+			LanguageMap: map[string]any{
+				"nodejs": map[string]any{
+					"respectSchemaVersion": true,
+				},
+				"go": map[string]any{
+					"generateResourceContainerTypes": true,
+					"respectSchemaVersion":           true,
+				},
+				"python": map[string]any{
+					"requires": map[string]any{
+						"pulumi": ">=3.0.0,<4.0.0",
+					},
+					"respectSchemaVersion": true,
+				},
+				"csharp": map[string]any{
+					"packageReferences": map[string]any{
+						"Pulumi": "3.*",
+					},
+					"respectSchemaVersion": true,
+				},
+			},
+		},
+		Components: p.components,
+	}
+
+	return provider.RunProvider(p.name, p.version, Provider(inferOpts))
+}


### PR DESCRIPTION
This PR shows an alternative implementation of the component package introduced in #308.

This method embraces that components are built on top of infer, leaving room for `infer.DefaultProvider` to support the rest of `infer`'s feature set in time.

This implementation makes it much easier to gradually transition from a more scaffolded "default" experience to an experience where the user assumes direct control.