### PR TITLE
[tests] bind an component input property to the child

### DIFF
--- a/tests/grpc/call_consumer/Pulumi.yaml
+++ b/tests/grpc/call_consumer/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: "call_consumer"
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 plugins:
   providers:
     - name: test

--- a/tests/grpc/call_consumer/__main__.py
+++ b/tests/grpc/call_consumer/__main__.py
@@ -4,6 +4,7 @@ import pulumi
 import pulumi_test as test
 
 c = test.Component(resource_name="my-component", my_input="foo")
+pulumi.export("my_output", c.my_output)
 
 result = c.my_method(arg1="bar")
 pulumi.export("resp1", result.resp1)

--- a/tests/grpc/provider/main.go
+++ b/tests/grpc/provider/main.go
@@ -52,7 +52,9 @@ func main() {
 					return nil, err
 				}
 
-				pet, err := random.NewRandomPet(ctx, "pet", &random.RandomPetArgs{}, pulumi.Parent(r))
+				pet, err := random.NewRandomPet(ctx, "pet", &random.RandomPetArgs{
+					Prefix: r.MyInput,
+				}, pulumi.Parent(r))
 				if err != nil {
 					return nil, err
 				}

--- a/tests/grpc/provider/main.go
+++ b/tests/grpc/provider/main.go
@@ -42,7 +42,7 @@ func main() {
 				ctx *pulumi.Context, typ, name string, inputs comProvider.ConstructInputs, opts pulumi.ResourceOption,
 			) (*comProvider.ConstructResult, error) {
 				r := new(testComponent)
-				err := inputs.CopyTo(r)
+				err := inputs.CopyTo(&r.testComponentArgs)
 				if err != nil {
 					return nil, err
 				}
@@ -113,9 +113,13 @@ func main() {
 	}
 }
 
+type testComponentArgs struct {
+	MyInput pulumi.StringPtrOutput `pulumi:"myInput"`
+}
+
 type testComponent struct {
 	pulumi.ResourceState
-	MyInput  pulumi.StringPtrOutput `pulumi:"myInput"`
+	testComponentArgs
 	MyOutput pulumi.StringPtrOutput `pulumi:"myOutput"`
 }
 


### PR DESCRIPTION
Relates to https://github.com/pulumi/pulumi-go-provider/issues/337

This PR intends to test whether a component may use its inputs to set input values on its children.  In this case, we use the `MyInput` argument of `testComponent` as the prefix of the encapsulated `RandomPet`.

When one binds the `Prefix` of `RandomPet` to `MyInput`, the system appears to lock up unless the args are split out into a separate struct. For this reason, we introduce `testComponentArgs`.

To improve the usability of call_consumer as a standalone program, we add some runtime options and make some handy exports.


