### PR TITLE
Change the form of `infer.Component`

### DIFF
--- a/examples/random-login/main_test.go
+++ b/examples/random-login/main_test.go
@@ -60,6 +60,7 @@ const schema = `{
       "isComponent": true
     },
     "random-login:index:RandomLogin": {
+      "description": "Generate a random login.",
       "properties": {
         "password": {
           "type": "string"
@@ -69,7 +70,8 @@ const schema = `{
         },
         "petName": {
           "type": "boolean",
-          "plain": true
+          "plain": true,
+          "description": "Whether to use a memorable pet name or a random string for the Username."
         },
         "username": {
           "type": "string"

--- a/examples/random-login/schema.json
+++ b/examples/random-login/schema.json
@@ -45,6 +45,7 @@
       "isComponent": true
     },
     "random-login:index:RandomLogin": {
+      "description": "Generate a random login.",
       "properties": {
         "password": {
           "type": "string"
@@ -54,7 +55,8 @@
         },
         "petName": {
           "type": "boolean",
-          "plain": true
+          "plain": true,
+          "description": "Whether to use a memorable pet name or a random string for the Username."
         },
         "username": {
           "type": "string"

--- a/infer/README.md
+++ b/infer/README.md
@@ -14,14 +14,13 @@ To encapsulate the idea of a new component resource, we define the resource, its
 and its outputs:
 
 ```go
-type Login struct{}
 type LoginArgs struct {
-  PasswordLength pulumi.IntPtrInput `pulumi:"passwordLength"`
-  PetName        bool               `pulumi:"petName"`
+	 PasswordLength pulumi.IntPtrInput `pulumi:"passwordLength"`
+	 PetName        bool               `pulumi:"petName"`
 }
 
-type LoginState struct {
-  pulumi.ResourceState
+type Login struct {
+	 pulumi.ResourceState
 
 	 PasswordLength pulumi.IntPtrInput `pulumi:"passwordLength"`
 	 PetName        bool               `pulumi:"petName"`
@@ -46,10 +45,10 @@ Now that we have defined the type of the component, we need to define how to act
 construct the component resource:
 
 ```go
-func (r *Login) Construct(ctx *pulumi.Context, name, typ string, args LoginArgs, opts pulumi.ResourceOption) (
- *LoginState, error) {
-	comp := &LoginState{}
-	err := ctx.RegisterComponentResource(typ, name, comp, opts)
+func NewLogin(ctx *pulumi.Context, name string, args LoginArgs, opts ...pulumi.ResourceOption) (
+ *Login, error) {
+	comp := &Login{}
+	err := ctx.RegisterComponentResource(p.GetTypeToken(ctx), name, comp, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +102,7 @@ func main() {
 func provider() p.Provider {
 	return infer.Provider(infer.Options{
 		Components: []infer.InferredComponent{
-			infer.Component[*Login, LoginArgs, *LoginState](),
+			infer.Component(NewLogin),
 		},
 	})
 }

--- a/infer/tests/token_test.go
+++ b/infer/tests/token_test.go
@@ -50,13 +50,11 @@ type TokenResult struct {
 
 type TokenComponent struct{ pulumi.ResourceState }
 
-type ComponentToken struct{}
-
 // Check that we allow other capitalization schemes
-func (c *ComponentToken) Annotate(a infer.Annotator) { a.SetToken("cmp", "tK") }
+func (c *TokenComponent) Annotate(a infer.Annotator) { a.SetToken("cmp", "tK") }
 
-func (*ComponentToken) Construct(
-	ctx *pulumi.Context, name, typ string, inputs TokenArgs, opts pulumi.ResourceOption,
+func Construct(
+	ctx *pulumi.Context, name string, inputs TokenArgs, opts ...pulumi.ResourceOption,
 ) (*TokenComponent, error) {
 	panic("unimplemented")
 }
@@ -83,7 +81,7 @@ func TestTokens(t *testing.T) {
 			infer.Resource[*CustomToken, TokenArgs, TokenResult](),
 		},
 		Components: []infer.InferredComponent{
-			infer.Component[*ComponentToken, TokenArgs, *TokenComponent](),
+			infer.Component(Construct),
 		},
 		Functions: []infer.InferredFunction{
 			infer.Function[*FnToken, TokenArgs, TokenResult](),

--- a/provider.go
+++ b/provider.go
@@ -1227,3 +1227,18 @@ func (e internalError) Error() string {
 }
 
 func (e internalError) Unwrap() error { return e.err }
+
+// GetTypeToken returns the type associated with the current call.
+//
+// ctx can either be the [context.Context] associated with currently gRPC method being
+// served or a [*pulumi.Context] within [github.com/pulumi/pulumi-go-provider/infer]'s
+// component resources.
+//
+// If no type token is available, then the empty string will be returned.
+func GetTypeToken[Ctx interface{ Value(any) any }](ctx Ctx) string {
+	urn, _ := ctx.Value(key.URN).(presource.URN)
+	if urn.IsValid() {
+		return urn.Type().String()
+	}
+	return ""
+}

--- a/tests/component_test.go
+++ b/tests/component_test.go
@@ -30,7 +30,7 @@ import (
 
 type Foo struct{ pulumi.ComponentResource }
 
-func (*Foo) Construct(ctx *pulumi.Context, name string, typ string, inputs FooArgs, opts pulumi.ResourceOption) (*Foo, error) {
+func NewFoo(ctx *pulumi.Context, name string, inputs FooArgs, opts ...pulumi.ResourceOption) (*Foo, error) {
 	return nil, nil
 }
 
@@ -47,7 +47,7 @@ type Bundle struct {
 func provider() integration.Server {
 	return integration.NewServer("foo", semver.Version{Major: 1},
 		infer.Provider(infer.Options{
-			Components: []infer.InferredComponent{infer.Component[*Foo, FooArgs, *Foo]()},
+			Components: []infer.InferredComponent{infer.Component(NewFoo)},
 		}),
 	)
 }


### PR DESCRIPTION
Instead of taking a `[Anchor, Args, State]` triple like custom resources, we change the shape to directly pass the `New*` construct function.

Existing users of `infer.Component` will need to make the changes seen in our example code.

The motivation for this change is to make the API of "packages" components (consumable from any language) compatible with the API that we suggest for "local" components (consumable from other Go programs). After this change, in both cases a component would require two parts:

```
type RandomLogin struct { ... }

func NewRandomLogin(ctx *pulumi.Context, name string, args RandomLoginArgs, opts ...pulumi.ResourceOption) { ... }
```

so, a type and a corresponding constructor function.

This aligns well with the story that we are building towards for all languages, and thus justifies the breaking change. We believe that a combination of a preview 0.x version of the library, low number of end users, and simplicity of migration warrants the breaking change to get clean API in the future.