### PR TITLE
refactor(infer): switch to request/response structs for call interface

### DIFF
--- a/examples/credentials/main.go
+++ b/examples/credentials/main.go
@@ -118,10 +118,12 @@ func (*User) Diff(ctx context.Context, req infer.DiffRequest[UserArgs, UserState
 
 type Sign struct{}
 
-func (Sign) Call(ctx context.Context, args SignArgs) (SignRes, error) {
+func (Sign) Call(ctx context.Context, req infer.FunctionRequest[SignArgs]) (infer.FunctionResponse[SignRes], error) {
 	config := infer.GetConfig[Config](ctx)
-	return SignRes{
-		Out: fmt.Sprintf("%s by %s", args.Message, config.User),
+	return infer.FunctionResponse[SignRes]{
+		Output: SignRes{
+			Out: fmt.Sprintf("%s by %s", req.Input.Message, config.User),
+		},
 	}, nil
 }
 

--- a/examples/str/main.go
+++ b/examples/str/main.go
@@ -37,8 +37,10 @@ func provider() p.Provider {
 
 type Replace struct{}
 
-func (Replace) Call(ctx context.Context, args ReplaceArgs) (Ret, error) {
-	return Ret{strings.ReplaceAll(args.S, args.Old, args.New)}, nil
+func (Replace) Call(ctx context.Context, req infer.FunctionRequest[ReplaceArgs]) (infer.FunctionResponse[Ret], error) {
+	return infer.FunctionResponse[Ret]{
+		Output: Ret{strings.ReplaceAll(req.Input.S, req.Input.Old, req.Input.New)},
+	}, nil
 }
 
 func (r *Replace) Annotate(a infer.Annotator) {
@@ -74,9 +76,9 @@ func (p *Print) Annotate(a infer.Annotator) {
 
 type Empty struct{}
 
-func (Print) Call(ctx context.Context, args In) (Empty, error) {
-	fmt.Print(args.S)
-	return Empty{}, nil
+func (Print) Call(ctx context.Context, req infer.FunctionRequest[In]) (infer.FunctionResponse[Empty], error) {
+	fmt.Print(req.Input.S)
+	return infer.FunctionResponse[Empty]{}, nil
 }
 
 type In struct {
@@ -85,8 +87,10 @@ type In struct {
 
 type GiveMeAString struct{}
 
-func (GiveMeAString) Call(ctx context.Context, args Empty) (Ret, error) {
-	return Ret{"A string"}, nil
+func (GiveMeAString) Call(ctx context.Context, _ infer.FunctionRequest[Empty]) (infer.FunctionResponse[Ret], error) {
+	return infer.FunctionResponse[Ret]{
+		Output: Ret{"A string"},
+	}, nil
 }
 
 func (g *GiveMeAString) Annotate(a infer.Annotator) {

--- a/examples/str/regex/regex.go
+++ b/examples/str/regex/regex.go
@@ -9,13 +9,15 @@ import (
 
 type Replace struct{}
 
-func (Replace) Call(_ context.Context, args ReplaceArgs) (Ret, error) {
-	r, err := regexp.Compile(args.Pattern)
+func (Replace) Call(_ context.Context, req infer.FunctionRequest[ReplaceArgs]) (infer.FunctionResponse[Ret], error) {
+	r, err := regexp.Compile(req.Input.Pattern)
 	if err != nil {
-		return Ret{}, err
+		return infer.FunctionResponse[Ret]{}, err
 	}
-	result := r.ReplaceAllLiteralString(args.S, args.New)
-	return Ret{result}, nil
+	result := r.ReplaceAllLiteralString(req.Input.S, req.Input.New)
+	return infer.FunctionResponse[Ret]{
+		Output: Ret{result},
+	}, nil
 }
 
 func (r *Replace) Annotate(a infer.Annotator) {

--- a/infer/provider_builder_test.go
+++ b/infer/provider_builder_test.go
@@ -70,8 +70,10 @@ type MockFunction struct{}
 type MockFunctionArgs struct{}
 type MockFunctionResult struct{}
 
-func (mf MockFunction) Call(ctx context.Context, args MockFunctionArgs) (MockFunctionResult, error) {
-	return MockFunctionResult{}, nil
+func (mf MockFunction) Call(
+	ctx context.Context,
+	req FunctionRequest[MockFunctionArgs]) (FunctionResponse[MockFunctionResult], error) {
+	return FunctionResponse[MockFunctionResult]{}, nil
 }
 
 func TestNewDefaultProvider(t *testing.T) {

--- a/infer/tests/provider_test.go
+++ b/infer/tests/provider_test.go
@@ -399,8 +399,12 @@ type JoinResult struct {
 	Result string `pulumi:"result"`
 }
 
-func (*GetJoin) Call(ctx context.Context, args JoinArgs) (JoinResult, error) {
-	return JoinResult{strings.Join(args.Elems, *args.Sep)}, nil
+func (*GetJoin) Call(
+	ctx context.Context,
+	req infer.FunctionRequest[JoinArgs]) (infer.FunctionResponse[JoinResult], error) {
+	return infer.FunctionResponse[JoinResult]{
+		Output: JoinResult{strings.Join(req.Input.Elems, *req.Input.Sep)},
+	}, nil
 }
 
 type ConfigCustom struct {

--- a/infer/tests/token_test.go
+++ b/infer/tests/token_test.go
@@ -63,7 +63,9 @@ type FnToken struct{}
 
 func (c *FnToken) Annotate(a infer.Annotator) { a.SetToken("fn", "TK") }
 
-func (*FnToken) Call(ctx context.Context, input TokenArgs) (output TokenResult, err error) {
+func (*FnToken) Call(
+	ctx context.Context,
+	_ infer.FunctionRequest[TokenArgs]) (output infer.FunctionResponse[TokenResult], err error) {
 	panic("unimplemented")
 }
 

--- a/tests/invoke_test.go
+++ b/tests/invoke_test.go
@@ -38,9 +38,11 @@ type invOutput struct {
 	Out string `pulumi:"out" provider:"secret"`
 }
 
-func (inv) Call(ctx context.Context, args invInput) (invOutput, error) {
-	return invOutput{
-		Out: args.Field + "-secret",
+func (inv) Call(ctx context.Context, req infer.FunctionRequest[invInput]) (infer.FunctionResponse[invOutput], error) {
+	return infer.FunctionResponse[invOutput]{
+		Output: invOutput{
+			Out: req.Input.Field + "-secret",
+		},
 	}, nil
 }
 


### PR DESCRIPTION
**Description:**  
This PR updates the custom `Call` function interface in the `infer` package to use structured request/response types instead of relying on function arguments and return values.

This change is aligned with #325 and targets the `Function` resource, instead of custom resources.

⚠️ **Breaking Change**:
This refactor introduces a breaking change for consumers of the `infer` package. Implementations of the `CustomCall` interface will need to be updated to the new request/response-style signatures.

**What’s included:**  
- Refactored all relevant function signatures to use request/response structs.  
- Updated all usages and associated tests accordingly.  
- Updated `infer` package documentation to reflect the new API style.  
- Code changes are organized in reviewable commits.  
- No behavioral or logic changes are introduced.

**Before vs. After Example:**

**Before:**
```go
type Fn[I any, O any] interface {
	// A function is a mapping from `I` to `O`.
	Call(ctx context.Context, args I) (output O, err error)
}
```

**After:**
```go
// FunctionRequest wraps the input type for a function call
type FunctionRequest[I any] struct {
	// Input contains the function input arguments.
	Input I
}

// FunctionResponse wraps the output type for a function call
type FunctionResponse[O any] struct {
	// Output contains the function result.
	Output O
}

// Fn is a function (also called fnvoke) inferred from code. `I` is the function input,
// and `O` is the function output. Both must be structs.
type Fn[I any, O any] interface {
	// A function is a mapping from `I` to `O`.
	Call(ctx context.Context, req FunctionRequest[I]) (resp FunctionResponse[O], err error)
}
```

**Note:**  
This is a structural refactor only. No new behavior or logic is introduced.

Closes: #302