### PR TITLE
fix: error on schemagen when using resource.Asset or resource.Archive

### DIFF
--- a/infer/function.go
+++ b/infer/function.go
@@ -122,7 +122,7 @@ func (*derivedInvokeController[F, I, O]) GetSchema(reg schema.RegisterDerivative
 
 func objectSchema(t reflect.Type) (*pschema.ObjectTypeSpec, error) {
 	descriptions := getAnnotated(t)
-	props, required, err := propertyListFromType(t, false)
+	props, required, err := propertyListFromType(t, false, inputType)
 	if err != nil {
 		return nil, fmt.Errorf("could not serialize input type %s: %w", t, err)
 	}

--- a/infer/schema.go
+++ b/infer/schema.go
@@ -132,10 +132,12 @@ func serializeTypeAsPropertyType(
 	// We will returrn an error if resource.Asset or resource.Archive is used directly for an input.
 	// pulumi/pulumi-go-provider#243
 	if propType == inputType && t == reflect.TypeOf(resource.Asset{}) {
-		return schema.TypeSpec{}, fmt.Errorf("resource.Asset is not a valid input type, please use types.AssetOrArchive instead")
+		return schema.TypeSpec{},
+			fmt.Errorf("resource.Asset is not a valid input type, please use types.AssetOrArchive instead")
 	}
 	if propType == inputType && t == reflect.TypeOf(resource.Archive{}) {
-		return schema.TypeSpec{}, fmt.Errorf("resource.Archive is not a valid input type, please use types.AssetOrArchive instead")
+		return schema.TypeSpec{},
+			fmt.Errorf("resource.Archive is not a valid input type, please use types.AssetOrArchive instead")
 	}
 
 	if t == reflect.TypeOf(resource.Asset{}) {

--- a/infer/tests/types_test.go
+++ b/infer/tests/types_test.go
@@ -16,7 +16,6 @@ package tests
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/blang/semver"
@@ -26,7 +25,6 @@ import (
 	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi-go-provider/infer/types"
 	"github.com/pulumi/pulumi-go-provider/integration"
-	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
@@ -71,13 +69,7 @@ func TestOmittingAssetTypes(t *testing.T) {
 	p := infer.Provider(providerOpts)
 	server := integration.NewServer("test", semver.MustParse("1.0.0"), p)
 
-	schemaResp, err := server.GetSchema(pgp.GetSchemaRequest{Version: 1})
-	require.NoError(t, err)
-
-	var spec pschema.PackageSpec
-	require.NoError(t, json.Unmarshal([]byte(schemaResp.Schema), &spec))
-
-	require.Len(t, spec.Types, 1)
-	require.Contains(t, spec.Types, "test:tests:RandomType")
-	// That's all - does not contain any asset types.
+	_, err := server.GetSchema(pgp.GetSchemaRequest{Version: 1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "is not a valid input type, please use types.AssetOrArchive instead")
 }

--- a/infer/types.go
+++ b/infer/types.go
@@ -29,6 +29,14 @@ import (
 	"github.com/pulumi/pulumi-go-provider/middleware/schema"
 )
 
+// A propertyType is used to determine if a property is an input or output property.
+type propertyType int
+
+const (
+	inputType propertyType = iota
+	outputType
+)
+
 // EnumKind is the set of allowed underlying values for [Enum].
 type EnumKind interface {
 	~string | ~float64 | ~bool | ~int


### PR DESCRIPTION
**Description:**  
This PR introduces an explicit error during schema generation when `resource.Asset` or `resource.Archive` is used as the type for an input property. Provider authors should use `types.AssetOrArchive` instead, which correctly supports both types in input scenarios.

**Breaking Change**  
Input properties previously defined as `resource.Asset` or `resource.Archive` must now use `types.AssetOrArchive`. This ensures compatibility with schema generation and SDK generation workflows.

**What’s included:**  
- Added validation to schemagen to error on invalid input types  
- Updated integration tests to reflect and test this behavior

Closes: #243