### PR TITLE
Rename `(Annotator).SetResourceDeprecationMessage` to `(Annotator).Deprecate`

### DIFF
--- a/infer/README.md
+++ b/infer/README.md
@@ -160,9 +160,14 @@ func (f *FileState) Annotate(a infer.Annotator) {
 }
 ```
 
-To deprecate a resource or field, annotate it with `Deprecate`.
+To deprecate a resource or field, annotate it with `Deprecate`:
 
-The only mandatory method for a `CustomResource` is `Create`.
+```go
+func (f *FileState) Annotate(a infer.Annotator) {
+	a.Deprecate(&f.OldField, "You should prefer to use NewField instead.")
+```
+
+The only mandatory method for a `CustomResource` is `Create`:
 
 ```go
 func (*File) Create(ctx context.Context, name string, input FileArgs, preview bool) (

--- a/infer/README.md
+++ b/infer/README.md
@@ -160,6 +160,8 @@ func (f *FileState) Annotate(a infer.Annotator) {
 }
 ```
 
+To deprecate a resource or field, annotate it with `Deprecate`.
+
 The only mandatory method for a `CustomResource` is `Create`.
 
 ```go

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -292,8 +292,8 @@ type Annotator interface {
 	// `mypkg:mymodule:MyResource`, in the same way `SetToken` does.
 	AddAlias(module tokens.ModuleName, name tokens.TypeName)
 
-	// Set a deprecation message for the resource, which officially marks it as deprecated.
-	Deprecate(message string)
+	// Set a deprecation message for a struct field, which officially marks it as deprecated.
+	Deprecate(i any, message string)
 }
 
 // Annotated is used to describe the fields of an object or a resource. Annotated can be

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -293,6 +293,18 @@ type Annotator interface {
 	AddAlias(module tokens.ModuleName, name tokens.TypeName)
 
 	// Set a deprecation message for a struct field, which officially marks it as deprecated.
+	//
+	// For example:
+	//
+	//	func (*s Struct) Annotated(a Annotator) {
+	//		a.Deprecate(&s.Field, "field is deprecated")
+	//	}
+	//
+	// To deprecate a resource, object or function, call Deprecate on the struct itself:
+	//
+	//	func (*s Struct) Annotated(a Annotator) {
+	//		a.Deprecate(&s, "Struct is deprecated")
+	//	}
 	Deprecate(i any, message string)
 }
 

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -293,7 +293,7 @@ type Annotator interface {
 	AddAlias(module tokens.ModuleName, name tokens.TypeName)
 
 	// Set a deprecation message for the resource, which officially marks it as deprecated.
-	SetResourceDeprecationMessage(message string)
+	Deprecate(message string)
 }
 
 // Annotated is used to describe the fields of an object or a resource. Annotated can be

--- a/infer/schema.go
+++ b/infer/schema.go
@@ -57,15 +57,18 @@ func getAnnotated(t reflect.Type) introspect.Annotator {
 		for k, v := range src.DefaultEnvs {
 			(*dst).DefaultEnvs[k] = v
 		}
+		for k, v := range src.DeprecationMessage {
+			(*dst).DeprecationMessage[k] = v
+		}
 		dst.Token = src.Token
 		dst.Aliases = append(dst.Aliases, src.Aliases...)
-		dst.DeprecationMessage = src.DeprecationMessage
 	}
 
 	ret := introspect.Annotator{
-		Descriptions: map[string]string{},
-		Defaults:     map[string]any{},
-		DefaultEnvs:  map[string][]string{},
+		Descriptions:       map[string]string{},
+		Defaults:           map[string]any{},
+		DefaultEnvs:        map[string][]string{},
+		DeprecationMessage: map[string]string{},
 	}
 	if t.Elem().Kind() == reflect.Struct {
 		for _, f := range reflect.VisibleFields(t.Elem()) {
@@ -118,7 +121,7 @@ func getResourceSchema[R, I, O any](isComponent bool) (schema.ResourceSpec, mult
 		RequiredInputs:     requiredInputs,
 		IsComponent:        isComponent,
 		Aliases:            aliases,
-		DeprecationMessage: annotations.DeprecationMessage,
+		DeprecationMessage: annotations.DeprecationMessage[""],
 	}, errs
 }
 
@@ -286,11 +289,12 @@ func propertyListFromType(typ reflect.Type, indicatePlain bool) (
 			required = append(required, tags.Name)
 		}
 		spec := &schema.PropertySpec{
-			TypeSpec:         serialized,
-			Secret:           tags.Secret,
-			ReplaceOnChanges: tags.ReplaceOnChanges,
-			Description:      annotations.Descriptions[tags.Name],
-			Default:          annotations.Defaults[tags.Name],
+			TypeSpec:           serialized,
+			Secret:             tags.Secret,
+			ReplaceOnChanges:   tags.ReplaceOnChanges,
+			Description:        annotations.Descriptions[tags.Name],
+			Default:            annotations.Defaults[tags.Name],
+			DeprecationMessage: annotations.DeprecationMessage[tags.Name],
 		}
 		if envs := annotations.DefaultEnvs[tags.Name]; len(envs) > 0 {
 			spec.DefaultInfo = &schema.DefaultSpec{

--- a/infer/schema.go
+++ b/infer/schema.go
@@ -57,18 +57,18 @@ func getAnnotated(t reflect.Type) introspect.Annotator {
 		for k, v := range src.DefaultEnvs {
 			(*dst).DefaultEnvs[k] = v
 		}
-		for k, v := range src.DeprecationMessage {
-			(*dst).DeprecationMessage[k] = v
+		for k, v := range src.DeprecationMessages {
+			(*dst).DeprecationMessages[k] = v
 		}
 		dst.Token = src.Token
 		dst.Aliases = append(dst.Aliases, src.Aliases...)
 	}
 
 	ret := introspect.Annotator{
-		Descriptions:       map[string]string{},
-		Defaults:           map[string]any{},
-		DefaultEnvs:        map[string][]string{},
-		DeprecationMessage: map[string]string{},
+		Descriptions:        map[string]string{},
+		Defaults:            map[string]any{},
+		DefaultEnvs:         map[string][]string{},
+		DeprecationMessages: map[string]string{},
 	}
 	if t.Elem().Kind() == reflect.Struct {
 		for _, f := range reflect.VisibleFields(t.Elem()) {
@@ -121,7 +121,7 @@ func getResourceSchema[R, I, O any](isComponent bool) (schema.ResourceSpec, mult
 		RequiredInputs:     requiredInputs,
 		IsComponent:        isComponent,
 		Aliases:            aliases,
-		DeprecationMessage: annotations.DeprecationMessage[""],
+		DeprecationMessage: annotations.DeprecationMessages[""],
 	}, errs
 }
 
@@ -294,7 +294,7 @@ func propertyListFromType(typ reflect.Type, indicatePlain bool) (
 			ReplaceOnChanges:   tags.ReplaceOnChanges,
 			Description:        annotations.Descriptions[tags.Name],
 			Default:            annotations.Defaults[tags.Name],
-			DeprecationMessage: annotations.DeprecationMessage[tags.Name],
+			DeprecationMessage: annotations.DeprecationMessages[tags.Name],
 		}
 		if envs := annotations.DefaultEnvs[tags.Name]; len(envs) > 0 {
 			spec.DefaultInfo = &schema.DefaultSpec{

--- a/infer/schema_test.go
+++ b/infer/schema_test.go
@@ -22,13 +22,18 @@ import (
 )
 
 type TestResource struct {
+	P1 string `pulumi:"p1,optional"`
 }
 
 func (r *TestResource) Annotate(a Annotator) {
 	a.Describe(&r, "This is a test resource.")
 	a.AddAlias("myMod", "MyAlias")
-	a.Deprecate("This resource is deprecated.")
+	a.Deprecate(&r, "This resource is deprecated.")
 	a.SetToken("myMod", "TheResource")
+
+	a.Describe(&r.P1, "This is a test property.")
+	a.SetDefault(&r.P1, defaultValue)
+	a.Deprecate(&r.P1, "This field is deprecated.")
 }
 
 func TestResourceAnnotations(t *testing.T) {
@@ -43,4 +48,10 @@ func TestResourceAnnotations(t *testing.T) {
 	require.Equal(t, "This is a test resource.", spec.Description)
 
 	require.Equal(t, "This resource is deprecated.", spec.DeprecationMessage)
+
+	p1, p1Exists := spec.Properties["p1"]
+	require.True(t, p1Exists)
+	assert.Equal(t, "This is a test property.", p1.Description)
+	assert.Equal(t, defaultValue, p1.Default)
+	assert.Equal(t, "This field is deprecated.", p1.DeprecationMessage)
 }

--- a/infer/schema_test.go
+++ b/infer/schema_test.go
@@ -27,7 +27,7 @@ type TestResource struct {
 func (r *TestResource) Annotate(a Annotator) {
 	a.Describe(&r, "This is a test resource.")
 	a.AddAlias("myMod", "MyAlias")
-	a.SetResourceDeprecationMessage("This resource is deprecated.")
+	a.Deprecate("This resource is deprecated.")
 	a.SetToken("myMod", "TheResource")
 }
 

--- a/internal/introspect/annotator.go
+++ b/internal/introspect/annotator.go
@@ -23,22 +23,22 @@ import (
 
 func NewAnnotator(resource any) Annotator {
 	return Annotator{
-		Descriptions:       map[string]string{},
-		Defaults:           map[string]any{},
-		DefaultEnvs:        map[string][]string{},
-		DeprecationMessage: map[string]string{},
-		matcher:            NewFieldMatcher(resource),
+		Descriptions:        map[string]string{},
+		Defaults:            map[string]any{},
+		DefaultEnvs:         map[string][]string{},
+		DeprecationMessages: map[string]string{},
+		matcher:             NewFieldMatcher(resource),
 	}
 }
 
 // Annotator implements the Annotator interface as defined in resource/resource.go.
 type Annotator struct {
-	Descriptions       map[string]string
-	Defaults           map[string]any
-	DefaultEnvs        map[string][]string
-	Token              string
-	Aliases            []string
-	DeprecationMessage map[string]string
+	Descriptions        map[string]string
+	Defaults            map[string]any
+	DefaultEnvs         map[string][]string
+	Token               string
+	Aliases             []string
+	DeprecationMessages map[string]string
 
 	matcher FieldMatcher
 }
@@ -118,12 +118,12 @@ func (a *Annotator) Deprecate(i any, message string) {
 			i = reflect.ValueOf(i).Elem().Interface()
 		}
 		if a.matcher.value.Addr().Interface() == i {
-			a.DeprecationMessage[""] = message
+			a.DeprecationMessages[""] = message
 			return
 		}
 		panic("Could not annotate field: could not find field")
 	}
-	a.DeprecationMessage[field.Name] = message
+	a.DeprecationMessages[field.Name] = message
 }
 
 // formatToken formats a (module, token) pair into a valid token string.

--- a/internal/introspect/annotator.go
+++ b/internal/introspect/annotator.go
@@ -97,7 +97,7 @@ func (a *Annotator) AddAlias(module tokens.ModuleName, token tokens.TypeName) {
 	a.Aliases = append(a.Aliases, formatToken(module, token))
 }
 
-func (a *Annotator) SetResourceDeprecationMessage(message string) {
+func (a *Annotator) Deprecate(message string) {
 	a.DeprecationMessage = message
 }
 

--- a/internal/introspect/introspect_test.go
+++ b/internal/introspect/introspect_test.go
@@ -114,7 +114,7 @@ func TestAnnotate(t *testing.T) {
 	assert.Equal(t, "Fizz is not MyStruct.Foo.", a.Descriptions["fizz"])
 	assert.Equal(t, "This is MyStruct, but also your struct.", a.Descriptions[""])
 	assert.Equal(t, "pkg:myMod:MyToken", a.Token)
-	assert.Equal(t, "This resource is deprecated.", a.DeprecationMessage)
+	assert.Equal(t, "This resource is deprecated.", a.DeprecationMessage[""])
 	assert.Equal(t, []string{"pkg:myMod:MyAlias"}, a.Aliases)
 }
 

--- a/internal/introspect/introspect_test.go
+++ b/internal/introspect/introspect_test.go
@@ -40,7 +40,7 @@ func (m *MyStruct) Annotate(a infer.Annotator) {
 	a.Describe(&m.Fizz, "Fizz is not MyStruct.Foo.")
 	a.SetDefault(&m.Foo, "Fizz")
 	a.SetToken("myMod", "MyToken")
-	a.SetResourceDeprecationMessage("This resource is deprecated.")
+	a.Deprecate("This resource is deprecated.")
 	a.AddAlias("myMod", "MyAlias")
 }
 

--- a/internal/introspect/introspect_test.go
+++ b/internal/introspect/introspect_test.go
@@ -114,7 +114,7 @@ func TestAnnotate(t *testing.T) {
 	assert.Equal(t, "Fizz is not MyStruct.Foo.", a.Descriptions["fizz"])
 	assert.Equal(t, "This is MyStruct, but also your struct.", a.Descriptions[""])
 	assert.Equal(t, "pkg:myMod:MyToken", a.Token)
-	assert.Equal(t, "This resource is deprecated.", a.DeprecationMessage[""])
+	assert.Equal(t, "This resource is deprecated.", a.DeprecationMessages[""])
 	assert.Equal(t, []string{"pkg:myMod:MyAlias"}, a.Aliases)
 }
 

--- a/internal/introspect/introspect_test.go
+++ b/internal/introspect/introspect_test.go
@@ -40,7 +40,7 @@ func (m *MyStruct) Annotate(a infer.Annotator) {
 	a.Describe(&m.Fizz, "Fizz is not MyStruct.Foo.")
 	a.SetDefault(&m.Foo, "Fizz")
 	a.SetToken("myMod", "MyToken")
-	a.Deprecate("This resource is deprecated.")
+	a.Deprecate(&m, "This resource is deprecated.")
 	a.AddAlias("myMod", "MyAlias")
 }
 


### PR DESCRIPTION
Based on https://github.com/pulumi/pulumi-go-provider/pull/245#pullrequestreview-2132327302 it looks like we want to rename `SetResourceDeprecationMessage` to `Describe`.

This PR also enables field-level deprecation messages.

Closes #248 
