### PR TITLE
Rewrite Call handling to use Host interface

### DIFF
--- a/integration/provider_linked.go
+++ b/integration/provider_linked.go
@@ -30,3 +30,9 @@ func linkedConstructRequestToRPC(req *p.ConstructRequest, marshal propertyToRPC)
 
 //go:linkname linkedConstructResponseFromRPC github.com/pulumi/pulumi-go-provider.linkedConstructResponseFromRPC
 func linkedConstructResponseFromRPC(resp *rpc.ConstructResponse) (p.ConstructResponse, error)
+
+//go:linkname linkedCallRequestToRPC github.com/pulumi/pulumi-go-provider.linkedCallRequestToRPC
+func linkedCallRequestToRPC(req *p.CallRequest, marshal propertyToRPC) *rpc.CallRequest
+
+//go:linkname linkedCallResponseFromRPC github.com/pulumi/pulumi-go-provider.linkedCallResponseFromRPC
+func linkedCallResponseFromRPC(resp *rpc.CallResponse) (p.CallResponse, error)

--- a/middleware/cancel/cancel.go
+++ b/middleware/cancel/cancel.go
@@ -90,6 +90,7 @@ func Wrap(provider p.Provider) p.Provider {
 		return r.Timeout
 	})
 	wrapper.Construct = setCancel2(cancel, provider.Construct, nil)
+	wrapper.Call = setCancel2(cancel, provider.Call, nil)
 	return wrapper
 }
 

--- a/middleware/context/context.go
+++ b/middleware/context/context.go
@@ -42,6 +42,7 @@ func Wrap(provider p.Provider, wrapper Wrapper) p.Provider {
 		Update:      delegateIO(wrapper, provider.Update),
 		Delete:      delegateI(wrapper, provider.Delete),
 		Construct:   delegateIO(wrapper, provider.Construct),
+		Call:        delegateIO(wrapper, provider.Call),
 	}
 }
 

--- a/middleware/rpc/provider_linked.go
+++ b/middleware/rpc/provider_linked.go
@@ -30,3 +30,9 @@ func linkedConstructRequestToRPC(req *p.ConstructRequest, marshal propertyToRPC)
 
 //go:linkname linkedConstructResponseFromRPC github.com/pulumi/pulumi-go-provider.linkedConstructResponseFromRPC
 func linkedConstructResponseFromRPC(resp *rpc.ConstructResponse) (p.ConstructResponse, error)
+
+//go:linkname linkedCallRequestToRPC github.com/pulumi/pulumi-go-provider.linkedCallRequestToRPC
+func linkedCallRequestToRPC(req *p.CallRequest, marshal propertyToRPC) *rpc.CallRequest
+
+//go:linkname linkedCallResponseFromRPC github.com/pulumi/pulumi-go-provider.linkedCallResponseFromRPC
+func linkedCallResponseFromRPC(resp *rpc.CallResponse) (p.CallResponse, error)

--- a/program.go
+++ b/program.go
@@ -34,3 +34,15 @@ func ProgramConstruct(ctx context.Context, req ConstructRequest, constructF comP
 	}
 	return host.Construct(ctx, req, constructF)
 }
+
+// ProgramCall is a convenience function for a Provider to implement [Provider.Call] using the Pulumi Go SDK.
+//
+// Call this method from within your [Provider.Call] method to transition into a Go SDK program context.
+func ProgramCall(ctx context.Context, req CallRequest, callF comProvider.CallFunc,
+) (CallResponse, error) {
+	host := GetHost(ctx)
+	if host == nil {
+		return CallResponse{}, ErrNoHost
+	}
+	return host.Call(ctx, req, callF)
+}

--- a/provider.go
+++ b/provider.go
@@ -858,7 +858,8 @@ type CallRequest struct {
 	Organization string
 }
 
-func newCallRequest(req *rpc.CallRequest, unmarshal rpcToProperty) (CallRequest, error) {
+func newCallRequest(req *rpc.CallRequest,
+	unmarshal func(s *structpb.Struct) (presource.PropertyMap, error)) (CallRequest, error) {
 	args, err := unmarshal(req.GetArgs())
 	if err != nil {
 		return CallRequest{}, fmt.Errorf("unable to convert args into a property map: %w", err)

--- a/provider.go
+++ b/provider.go
@@ -780,6 +780,9 @@ func (p *provider) Call(ctx context.Context, req *rpc.CallRequest) (*rpc.CallRes
 	if err != nil {
 		return nil, err
 	}
+
+	contract.Assertf(req.AcceptsOutputValues, "The caller must accept output values")
+
 	resp, err := p.client.Call(ctx, r)
 	if err != nil {
 		return nil, err

--- a/provider.go
+++ b/provider.go
@@ -38,10 +38,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	comProvider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
 	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
@@ -777,58 +775,24 @@ func (p *provider) Invoke(ctx context.Context, req *rpc.InvokeRequest) (*rpc.Inv
 }
 
 func (p *provider) Call(ctx context.Context, req *rpc.CallRequest) (*rpc.CallResponse, error) {
-
-	configPropertyMap := make(presource.PropertyMap, len(req.GetConfig()))
-	for k, v := range req.GetConfig() {
-		configPropertyMap[presource.PropertyKey(k)] = presource.NewProperty(v)
-	}
-	pulumiContext, err := pulumi.NewContext(ctx, pulumi.RunInfo{
-		Project:           req.GetProject(),
-		Stack:             req.GetStack(),
-		Config:            req.GetConfig(),
-		ConfigSecretKeys:  req.GetConfigSecretKeys(),
-		ConfigPropertyMap: configPropertyMap,
-		Parallel:          req.GetParallel(),
-		DryRun:            req.GetDryRun(),
-		MonitorAddr:       req.GetMonitorEndpoint(),
-		Organization:      req.GetOrganization(),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to build pulumi.Context: %w", err)
-	}
-
-	args, err := p.getMap(req.GetArgs())
-	if err != nil {
-		return nil, fmt.Errorf("unable to convert args into a property map: %w", err)
-	}
-
-	resp, err := p.client.Call(ctx, CallRequest{
-		Tok:     tokens.ModuleMember(req.GetTok()),
-		Args:    args,
-		Context: pulumiContext,
-	})
+	ctx = p.ctx(ctx, "")
+	r, err := newCallRequest(req, p.getMap)
 	if err != nil {
 		return nil, err
 	}
-
-	// [comProvider.Call] acts as a synchronization point, ensuring that all actions
-	// within p.client.Call are witnessed before Call returns.
-	//
-	// Eventually, [comProvider.Call] results in a call to [pulumi.Context.wait],
-	// which is what forces the synchronization.
-	var engineConn *grpc.ClientConn
-	if p.host != nil {
-		engineConn = p.host.EngineConn()
-	}
-	_, err = comProvider.Call(ctx, req, engineConn,
-		func(ctx *pulumi.Context, tok string, args comProvider.CallArgs) (*comProvider.CallResult, error) {
-			return &comProvider.CallResult{}, nil
-		})
+	resp, err := p.client.Call(ctx, r)
 	if err != nil {
 		return nil, err
 	}
 
 	returnDependencies := map[string]*rpc.CallResponse_ReturnDependencies{}
+	for name, v := range resp.ReturnDependencies {
+		var urns []string
+		for _, dep := range v {
+			urns = append(urns, string(dep))
+		}
+		returnDependencies[string(name)] = &rpc.CallResponse_ReturnDependencies{Urns: urns}
+	}
 	for name, v := range resp.Return {
 		var urns []string
 		resourcex.Walk(v, func(v presource.PropertyValue, state resourcex.WalkState) {
@@ -840,7 +804,9 @@ func (p *provider) Call(ctx context.Context, req *rpc.CallRequest) (*rpc.CallRes
 			}
 		})
 
-		returnDependencies[string(name)] = &rpc.CallResponse_ReturnDependencies{Urns: urns}
+		if _, ok := returnDependencies[string(name)]; !ok {
+			returnDependencies[string(name)] = &rpc.CallResponse_ReturnDependencies{Urns: urns}
+		}
 	}
 
 	_return, err := p.asStruct(resp.Return)
@@ -855,13 +821,126 @@ func (p *provider) Call(ctx context.Context, req *rpc.CallRequest) (*rpc.CallRes
 	}, nil
 }
 
+func (h *host) Call(ctx context.Context, req CallRequest, call comProvider.CallFunc,
+) (CallResponse, error) {
+	r, err := comProvider.Call(ctx, req.rpc(internalrpc.MarshalProperties), h.host.EngineConn(), call)
+	if err != nil {
+		return CallResponse{}, err
+	}
+	return newCallResponse(r)
+}
+
 // CallRequest represents a requested resource method invocation.
 //
 // It corresponds to [rpc.CallRequest] on the wire.
 type CallRequest struct {
-	Tok     tokens.ModuleMember
-	Args    presource.PropertyMap
-	Context *pulumi.Context
+	Tok              tokens.ModuleMember                       // the function token to invoke.
+	Args             presource.PropertyMap                     // the arguments for the function invocation.
+	ArgDependencies  map[presource.PropertyKey][]presource.URN // a map from argument keys to the dependencies of the argument.
+	Project          string                                    // the project name.
+	Stack            string                                    // the name of the stack being deployed into.
+	Config           map[pconfig.Key]string                    // the configuration variables to apply before running.
+	ConfigSecretKeys []pconfig.Key                             // the configuration keys that have secret values.
+	DryRun           bool                                      // true if we're only doing a dryrun (preview).
+	Parallel         int32                                     // the degree of parallelism for resource operations (<=1 for serial).
+	MonitorEndpoint  string                                    // the address for communicating back to the resource monitor.
+	Organization     string                                    // the organization of the stack being deployed into.
+}
+
+func newCallRequest(req *rpc.CallRequest, unmarshal rpcToProperty) (CallRequest, error) {
+	args, err := unmarshal(req.GetArgs())
+	if err != nil {
+		return CallRequest{}, fmt.Errorf("unable to convert args into a property map: %w", err)
+	}
+
+	r := CallRequest{
+		Tok:  tokens.ModuleMember(req.GetTok()),
+		Args: args,
+		ArgDependencies: func() map[presource.PropertyKey][]presource.URN {
+			r := make(map[presource.PropertyKey][]presource.URN, len(req.GetArgDependencies()))
+			for k, v := range req.GetArgDependencies() {
+				r[presource.PropertyKey(k)] = make([]presource.URN, len(v.GetUrns()))
+				for i, urn := range v.GetUrns() {
+					r[presource.PropertyKey(k)][i] = presource.URN(urn)
+				}
+			}
+			return r
+		}(),
+		Project: req.GetProject(),
+		Stack:   req.GetStack(),
+		Config: func() map[pconfig.Key]string {
+			m := make(map[pconfig.Key]string, len(req.GetConfig()))
+			for k, v := range req.GetConfig() {
+				m[pconfig.MustParseKey(k)] = v
+			}
+			return m
+		}(),
+		ConfigSecretKeys: func() []pconfig.Key {
+			keys := make([]pconfig.Key, len(req.GetConfigSecretKeys()))
+			for i, k := range req.GetConfigSecretKeys() {
+				keys[i] = pconfig.MustParseKey(k)
+			}
+			return keys
+		}(),
+		DryRun:          req.GetDryRun(),
+		Parallel:        req.GetParallel(),
+		MonitorEndpoint: req.GetMonitorEndpoint(),
+		Organization:    req.GetOrganization(),
+	}
+	return r, nil
+}
+
+func (c CallRequest) rpc(marshal propertyToRPC) *rpc.CallRequest {
+
+	fromUrns := func(urns []presource.URN) []string {
+		r := make([]string, len(urns))
+		for i, urn := range urns {
+			r[i] = string(urn)
+		}
+		return r
+	}
+
+	// Marshal the args.
+	args, err := marshal(c.Args)
+	if err != nil {
+		return nil
+	}
+
+	req := &rpc.CallRequest{
+		Tok:  c.Tok.String(),
+		Args: args,
+		ArgDependencies: func() map[string]*rpc.CallRequest_ArgumentDependencies {
+			r := make(map[string]*rpc.CallRequest_ArgumentDependencies, len(c.ArgDependencies))
+			for k, v := range c.ArgDependencies {
+				r[string(k)] = &rpc.CallRequest_ArgumentDependencies{
+					Urns: fromUrns(v),
+				}
+			}
+			return r
+		}(),
+		Project: c.Project,
+		Config: func() map[string]string {
+			m := make(map[string]string, len(c.Config))
+			for k, v := range c.Config {
+				m[k.String()] = v
+			}
+			return m
+		}(),
+		ConfigSecretKeys: func() []string {
+			keys := make([]string, len(c.ConfigSecretKeys))
+			for i, k := range c.ConfigSecretKeys {
+				keys[i] = k.String()
+			}
+			return keys
+		}(),
+		DryRun:              c.DryRun,
+		Parallel:            c.Parallel,
+		MonitorEndpoint:     c.MonitorEndpoint,
+		Organization:        c.Organization,
+		AcceptsOutputValues: true,
+	}
+
+	return req
 }
 
 // CallResponse represents a completed resource method invocation.
@@ -870,8 +949,44 @@ type CallRequest struct {
 type CallResponse struct {
 	// The returned values, if the call was successful.
 	Return presource.PropertyMap
+	// A map from return keys to the dependencies of the return value.
+	ReturnDependencies map[presource.PropertyKey][]presource.URN
 	// The failures if any arguments didn't pass verification.
 	Failures []CheckFailure
+}
+
+func newCallResponse(req *rpc.CallResponse) (CallResponse, error) {
+
+	// Umarshal the return properties.
+	ret, err := internalrpc.UnmarshalProperties(req.Return)
+	if err != nil {
+		return CallResponse{}, err
+	}
+
+	r := CallResponse{
+		Return: ret,
+		Failures: func() []CheckFailure {
+			failures := make([]CheckFailure, len(req.Failures))
+			for i, f := range req.Failures {
+				failures[i] = CheckFailure{
+					Property: f.Property,
+					Reason:   f.Reason,
+				}
+			}
+			return failures
+		}(),
+		ReturnDependencies: func() map[presource.PropertyKey][]presource.URN {
+			r := make(map[presource.PropertyKey][]presource.URN, len(req.ReturnDependencies))
+			for k, v := range req.ReturnDependencies {
+				r[presource.PropertyKey(k)] = make([]presource.URN, len(v.Urns))
+				for i, urn := range v.Urns {
+					r[presource.PropertyKey(k)][i] = presource.URN(urn)
+				}
+			}
+			return r
+		}(),
+	}
+	return r, nil
 }
 
 func (p *provider) Check(ctx context.Context, req *rpc.CheckRequest) (*rpc.CheckResponse, error) {
@@ -1608,6 +1723,9 @@ func GetTypeToken[Ctx interface{ Value(any) any }](ctx Ctx) string {
 type Host interface {
 	// Construct constructs a new resource using the provided [comProvider.ConstructFunc].
 	Construct(context.Context, ConstructRequest, comProvider.ConstructFunc) (ConstructResponse, error)
+
+	// Call calls a method using the provided [comProvider.CallFunc].
+	Call(context.Context, CallRequest, comProvider.CallFunc) (CallResponse, error)
 }
 
 // GetHost retrieves the provider's [Host] from the context.

--- a/provider.go
+++ b/provider.go
@@ -834,17 +834,28 @@ func (h *host) Call(ctx context.Context, req CallRequest, call comProvider.CallF
 //
 // It corresponds to [rpc.CallRequest] on the wire.
 type CallRequest struct {
-	Tok              tokens.ModuleMember                       // the function token to invoke.
-	Args             presource.PropertyMap                     // the arguments for the function invocation.
-	ArgDependencies  map[presource.PropertyKey][]presource.URN // a map from argument keys to the dependencies of the argument.
-	Project          string                                    // the project name.
-	Stack            string                                    // the name of the stack being deployed into.
-	Config           map[pconfig.Key]string                    // the configuration variables to apply before running.
-	ConfigSecretKeys []pconfig.Key                             // the configuration keys that have secret values.
-	DryRun           bool                                      // true if we're only doing a dryrun (preview).
-	Parallel         int32                                     // the degree of parallelism for resource operations (<=1 for serial).
-	MonitorEndpoint  string                                    // the address for communicating back to the resource monitor.
-	Organization     string                                    // the organization of the stack being deployed into.
+	// the function token to invoke.
+	Tok tokens.ModuleMember
+	// the arguments for the function invocation.
+	Args presource.PropertyMap
+	// a map from argument keys to the dependencies of the argument.
+	ArgDependencies map[presource.PropertyKey][]presource.URN
+	// the project name.
+	Project string
+	// the name of the stack being deployed into.
+	Stack string
+	// the configuration variables to apply before running.
+	Config map[pconfig.Key]string
+	// the configuration keys that have secret values.
+	ConfigSecretKeys []pconfig.Key
+	// true if we're only doing a dryrun (preview).
+	DryRun bool
+	// the degree of parallelism for resource operations (<=1 for serial).
+	Parallel int32
+	// the address for communicating back to the resource monitor.
+	MonitorEndpoint string
+	// the organization of the stack being deployed into.
+	Organization string
 }
 
 func newCallRequest(req *rpc.CallRequest, unmarshal rpcToProperty) (CallRequest, error) {

--- a/provider.go
+++ b/provider.go
@@ -930,6 +930,7 @@ func (c CallRequest) rpc(marshal propertyToRPC) *rpc.CallRequest {
 			return r
 		}(),
 		Project: c.Project,
+		Stack:   c.Stack,
 		Config: func() map[string]string {
 			m := make(map[string]string, len(c.Config))
 			for k, v := range c.Config {

--- a/provider_linked.go
+++ b/provider_linked.go
@@ -32,3 +32,13 @@ func linkedConstructRequestToRPC(req *ConstructRequest, marshal propertyToRPC) *
 func linkedConstructResponseFromRPC(resp *pulumirpc.ConstructResponse) (ConstructResponse, error) {
 	return newConstructResponse(resp)
 }
+
+//nolint:unused
+func linkedCallRequestToRPC(req *CallRequest, marshal propertyToRPC) *pulumirpc.CallRequest {
+	return req.rpc(marshal)
+}
+
+//nolint:unused
+func linkedCallResponseFromRPC(resp *pulumirpc.CallResponse) (CallResponse, error) {
+	return newCallResponse(resp)
+}

--- a/tests/grpc/call_consumer/__main__.py
+++ b/tests/grpc/call_consumer/__main__.py
@@ -5,4 +5,5 @@ import pulumi_test as test
 
 c = test.Component(resource_name="my-component", my_input="foo")
 
-c.my_method(arg1="bar")
+result = c.my_method(arg1="bar")
+pulumi.export("resp1", result.resp1)

--- a/tests/grpc/call_test.go
+++ b/tests/grpc/call_test.go
@@ -20,9 +20,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/providertest/replay"
+	replay "github.com/pulumi/providertest/replay"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
@@ -44,61 +45,124 @@ func TestCallLifecycle(t *testing.T) {
 }
 
 func TestCall(t *testing.T) {
-	replay.Replay(t, callProvider(t), `{
+
+	jsonLog := `
+{
     "method": "/pulumirpc.ResourceProvider/Call",
     "request": {
         "tok": "some-token",
         "args": {
             "k1": "s",
-        "k2": 3.14
+            "k2": 3.14
         },
+        "argDependencies": {
+            "k1": {
+                "urns": ["urn1", "urn2"]
+            }
+        },
+        "config": {
+            "test:c1": "s",
+            "test:c2": "3.14"
+        },
+        "configSecretKeys": ["test:c1"],
+        "dryRun": true,
         "project": "some-project",
         "stack": "some-stack",
         "acceptsOutputValues": true
     },
     "response": {
-	"return": {
-	  "r1":{
-		"4dabf18193072939515e22adb298388d": "d0e6a833031e9bbcd3f4e8bde6ca49a4",
-		"dependencies": ["urn1","urn2"]
-	}
-	},
-	"returnDependencies": {
-	  "r1": {
-            "urns": ["urn1", "urn2"]
+        "return": {
+          "r1":{
+              "4dabf18193072939515e22adb298388d": "d0e6a833031e9bbcd3f4e8bde6ca49a4",
+              "dependencies": ["urn1","urn2"]
           }
-	}
+       },
+       "returnDependencies": {
+           "r1": {
+              "urns": ["urn1", "urn2"]
+           }
+        }
     },
     "metadata": {
         "kind": "resource",
         "mode": "client",
         "name": "asset"
     }
-}`)
+}`
+
+	call := func(_ context.Context, req p.CallRequest) (p.CallResponse, error) {
+		assert.Equal(t, resource.PropertyMap{
+			"k1": resource.NewProperty("s"),
+			"k2": resource.NewProperty(3.14),
+		}, req.Args)
+		assert.Equal(t, map[resource.PropertyKey][]resource.URN{
+			"k1": {resource.URN("urn1"), resource.URN("urn2")},
+		}, req.ArgDependencies)
+		assert.Equal(t, tokens.ModuleMember("some-token"), req.Tok)
+		assert.Equal(t, "some-project", req.Project)
+		assert.Equal(t, "some-stack", req.Stack)
+		assert.Equal(t, true, req.DryRun)
+		assert.Equal(t, map[config.Key]string{
+			config.MustParseKey("test:c1"): "s",
+			config.MustParseKey("test:c2"): "3.14",
+		}, req.Config)
+		assert.Equal(t, []config.Key{config.MustParseKey("test:c1")}, req.ConfigSecretKeys)
+		assert.Equal(t, true, req.AcceptsOutputValues)
+
+		return p.CallResponse{
+			Return: resource.PropertyMap{
+				"r1": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("e1"),
+					Dependencies: []resource.URN{
+						"urn1", "urn2",
+					},
+				}),
+			},
+		}, nil
+	}
+
+	replay.Replay(t, callProvider(t, call), jsonLog)
 }
 
-func callProvider(t *testing.T) pulumirpc.ResourceProviderServer {
-	s, err := p.RawServer("call", "0.1.0", p.Provider{
-		Call: func(_ context.Context, req p.CallRequest) (p.CallResponse, error) {
-			assert.Equal(t, resource.PropertyMap{
-				"k1": resource.NewProperty("s"),
-				"k2": resource.NewProperty(3.14),
-			}, req.Args)
-			assert.Equal(t, tokens.ModuleMember("some-token"), req.Tok)
-			assert.Equal(t, "some-project", req.Project)
-			assert.Equal(t, "some-stack", req.Stack)
+func TestCallWithMalformedRequest(t *testing.T) {
 
-			return p.CallResponse{
-				Return: resource.PropertyMap{
-					"r1": resource.NewProperty(resource.Output{
-						Element: resource.NewProperty("e1"),
-						Dependencies: []resource.URN{
-							"urn1", "urn2",
-						},
-					}),
-				},
-			}, nil
-		},
+	jsonLog := `
+{
+    "method": "/pulumirpc.ResourceProvider/Call",
+    "request": {
+        "tok": "some-token",
+        "args": {
+            "r1": {
+                "4dabf18193072939515e22adb298388d": "invalid"
+            }
+        },
+        "project": "some-project",
+        "stack": "some-stack",
+        "config": {
+            "INVALID": "s"
+        },
+        "acceptsOutputValues": true
+    },
+    "errors": ["*"],
+    "metadata": {
+        "kind": "resource",
+        "mode": "client",
+        "name": "asset"
+    }
+}`
+	call := func(ctx context.Context, req p.CallRequest) (p.CallResponse, error) {
+		assert.FailNow(t, "call was not expected to be called")
+		return p.CallResponse{}, nil
+	}
+
+	replay.Replay(t, callProvider(t, call), jsonLog)
+}
+
+type callF func(_ context.Context, req p.CallRequest) (p.CallResponse, error)
+
+func callProvider(t *testing.T, call callF) pulumirpc.ResourceProviderServer {
+	s, err := p.RawServer("call", "0.1.0", p.Provider{
+		Call: call,
 	})(nil)
 	require.NoError(t, err)
 	return s

--- a/tests/grpc/call_test.go
+++ b/tests/grpc/call_test.go
@@ -49,9 +49,10 @@ func TestCall(t *testing.T) {
     "request": {
         "tok": "some-token",
         "args": {
-		"k1": "s",
-		"k2": 3.14
-	},
+            "k1": "s",
+        "k2": 3.14
+        },
+        "project": "some-project",
         "stack": "some-stack",
         "acceptsOutputValues": true
     },
@@ -84,7 +85,8 @@ func callProvider(t *testing.T) pulumirpc.ResourceProviderServer {
 				"k2": resource.NewProperty(3.14),
 			}, req.Args)
 			assert.Equal(t, tokens.ModuleMember("some-token"), req.Tok)
-			assert.Equal(t, "some-stack", req.Context.Stack())
+			assert.Equal(t, "some-project", req.Project)
+			assert.Equal(t, "some-stack", req.Stack)
 
 			return p.CallResponse{
 				Return: resource.PropertyMap{

--- a/tests/grpc/construct_test.go
+++ b/tests/grpc/construct_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pulumi/providertest/replay"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
@@ -114,7 +115,11 @@ func TestConstruct(t *testing.T) {
 		_true := true
 		assert.Equal(t, resource.URN("urn:pulumi:test::test::test:index:Parent$test:index:Component::test-component"), req.Urn)
 		assert.Equal(t, resource.URN("urn:pulumi:test::test::test:index:Parent::parent"), req.Parent)
-
+		assert.Equal(t, map[config.Key]string{
+			config.MustParseKey("test:c1"): "s",
+			config.MustParseKey("test:c2"): "3.14",
+		}, req.Config)
+		assert.Equal(t, []config.Key{config.MustParseKey("test:c1")}, req.ConfigSecretKeys)
 		assert.Equal(t, []resource.URN{"urn2"}, req.Aliases)
 		assert.Equal(t, []resource.URN{"urn3"}, req.Dependencies)
 		assert.Equal(t, &_true, req.Protect)

--- a/tests/grpc/provider/main.go
+++ b/tests/grpc/provider/main.go
@@ -73,8 +73,8 @@ func main() {
 				return p.CallResponse{}, fmt.Errorf("unknown token %q", req.Tok)
 			}
 
-			host := p.GetHost(ctx)
-			return host.Call(ctx, req, func(ctx *pulumi.Context, tok string, args comProvider.CallArgs) (*comProvider.CallResult, error) {
+			return p.ProgramCall(ctx, req, func(ctx *pulumi.Context, tok string, args comProvider.CallArgs,
+			) (*comProvider.CallResult, error) {
 				pet, err := random.NewRandomPet(ctx, "call-pet", &random.RandomPetArgs{})
 				if err != nil {
 					return nil, err

--- a/tests/grpc/provider/main.go
+++ b/tests/grpc/provider/main.go
@@ -90,7 +90,6 @@ func main() {
 					urn := vs[0].(pulumi.URN)
 					arg1 := vs[1].(string)
 					id := vs[2].(pulumi.ID)
-
 					return arg1 + ":" + string(urn) + ":" + string(id), nil
 				}).(pulumi.StringOutput)
 


### PR DESCRIPTION
_A follow-up to https://github.com/pulumi/pulumi-go-provider/pull/338._

This PR rewrites Call handling to be consistent with how Construct works by leveraging the Host interface.  Now we avoid the duplicative creation of two `pulumi.Context` instances, and the awkward "synchronization point".  This is accomplished by invoking the user's `Call` code naturally from within the Go SDK's `call` function.

This PR also updates the test provider's Call implementation to more fully utilize the Go SDK, e.g. it now uses Input/Output types and calls `NewCallResult`.

It integrates provider cancelation into Call, so that all outstanding Calls are canceled.  This is made possible by creating the `pulumi.Context` less eagerly than before, so that it wraps the middleware's cancelable context.

It adds support for Call to `middleware.rpc`, to be able to wrap a legacy provider that implements Call.

Finally it adds support for integration testing of Provider.Call.

_In the below diagram(s), the yellow region is where the system is in a Pulumi program context and using Go SDK features such as inputs and outputs._

```mermaid
sequenceDiagram
    actor User as Pulumi
    participant Server as Provider Server
    participant SDK as Pulumi SDK
    participant Provider

    User->>Server: Call
    activate Server
    Server->>+Provider: Provider.Call
    Provider->>Provider: getHost(ctx)
    Provider->>Server: Host.Call
    activate Server
    Server->>Server: getEngineConn
    Server->>SDK: comProvider.Call
    activate SDK
    SDK->>SDK: pulumi.NewContext
    rect rgb(255,255,191)
    SDK->>Provider: CallFunc
    activate Provider
    Provider-->>SDK: RegisterResource
    SDK-->>User: RegisterResource
    Provider->>SDK: NewCallResult
    SDK->>Provider: 
    Provider->>SDK: (result)
    deactivate Provider
    end
    SDK->>Server: (result)
    deactivate SDK
    Server->>Provider: (result)
    deactivate Server
    Provider->>Server: (result)
    deactivate Provider
    Server->>User: (response)
    deactivate Server
```

The `call_consumer` program shows the expected output, the concatenated string produced by the test provider:
```plain

View in Browser (Ctrl+O): https://app.pulumi.com/eron-pulumi-corp/call_consumer/dev/updates/18

     Type                          Name               Status              
 +   pulumi:pulumi:Stack           call_consumer-dev  created (1s)        
 +   ├─ test:index:Component       test               created (0.56s)     
 +   │  └─ random:index:RandomPet  pet                created (0.07s)     
 +   └─ random:index:RandomPet     call-pet           created (0.16s)     

Outputs:
    resp1: "bar:urn:pulumi:dev::call_consumer::test:index:Component::test:smashing-fawn"

```

Stacked on top of https://github.com/pulumi/pulumi-go-provider/pull/338.

Closes #340 