### PR TITLE
refactor(infer): switch to request/response structs for infer custom resource interface functions

### DIFF
--- a/examples/assets/main.go
+++ b/examples/assets/main.go
@@ -83,17 +83,20 @@ func assertState(s HasAssetsArgs, includesAssets bool) {
 	}
 }
 
-func (*HasAssets) Create(ctx context.Context, name string, input HasAssetsArgs, preview bool) (id string, output HasAssetsArgs, err error) {
-	if preview {
-		return "", HasAssetsArgs{}, nil
+func (*HasAssets) Create(ctx context.Context, req infer.CreateRequest[HasAssetsArgs]) (resp infer.CreateResponse[HasAssetsArgs], err error) {
+	if req.Preview {
+		return resp, nil
 	}
 
-	output = input
+	output := req.Inputs
 	assertState(output, true)
-	return name, output, nil
+	return infer.CreateResponse[HasAssetsArgs]{
+		ID:     req.Name,
+		Output: output,
+	}, nil
 }
 
-func (*HasAssets) Delete(ctx context.Context, id string, state HasAssetsArgs) error {
-	assertState(state, false)
-	return nil
+func (*HasAssets) Delete(ctx context.Context, req infer.DeleteRequest[HasAssetsArgs]) (infer.DeleteResponse, error) {
+	assertState(req.State, false)
+	return infer.DeleteResponse{}, nil
 }

--- a/examples/credentials/main.go
+++ b/examples/credentials/main.go
@@ -91,20 +91,22 @@ type UserState struct {
 	Password string `pulumi:"password"`
 }
 
-func (*User) Create(ctx context.Context, name string, input UserArgs, preview bool) (string, UserState, error) {
+func (*User) Create(ctx context.Context, req infer.CreateRequest[UserArgs]) (infer.CreateResponse[UserState], error) {
 	config := infer.GetConfig[Config](ctx)
-	return name, UserState{
-		Name:     config.User,
-		Password: config.hashedPassword,
-	}, nil
+	return infer.CreateResponse[UserState]{
+		ID: req.Name,
+		Output: UserState{
+			Name:     config.User,
+			Password: config.hashedPassword,
+		}}, nil
 }
 
 var _ = (infer.CustomDiff[UserArgs, UserState])((*User)(nil))
 
-func (*User) Diff(ctx context.Context, id string, olds UserState, news UserArgs) (p.DiffResponse, error) {
+func (*User) Diff(ctx context.Context, req infer.DiffRequest[UserArgs, UserState]) (infer.DiffResponse, error) {
 	config := infer.GetConfig[Config](ctx)
-	if config.User != olds.Name {
-		return p.DiffResponse{
+	if config.User != req.Olds.Name {
+		return infer.DiffResponse{
 			HasChanges: true,
 			DetailedDiff: map[string]p.PropertyDiff{
 				"name": {Kind: p.UpdateReplace},

--- a/examples/file/main.go
+++ b/examples/file/main.go
@@ -68,111 +68,125 @@ func (f *FileState) Annotate(a infer.Annotator) {
 	a.Describe(&f.Path, "The path of the file.")
 }
 
-func (*File) Create(ctx context.Context, name string, input FileArgs, preview bool) (id string, output FileState, err error) {
-	if !input.Force {
-		_, err := os.Stat(input.Path)
+func (*File) Create(ctx context.Context, req infer.CreateRequest[FileArgs]) (resp infer.CreateResponse[FileState], err error) {
+	if !req.Inputs.Force {
+		_, err := os.Stat(req.Inputs.Path)
 		if !os.IsNotExist(err) {
-			return "", FileState{}, fmt.Errorf("file already exists; pass force=true to override")
+			return resp, fmt.Errorf("file already exists; pass force=true to override")
 		}
 	}
 
-	if preview { // Don't do the actual creating if in preview
-		return input.Path, FileState{}, nil
+	if req.Preview { // Don't do the actual creating if in preview
+		return infer.CreateResponse[FileState]{ID: req.Inputs.Path}, nil
 	}
 
-	f, err := os.Create(input.Path)
+	f, err := os.Create(req.Inputs.Path)
 	if err != nil {
-		return "", FileState{}, err
+		return resp, err
 	}
 	defer f.Close()
-	n, err := f.WriteString(input.Content)
+	n, err := f.WriteString(req.Inputs.Content)
 	if err != nil {
-		return "", FileState{}, err
+		return resp, err
 	}
-	if n != len(input.Content) {
-		return "", FileState{}, fmt.Errorf("only wrote %d/%d bytes", n, len(input.Content))
+	if n != len(req.Inputs.Content) {
+		return resp, fmt.Errorf("only wrote %d/%d bytes", n, len(req.Inputs.Content))
 	}
-	return input.Path, FileState{
-		Path:    input.Path,
-		Force:   input.Force,
-		Content: input.Content,
+	return infer.CreateResponse[FileState]{
+		ID: req.Inputs.Path,
+		Output: FileState{
+			Path:    req.Inputs.Path,
+			Force:   req.Inputs.Force,
+			Content: req.Inputs.Content,
+		},
 	}, nil
 }
 
-func (*File) Delete(ctx context.Context, id string, props FileState) error {
-	err := os.Remove(props.Path)
+func (*File) Delete(ctx context.Context, req infer.DeleteRequest[FileState]) (infer.DeleteResponse, error) {
+	err := os.Remove(req.State.Path)
 	if os.IsNotExist(err) {
-		p.GetLogger(ctx).Warningf("file %q already deleted", props.Path)
+		p.GetLogger(ctx).Warningf("file %q already deleted", req.State.Path)
 		err = nil
 	}
-	return err
+	return infer.DeleteResponse{}, err
 }
 
-func (*File) Check(ctx context.Context, name string, oldInputs, newInputs resource.PropertyMap) (FileArgs, []p.CheckFailure, error) {
-	if _, ok := newInputs["path"]; !ok {
-		newInputs["path"] = resource.NewStringProperty(name)
+func (*File) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckResponse[FileArgs], error) {
+	if _, ok := req.NewInputs["path"]; !ok {
+		req.NewInputs["path"] = resource.NewStringProperty(req.Name)
 	}
-	return infer.DefaultCheck[FileArgs](ctx, newInputs)
+	args, f, err := infer.DefaultCheck[FileArgs](ctx, req.NewInputs)
+
+	return infer.CheckResponse[FileArgs]{
+		Inputs:   args,
+		Failures: f,
+	}, err
 }
 
-func (*File) Update(ctx context.Context, id string, olds FileState, news FileArgs, preview bool) (FileState, error) {
-	if !preview && olds.Content != news.Content {
-		f, err := os.Create(olds.Path)
+func (*File) Update(ctx context.Context, req infer.UpdateRequest[FileArgs, FileState]) (infer.UpdateResponse[FileState], error) {
+	if !req.Preview && req.Olds.Content != req.News.Content {
+		f, err := os.Create(req.Olds.Path)
 		if err != nil {
-			return FileState{}, err
+			return infer.UpdateResponse[FileState]{}, err
 		}
 		defer f.Close()
-		n, err := f.WriteString(news.Content)
+		n, err := f.WriteString(req.News.Content)
 		if err != nil {
-			return FileState{}, err
+			return infer.UpdateResponse[FileState]{}, err
 		}
-		if n != len(news.Content) {
-			return FileState{}, fmt.Errorf("only wrote %d/%d bytes", n, len(news.Content))
+		if n != len(req.News.Content) {
+			return infer.UpdateResponse[FileState]{}, fmt.Errorf("only wrote %d/%d bytes", n, len(req.News.Content))
 		}
 	}
 
-	return FileState{
-		Path:    news.Path,
-		Force:   news.Force,
-		Content: news.Content,
+	return infer.UpdateResponse[FileState]{
+		Output: FileState{
+			Path:    req.News.Path,
+			Force:   req.News.Force,
+			Content: req.News.Content,
+		},
 	}, nil
 
 }
 
-func (*File) Diff(ctx context.Context, id string, olds FileState, news FileArgs) (p.DiffResponse, error) {
+func (*File) Diff(ctx context.Context, req infer.DiffRequest[FileArgs, FileState]) (infer.DiffResponse, error) {
 	diff := map[string]p.PropertyDiff{}
-	if news.Content != olds.Content {
+	if req.News.Content != req.Olds.Content {
 		diff["content"] = p.PropertyDiff{Kind: p.Update}
 	}
-	if news.Force != olds.Force {
+	if req.News.Force != req.Olds.Force {
 		diff["force"] = p.PropertyDiff{Kind: p.Update}
 	}
-	if news.Path != olds.Path {
+	if req.News.Path != req.Olds.Path {
 		diff["path"] = p.PropertyDiff{Kind: p.UpdateReplace}
 	}
-	return p.DiffResponse{
+	return infer.DiffResponse{
 		DeleteBeforeReplace: true,
 		HasChanges:          len(diff) > 0,
 		DetailedDiff:        diff,
 	}, nil
 }
 
-func (*File) Read(ctx context.Context, id string, inputs FileArgs, state FileState) (canonicalID string, normalizedInputs FileArgs, normalizedState FileState, err error) {
-	path := id
+func (*File) Read(ctx context.Context, req infer.ReadRequest[FileArgs, FileState]) (infer.ReadResponse[FileArgs, FileState], error) {
+	path := req.ID
 	byteContent, err := os.ReadFile(path)
 	if err != nil {
-		return "", FileArgs{}, FileState{}, err
+		return infer.ReadResponse[FileArgs, FileState]{}, err
 	}
 	content := string(byteContent)
-	return path, FileArgs{
+	return infer.ReadResponse[FileArgs, FileState]{
+		ID: path,
+		Inputs: FileArgs{
 			Path:    path,
-			Force:   inputs.Force && state.Force,
+			Force:   req.Inputs.Force && req.State.Force,
 			Content: content,
-		}, FileState{
+		},
+		State: FileState{
 			Path:    path,
-			Force:   inputs.Force && state.Force,
+			Force:   req.Inputs.Force && req.State.Force,
 			Content: content,
-		}, nil
+		},
+	}, nil
 }
 
 func (*File) WireDependencies(f infer.FieldSelector, args *FileArgs, state *FileState) {

--- a/infer/provider_builder_test.go
+++ b/infer/provider_builder_test.go
@@ -52,9 +52,9 @@ type MockResourceArgs struct{}
 type MockResourceState struct{}
 
 func (m MockResource) Create(
-	ctx context.Context, name string, args MockResourceArgs, preview bool,
-) (string, *MockResourceState, error) {
-	return "", &MockResourceState{}, nil
+	ctx context.Context, req CreateRequest[MockResourceArgs],
+) (CreateResponse[MockResourceState], error) {
+	return CreateResponse[MockResourceState]{}, nil
 }
 
 type MockConfig struct{}

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -74,19 +74,25 @@ import (
 //	}
 //
 //	func (*MyResource) Create(
-//		ctx context.Context, name string, inputs MyResourceInputs, preview bool,
-//	) (string, MyResourceOutputs, error) {
-//		id := input.MyString + ".id"
-//		if preview {
-//			return id, MyResourceOutputs{MyResourceInputs: inputs}, nil
+//		ctx context.Context, req infer.CreateRequest[MyResourceInputs],
+//	) (infer.CreateResponse[MyResourceOutputs], error) {
+//		id := req.Inputs.MyString + ".id"
+//		if req.Preview {
+//			return infer.CreateResponse[MyResourceOutputs]{
+//				ID: id,
+//				Output: MyResourceOutputs{MyResourceInputs: inputs},
+//			}, nil
 //		}
 //
-//		result := input.MyString
-//		if inputs.OptionalInt != nil {
-//			result = fmt.Sprintf("%s.%d", result, *inputs.OptionalInt)
+//		result := req.Inputs.MyString
+//		if req.Inputs.OptionalInt != nil {
+//			result = fmt.Sprintf("%s.%d", result, *req.Inputs.OptionalInt)
 //		}
 //
-//		return id, MyResourceOutputs{inputs, result}, nil
+//		return infer.CreateResponse[MyResourceOutputs]{
+//					ID: id,
+//					Output: MyResourceOutputs{inputs, result},
+//				}, nil
 //	}
 type CustomResource[I, O any] interface {
 	// All custom resources must be able to be created.

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -93,8 +93,44 @@ type CustomResource[I, O any] interface {
 	CustomCreate[I, O]
 }
 
+// CreateRequest contains all the parameters for a Create operation
+type CreateRequest[I any] struct {
+	// The resource name.
+	Name string
+	// The resource inputs.
+	Inputs I
+	// Whether this is a preview operation.
+	Preview bool
+}
+
+// CreateResponse contains all the results from a Create operation
+type CreateResponse[O any] struct {
+	// The provider assigned unique ID of the created resource.
+	ID string
+	// The output state of the resource to checkpoint.
+	Output O
+}
+
 type CustomCreate[I, O any] interface {
-	Create(ctx context.Context, name string, inputs I, preview bool) (id string, output O, err error)
+	Create(ctx context.Context, req CreateRequest[I]) (CreateResponse[O], error)
+}
+
+// CheckRequest contains all the parameters for a Check operation.
+type CheckRequest struct {
+	// The resource name.
+	Name string
+	// The old resource inputs.
+	OldInputs resource.PropertyMap
+	// The new resource inputs.
+	NewInputs resource.PropertyMap
+}
+
+// CheckResponse contains all the results from a Check operation
+type CheckResponse[I any] struct {
+	// The validated inputs.
+	Inputs I
+	// Any validation failures encountered.
+	Failures []p.CheckFailure
 }
 
 // CustomCheck describes a resource that understands how to check its inputs.
@@ -109,12 +145,24 @@ type CustomCreate[I, O any] interface {
 // Example:
 // TODO - Maybe a resource that has a regex. We could reject invalid regex before the up
 // actually happens.
+// CheckRequest contains all the parameters for a Check operation
 type CustomCheck[I any] interface {
-	// Maybe oldInputs can be of type I
-	Check(
-		ctx context.Context, name string, oldInputs, newInputs resource.PropertyMap,
-	) (I, []p.CheckFailure, error)
+	// Check validates the inputs for a resource.
+	Check(ctx context.Context, req CheckRequest) (CheckResponse[I], error)
 }
+
+// DiffRequest contains all the parameters for a Diff operation
+type DiffRequest[I, O any] struct {
+	// The resource ID.
+	ID string
+	// The old resource state.
+	Olds O
+	// The new resource inputs.
+	News I
+}
+
+// DiffResponse contains all the results from a Diff operation.
+type DiffResponse = p.DiffResponse
 
 // CustomDiff describes a resource that understands how to diff itself given a new set of
 // inputs.
@@ -125,8 +173,25 @@ type CustomCheck[I any] interface {
 // Example:
 // TODO - Indicate replacements for certain changes but not others.
 type CustomDiff[I, O any] interface {
-	// Maybe oldInputs can be of type I
-	Diff(ctx context.Context, id string, olds O, news I) (p.DiffResponse, error)
+	Diff(ctx context.Context, req DiffRequest[I, O]) (DiffResponse, error)
+}
+
+// UpdateRequest contains all the parameters for an Update operation
+type UpdateRequest[I, O any] struct {
+	// The resource ID.
+	ID string
+	// The old resource state.
+	Olds O
+	// The new resource inputs.
+	News I
+	// Whether this is a preview operation.
+	Preview bool
+}
+
+// UpdateResponse contains all the results from an Update operation
+type UpdateResponse[O any] struct {
+	// The output state of the resource to checkpoint.
+	Output O
 }
 
 // CustomUpdate descibes a resource that can adapt to new inputs with a delete and
@@ -142,7 +207,27 @@ type CustomDiff[I, O any] interface {
 //
 //	TODO
 type CustomUpdate[I, O any] interface {
-	Update(ctx context.Context, id string, olds O, news I, preview bool) (O, error)
+	Update(ctx context.Context, req UpdateRequest[I, O]) (UpdateResponse[O], error)
+}
+
+// ReadRequest contains all the parameters for a Read operation
+type ReadRequest[I, O any] struct {
+	// The resource ID.
+	ID string
+	// The resource inputs.
+	Inputs I
+	// The current resource state.
+	State O
+}
+
+// ReadResponse contains all the results from a Read operation
+type ReadResponse[I, O any] struct {
+	// The canonical ID of the resource.
+	ID string
+	// The normalized inputs.
+	Inputs I
+	// The normalized state.
+	State O
 }
 
 // CustomRead describes resource that can recover its state from the provider.
@@ -154,10 +239,24 @@ type CustomUpdate[I, O any] interface {
 // Example:
 // TODO - Probably something to do with the file system.
 type CustomRead[I, O any] interface {
-	// Read accepts a resource id, and a best guess of the input and output state. It returns
-	// a normalized version of each, assuming it can be recovered.
-	Read(ctx context.Context, id string, inputs I, state O) (
-		canonicalID string, normalizedInputs I, normalizedState O, err error)
+	// Read accepts a resource's current state and returns a normalized version.
+	// It can be used to sync the Pulumi state with the actual resource state.
+
+	Read(ctx context.Context, req ReadRequest[I, O]) (ReadResponse[I, O], error)
+}
+
+// DeleteRequest contains all the parameters for a Delete operation
+type DeleteRequest[O any] struct {
+	// The resource ID.
+	ID string
+	// The current resource state.
+	State O
+}
+
+// DeleteResponse contains all the results from a Delete operation
+type DeleteResponse struct {
+	// Currently empty, but may be extended in the future to return additional
+	// information.
 }
 
 // CustomDelete describes a resource that knows how to delete itself.
@@ -165,7 +264,7 @@ type CustomRead[I, O any] interface {
 // If a resource does not implement Delete, no code will be run on resource deletion.
 type CustomDelete[O any] interface {
 	// Delete is called before a resource is removed from pulumi state.
-	Delete(ctx context.Context, id string, props O) error
+	Delete(ctx context.Context, req DeleteRequest[O]) (DeleteResponse, error)
 }
 
 // StateMigrationFunc represents a stateless mapping from an old state shape to a new
@@ -935,8 +1034,12 @@ func callCustomCheck[T any](
 ) (*ende.Encoder, T, []p.CheckFailure, error) {
 	defaultCheckEncoder := new(defaultCheckEncoderValue)
 	ctx = context.WithValue(ctx, defaultCheckEncoderKey{}, defaultCheckEncoder)
-	i, failures, err := r.Check(ctx, name, olds, news)
-	return defaultCheckEncoder.enc, i, failures, err
+	resp, err := r.Check(ctx, CheckRequest{
+		Name:      name,
+		OldInputs: olds,
+		NewInputs: news,
+	})
+	return defaultCheckEncoder.enc, resp.Inputs, resp.Failures, err
 }
 
 // DefaultCheck verifies that inputs can deserialize cleanly into I. This is the default
@@ -1039,11 +1142,15 @@ func diff[R, I, O any](
 		if err != nil {
 			return p.DiffResponse{}, err
 		}
-		diff, err := r.Diff(ctx, req.ID, olds, news)
+		resp, err := r.Diff(ctx, DiffRequest[I, O]{
+			ID:   req.ID,
+			Olds: olds,
+			News: news,
+		})
 		if err != nil {
 			return p.DiffResponse{}, err
 		}
-		return diff, nil
+		return resp, nil
 	}
 
 	inputProps, err := introspect.FindProperties(typeFor[I]())
@@ -1106,7 +1213,11 @@ func (rc *derivedResourceController[R, I, O]) Create(
 		return p.CreateResponse{}, fmt.Errorf("invalid inputs: %w", err)
 	}
 
-	id, o, err := (*r).Create(ctx, req.Urn.Name(), input, req.Preview)
+	inferResp, err := (*r).Create(ctx, CreateRequest[I]{
+		Name:    req.Urn.Name(),
+		Inputs:  input,
+		Preview: req.Preview,
+	})
 	if initFailed := (ResourceInitFailedError{}); errors.As(err, &initFailed) {
 		defer func(createErr error) {
 			// If there was an error, it indicates a problem with serializing
@@ -1131,23 +1242,23 @@ func (rc *derivedResourceController[R, I, O]) Create(
 		return p.CreateResponse{}, err
 	}
 
-	if id == "" && !req.Preview {
+	if inferResp.ID == "" && !req.Preview {
 		return p.CreateResponse{}, ProviderErrorf("'%s' was created without an id", req.Urn)
 	}
 
-	m, err := encoder.AllowUnknown(req.Preview).Encode(o)
+	m, err := encoder.AllowUnknown(req.Preview).Encode(inferResp.Output)
 	if err != nil {
 		return p.CreateResponse{}, fmt.Errorf("encoding resource properties: %w", err)
 	}
 
-	setDeps, err := getDependencies(r, &input, &o, true /* isCreate */, req.Preview)
+	setDeps, err := getDependencies(r, &input, &inferResp.Output, true /* isCreate */, req.Preview)
 	if err != nil {
 		return p.CreateResponse{}, err
 	}
 	setDeps(nil, req.Properties, m)
 
 	return p.CreateResponse{
-		ID:         id,
+		ID:         inferResp.ID,
 		Properties: m,
 	}, err
 }
@@ -1201,7 +1312,11 @@ func (rc *derivedResourceController[R, I, O]) Read(
 			Inputs:     req.Inputs,
 		}, nil
 	}
-	id, inputs, state, err := read.Read(ctx, req.ID, inputs, state)
+	inferResp, err := read.Read(ctx, ReadRequest[I, O]{
+		ID:     req.ID,
+		Inputs: inputs,
+		State:  state,
+	})
 	if initFailed := (ResourceInitFailedError{}); errors.As(err, &initFailed) {
 		defer func(readErr error) {
 			// If there was an error, it indicates a problem with serializing
@@ -1226,17 +1341,17 @@ func (rc *derivedResourceController[R, I, O]) Read(
 		return p.ReadResponse{}, err
 	}
 
-	i, err := inputEncoder.Encode(inputs)
+	i, err := inputEncoder.Encode(inferResp.Inputs)
 	if err != nil {
 		return p.ReadResponse{}, err
 	}
-	s, err := stateEncoder.Encode(state)
+	s, err := stateEncoder.Encode(inferResp.State)
 	if err != nil {
 		return p.ReadResponse{}, err
 	}
 
 	return p.ReadResponse{
-		ID:         id,
+		ID:         inferResp.ID,
 		Properties: s,
 		Inputs:     i,
 	}, nil
@@ -1263,7 +1378,12 @@ func (rc *derivedResourceController[R, I, O]) Update(
 	if err != nil {
 		return p.UpdateResponse{}, err
 	}
-	o, err := update.Update(ctx, req.ID, olds, news, req.Preview)
+	inferResp, err := update.Update(ctx, UpdateRequest[I, O]{
+		ID:      req.ID,
+		Olds:    olds,
+		News:    news,
+		Preview: req.Preview,
+	})
 	if initFailed := (ResourceInitFailedError{}); errors.As(err, &initFailed) {
 		defer func(updateErr error) {
 			// If there was an error, it indicates a problem with serializing
@@ -1289,11 +1409,11 @@ func (rc *derivedResourceController[R, I, O]) Update(
 	if err != nil {
 		return p.UpdateResponse{}, err
 	}
-	m, err := encoder.AllowUnknown(req.Preview).Encode(o)
+	m, err := encoder.AllowUnknown(req.Preview).Encode(inferResp.Output)
 	if err != nil {
 		return p.UpdateResponse{}, err
 	}
-	setDeps, err := getDependencies(r, &news, &o, false /* isCreate */, req.Preview)
+	setDeps, err := getDependencies(r, &news, &inferResp.Output, false /* isCreate */, req.Preview)
 	if err != nil {
 		return p.UpdateResponse{}, err
 	}
@@ -1312,7 +1432,11 @@ func (rc *derivedResourceController[R, I, O]) Delete(ctx context.Context, req p.
 		if err != nil {
 			return err
 		}
-		return del.Delete(ctx, req.ID, olds)
+		_, err = del.Delete(ctx, DeleteRequest[O]{
+			ID:    req.ID,
+			State: olds,
+		})
+		return err
 	}
 	return nil
 }

--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -493,9 +493,9 @@ func (c *checkResource) Annotate(a Annotator) {
 
 type checkResourceOutput struct{}
 
-func (c checkResource) Create(context.Context, string, checkResource, bool,
-) (id string, output checkResourceOutput, err error) {
-	return "", checkResourceOutput{}, nil
+func (c checkResource) Create(context.Context, CreateRequest[checkResource],
+) (resp CreateResponse[checkResourceOutput], err error) {
+	return resp, nil
 }
 
 func TestCheck(t *testing.T) {

--- a/infer/tests/migrate_test.go
+++ b/infer/tests/migrate_test.go
@@ -247,29 +247,31 @@ func TestMigrateRead(t *testing.T) {
 	})
 }
 
-func (*MigrateR) Create(context.Context, string, MigrateStateInput, bool) (string, MigrateStateV2, error) {
+func (*MigrateR) Create(_ context.Context,
+	req infer.CreateRequest[MigrateStateInput]) (infer.CreateResponse[MigrateStateV2], error) {
 	panic("CANNOT CREATE; ONLY MIGRATE")
 }
 
 // Just return the old state so it is visible to tests.
 func (*MigrateR) Update(
-	_ context.Context, _ string, s MigrateStateV2, _ MigrateStateInput, _ bool,
-) (MigrateStateV2, error) {
-	return s, nil
+	_ context.Context, req infer.UpdateRequest[MigrateStateInput, MigrateStateV2],
+) (infer.UpdateResponse[MigrateStateV2], error) {
+	return infer.UpdateResponse[MigrateStateV2]{Output: req.Olds}, nil
 }
 
 func (*MigrateR) Read(
-	_ context.Context, id string, input MigrateStateInput, output MigrateStateV2,
-) (string, MigrateStateInput, MigrateStateV2, error) {
-	return id, input, output, nil
+	_ context.Context, req infer.ReadRequest[MigrateStateInput, MigrateStateV2],
+) (infer.ReadResponse[MigrateStateInput, MigrateStateV2], error) {
+	return infer.ReadResponse[MigrateStateInput, MigrateStateV2](req), nil
 }
 
-func (*MigrateR) Delete(_ context.Context, _ string, s MigrateStateV2) error {
-	return viaError[MigrateStateV2]{s}
+func (*MigrateR) Delete(_ context.Context, req infer.DeleteRequest[MigrateStateV2]) (infer.DeleteResponse, error) {
+	return infer.DeleteResponse{}, viaError[MigrateStateV2]{req.State}
 }
 
-func (*MigrateR) Diff(_ context.Context, _ string, s MigrateStateV2, _ MigrateStateInput) (p.DiffResponse, error) {
-	return p.DiffResponse{}, viaError[MigrateStateV2]{s}
+func (*MigrateR) Diff(_ context.Context,
+	req infer.DiffRequest[MigrateStateInput, MigrateStateV2]) (infer.DiffResponse, error) {
+	return infer.DiffResponse{}, viaError[MigrateStateV2]{req.Olds}
 }
 
 type viaError[T any] struct{ t T }

--- a/infer/tests/token_test.go
+++ b/infer/tests/token_test.go
@@ -34,8 +34,8 @@ type CustomToken struct{}
 func (c *CustomToken) Annotate(a infer.Annotator) { a.SetToken("overwritten", "Tk") }
 
 func (*CustomToken) Create(
-	context.Context, string, TokenArgs, bool,
-) (string, TokenResult, error) {
+	context.Context, infer.CreateRequest[TokenArgs],
+) (infer.CreateResponse[TokenResult], error) {
 	panic("unimplemented")
 }
 

--- a/infer/tests/types_test.go
+++ b/infer/tests/types_test.go
@@ -33,10 +33,13 @@ import (
 type HasAssets struct{}
 
 func (*HasAssets) Create(
-	_ context.Context, _ string, inputs HasAssetsInputs, _ bool,
-) (string, HasAssetsOutputs, error) {
-	state := HasAssetsOutputs{HasAssetsInputs: inputs}
-	return "id", state, nil
+	_ context.Context, req infer.CreateRequest[HasAssetsInputs],
+) (infer.CreateResponse[HasAssetsOutputs], error) {
+	state := HasAssetsOutputs{HasAssetsInputs: req.Inputs}
+	return infer.CreateResponse[HasAssetsOutputs]{
+		ID:     "id",
+		Output: state,
+	}, nil
 }
 
 // RandomType serves as a control that types that are not assets do make it into the schema.

--- a/tests/grpc/asset_test.go
+++ b/tests/grpc/asset_test.go
@@ -79,6 +79,7 @@ type AssetInputs struct {
 
 type AssetState struct{}
 
-func (*A) Create(ctx context.Context, name string, input AssetInputs, preview bool) (id string, output AssetState, err error) {
+func (*A) Create(ctx context.Context,
+	_ infer.CreateRequest[AssetInputs]) (_ infer.CreateResponse[AssetState], err error) {
 	panic("THE CURRENT TEST ONLY TESTS 'CHECK'")
 }

--- a/tests/grpc/config/provider/provider.go
+++ b/tests/grpc/config/provider/provider.go
@@ -72,8 +72,12 @@ type GetState struct {
 	Config string `pulumi:"config"`
 }
 
-func (*Get) Create(ctx context.Context, name string, input GetArgs, preview bool) (string, GetState, error) {
+func (*Get) Create(ctx context.Context,
+	req infer.CreateRequest[GetArgs]) (infer.CreateResponse[GetState], error) {
 	config := infer.GetConfig[Config](ctx)
 	bytes, err := json.Marshal(&config)
-	return name, GetState{Config: string(bytes)}, err
+	return infer.CreateResponse[GetState]{
+		ID:     req.Name,
+		Output: GetState{Config: string(bytes)},
+	}, err
 }

--- a/tests/resource_test.go
+++ b/tests/resource_test.go
@@ -36,7 +36,7 @@ type resInput struct {
 
 type resOutput struct{ resInput }
 
-func (c res) Create(context.Context, string, resInput, bool) (string, resOutput, error) {
+func (c res) Create(context.Context, infer.CreateRequest[resInput]) (infer.CreateResponse[resOutput], error) {
 	panic("unimplemented")
 }
 


### PR DESCRIPTION
**Description:**  
This PR updates the custom `Create`, `Read`, `Update`, `Delete`, `Diff`, and `Check` function interfaces in the `infer` package to use structured request/response types instead of relying on function arguments and return values.

**Why this matters:**  
By adopting request/response structs, we improve long-term maintainability and extensibility for users of this package. Future enhancements—such as additional input/output fields—can be introduced without breaking changes to function signatures.

⚠️ **Breaking Change**:
This refactor introduces a breaking change for consumers of the `infer` package. Implementations of the `CustomCreate`, `CustomRead`, `CustomUpdate`, `CustomDelete`, `CustomDiff`, and `CustomCheck` interfaces will need to be updated to the new request/response-style signatures.

**What’s included:**  
- Refactored all relevant function signatures to use request/response structs.  
- Updated all usages and associated tests accordingly.  
- Updated `infer` package documentation to reflect the new API style.  
- Code changes are organized in reviewable commits.  
- No behavioral or logic changes are introduced.

**Before vs. After Example:**

**Before:**
```go
type CustomCreate[I, O any] interface {
	Create(ctx context.Context, name string, inputs I, preview bool) (id string, output O, err error)
}
```

**After:**
```go
type CreateRequest[I any] struct {
	Name    string
	Inputs  I
	Preview bool
}

type CreateResponse[O any] struct {
	ID     string
	Output O
}

type CustomCreate[I, O any] interface {
	Create(ctx context.Context, req CreateRequest[I]) (CreateResponse[O], error)
}
```

**Note:**  
This is a structural refactor only. No new behavior or logic is introduced.

Closes: #302