### PR TITLE
Default the version of NewDefaultProvider to 0.0.0

### DIFF
--- a/infer/provider_builder.go
+++ b/infer/provider_builder.go
@@ -88,6 +88,9 @@ func NewProviderBuilder() *ProviderBuilder {
 	}
 
 	return &ProviderBuilder{
+		// Default the component provider schema version to "0.0.0" if not provided for now,
+		// otherwise SDK codegen gets confused without a version.
+		version:  "0.0.0",
 		metadata: defaultMetadata,
 	}
 }

--- a/infer/provider_builder_test.go
+++ b/infer/provider_builder_test.go
@@ -96,6 +96,7 @@ func TestNewDefaultProvider(t *testing.T) {
 		},
 	}
 
+	assert.Equal(t, "0.0.0", dp.version)
 	assert.Equal(t, expectedLangMap, dp.metadata.LanguageMap)
 }
 


### PR DESCRIPTION
Default the component provider schema version to "0.0.0" if not provided for now, otherwise SDK codegen gets confused without a version.

One unfortunate difference to other languages is that this is not just components. I think that's okay for now? (users can override)