### PR TITLE
fix: error during schemagen when marking a field as secret in pulumi tag

### DIFF
--- a/internal/introspect/introspect.go
+++ b/internal/introspect/introspect.go
@@ -166,6 +166,15 @@ func ParseTag(field reflect.StructField) (FieldTag, error) {
 		}
 	}
 
+	// Determine if the provider author had accidentally marked the field as secret
+	// in the `pulumi` namespace. We need to error out if this is the case, as it will
+	// lead to a Pulumi program runtime panic.
+	// pulumi/pulumi-go-provider#192
+	if pulumi["secret"] {
+		return FieldTag{},
+			fmt.Errorf("`marking a field as secret in the `pulumi` tag namespace is not allowed, use `provider` instead")
+	}
+
 	return FieldTag{
 		Name:             name,
 		Optional:         pulumi["optional"],

--- a/internal/introspect/introspect_test.go
+++ b/internal/introspect/introspect_test.go
@@ -29,10 +29,11 @@ import (
 )
 
 type MyStruct struct {
-	Foo     string `pulumi:"foo,optional" provider:"secret,output"`
-	Bar     int    `provider:"secret"`
-	Fizz    *int   `pulumi:"fizz"`
-	ExtType string `pulumi:"typ" provider:"type=example@1.2.3:m1:m2"`
+	Foo         string `pulumi:"foo,optional" provider:"secret,output"`
+	Bar         int    `provider:"secret"`
+	Fizz        *int   `pulumi:"fizz"`
+	ExtType     string `pulumi:"typ" provider:"type=example@1.2.3:m1:m2"`
+	WrongSecret string `pulumi:"wrongSecret,secret"`
 }
 
 func (m *MyStruct) Annotate(a infer.Annotator) {
@@ -82,6 +83,10 @@ func TestParseTag(t *testing.T) {
 					Name:    "m2",
 				},
 			},
+		},
+		{
+			Field: "WrongSecret",
+			Error: "`marking a field as secret in the `pulumi` tag namespace is not allowed, use `provider` instead",
 		},
 	}
 


### PR DESCRIPTION
**Description:**
This PR improves validation of struct field tags by catching cases where `provider`-specific tag parts (like `secret`) are mistakenly placed in the `pulumi` tag. For example, the following struct tag:

```go
type myResource struct {
    myField `pulumi:"myField,optional,secret"`
}
```

should instead be written as:

```go
type myResource struct {
    myField `pulumi:"myField,optional" provider:"secret"`
}
```

Previously, this would compile and generate SDKs correctly but would lead to Pulumi program runtime panics like:

```
panic: fatal: An assertion has failed: Unrecognized tagpart on field Foo.Token: secret
```

**What’s included:**
- We now validate tag parts during schema generation and return a clear error if an invalid tag is used under the `pulumi` namespace.
- This helps provider authors catch mistakes early and avoids confusing panics for provider users later.

Closes: #192