### PR TITLE
Migrate `resource.PropertyValue` to `property.Value` in public APIs

### DIFF
--- a/examples/auto-naming/main.go
+++ b/examples/auto-naming/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 func main() {
@@ -81,20 +82,16 @@ func (*User) Check(
 //
 // oldInputs are the old inputs as passed in via [infer.CustomCheck.Check].
 func autoname(
-	field *string, name string, fieldName resource.PropertyKey,
-	oldInputs resource.PropertyMap,
+	field *string, name, fieldName string,
+	oldInputs property.Map,
 ) (*string, error) {
 	if field != nil {
 		return field, nil
 	}
 
-	prev := oldInputs[fieldName]
-	if prev.IsSecret() {
-		prev = prev.SecretValue().Element
-	}
-
-	if prev.IsString() && prev.StringValue() != "" {
-		n := prev.StringValue()
+	prev := oldInputs.Get(fieldName)
+	if prev.IsString() && prev.AsString() != "" {
+		n := prev.AsString()
 		field = &n
 	} else {
 		n, err := resource.NewUniqueHex(name+"-", 6, 20)
@@ -103,5 +100,6 @@ func autoname(
 		}
 		field = &n
 	}
+
 	return field, nil
 }

--- a/examples/auto-naming/main_test.go
+++ b/examples/auto-naming/main_test.go
@@ -8,6 +8,7 @@ import (
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,99 +20,99 @@ func TestAutoName(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		olds     resource.PropertyMap
-		news     resource.PropertyMap
-		validate func(*testing.T, resource.PropertyMap)
+		olds     property.Map
+		news     property.Map
+		validate func(*testing.T, property.Map)
 	}{
 		{
 			name: "create new auto-named resource",
-			news: resource.PropertyMap{},
-			validate: func(t *testing.T, result resource.PropertyMap) {
-				name, ok := result["name"]
+			news: property.Map{},
+			validate: func(t *testing.T, result property.Map) {
+				name, ok := result.GetOk("name")
 				require.True(t, ok, "could not find name in %q", result)
-				assert.True(t, strings.HasPrefix(name.StringValue(), "name-"))
-				assert.Len(t, name.StringValue(), 11)
-				assert.Len(t, result, 1)
+				assert.True(t, strings.HasPrefix(name.AsString(), "name-"))
+				assert.Len(t, name.AsString(), 11)
+				assert.Equal(t, 1, result.Len())
 			},
 		},
 		{
 			name: "create new manually named resource",
-			news: resource.PropertyMap{
-				"name": resource.NewProperty("custom-name"),
-			},
-			validate: func(t *testing.T, result resource.PropertyMap) {
-				name, ok := result["name"]
+			news: property.NewMap(map[string]property.Value{
+				"name": property.New("custom-name"),
+			}),
+			validate: func(t *testing.T, result property.Map) {
+				name, ok := result.GetOk("name")
 				require.True(t, ok, "could not find name in %q", result)
-				assert.Equal(t, "custom-name", name.StringValue())
+				assert.Equal(t, "custom-name", name.AsString())
 			},
 		},
 		{
 			name: "update an auto-named resource (same name)",
-			news: resource.PropertyMap{},
-			olds: resource.PropertyMap{
-				"name": resource.NewProperty("name-123456"),
-			},
-			validate: func(t *testing.T, result resource.PropertyMap) {
-				name, ok := result["name"]
+			news: property.Map{},
+			olds: property.NewMap(map[string]property.Value{
+				"name": property.New("name-123456"),
+			}),
+			validate: func(t *testing.T, result property.Map) {
+				name, ok := result.GetOk("name")
 				require.True(t, ok, "could not find name in %q", result)
-				assert.Equal(t, "name-123456", name.StringValue())
+				assert.Equal(t, "name-123456", name.AsString())
 			},
 		},
 		{
 			name: "update an auto-named resource (new name)",
-			news: resource.PropertyMap{
-				"name": resource.NewProperty("custom-name"),
-			},
-			olds: resource.PropertyMap{
-				"name": resource.NewProperty("name-123456"),
-			},
-			validate: func(t *testing.T, result resource.PropertyMap) {
-				name, ok := result["name"]
+			news: property.NewMap(map[string]property.Value{
+				"name": property.New("custom-name"),
+			}),
+			olds: property.NewMap(map[string]property.Value{
+				"name": property.New("name-123456"),
+			}),
+			validate: func(t *testing.T, result property.Map) {
+				name, ok := result.GetOk("name")
 				require.True(t, ok, "could not find name in %q", result)
-				assert.Equal(t, "custom-name", name.StringValue())
+				assert.Equal(t, "custom-name", name.AsString())
 			},
 		},
 		{
 			name: "update a manually named resource (same name)",
-			news: resource.PropertyMap{
-				"name": resource.NewProperty("custom-name"),
-			},
-			olds: resource.PropertyMap{
-				"name": resource.NewProperty("custom-name"),
-			},
-			validate: func(t *testing.T, result resource.PropertyMap) {
-				name, ok := result["name"]
+			news: property.NewMap(map[string]property.Value{
+				"name": property.New("custom-name"),
+			}),
+			olds: property.NewMap(map[string]property.Value{
+				"name": property.New("custom-name"),
+			}),
+			validate: func(t *testing.T, result property.Map) {
+				name, ok := result.GetOk("name")
 				require.True(t, ok, "could not find name in %q", result)
-				assert.Equal(t, "custom-name", name.StringValue())
+				assert.Equal(t, "custom-name", name.AsString())
 			},
 		},
 		{
 			name: "update a manually named resource (different name)",
-			news: resource.PropertyMap{
-				"name": resource.NewProperty("custom-name1"),
-			},
-			olds: resource.PropertyMap{
-				"name": resource.NewProperty("custom-name2"),
-			},
-			validate: func(t *testing.T, result resource.PropertyMap) {
-				name, ok := result["name"]
+			news: property.NewMap(map[string]property.Value{
+				"name": property.New("custom-name1"),
+			}),
+			olds: property.NewMap(map[string]property.Value{
+				"name": property.New("custom-name2"),
+			}),
+			validate: func(t *testing.T, result property.Map) {
+				name, ok := result.GetOk("name")
 				require.True(t, ok, "could not find name in %q", result)
-				assert.Equal(t, "custom-name1", name.StringValue())
+				assert.Equal(t, "custom-name1", name.AsString())
 			},
 		},
 		{
 			name: "convert from a named to an auto-named resource",
-			news: resource.PropertyMap{},
-			olds: resource.PropertyMap{
-				"name": resource.NewProperty("custom-name"),
-			},
-			validate: func(t *testing.T, result resource.PropertyMap) {
+			news: property.Map{},
+			olds: property.NewMap(map[string]property.Value{
+				"name": property.New("custom-name"),
+			}),
+			validate: func(t *testing.T, result property.Map) {
 				t.Skipf("It's not possible to drop custom-named resources without a side channel")
-				name, ok := result["name"]
+				name, ok := result.GetOk("name")
 				require.True(t, ok, "could not find name in %q", result)
 
-				assert.True(t, strings.HasPrefix(name.StringValue(), "name-"))
-				assert.Len(t, name.StringValue(), 11)
+				assert.True(t, strings.HasPrefix(name.AsString(), "name-"))
+				assert.Len(t, name.AsString(), 11)
 				assert.Len(t, result, 1)
 			},
 		},

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -10,8 +10,8 @@ import (
 	"os"
 
 	p "github.com/pulumi/pulumi-go-provider"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 func main() {
@@ -69,16 +69,16 @@ func main() {
 			}
 			return p.CheckResponse{
 				// Only take "value" and ignore everything else.
-				Inputs: resource.PropertyMap{
-					"value": req.News["value"],
-				},
+				Inputs: property.NewMap(map[string]property.Value{
+					"value": req.News.Get("value"),
+				}),
 			}, nil
 		},
 		Diff: func(_ context.Context, req p.DiffRequest) (p.DiffResponse, error) {
 			if req.Urn.Type() != echoType {
 				return p.DiffResponse{}, fmt.Errorf("unknown resource %q", req.Urn.Type())
 			}
-			if req.News["value"].DeepEquals(req.Olds["value"]) {
+			if req.News.Get("value").Equals(req.Olds.Get("value")) {
 				return p.DiffResponse{
 					HasChanges: false,
 				}, nil

--- a/examples/file/main.go
+++ b/examples/file/main.go
@@ -7,8 +7,8 @@ import (
 
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 func main() {
@@ -112,8 +112,8 @@ func (*File) Delete(ctx context.Context, req infer.DeleteRequest[FileState]) (in
 }
 
 func (*File) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckResponse[FileArgs], error) {
-	if _, ok := req.NewInputs["path"]; !ok {
-		req.NewInputs["path"] = resource.NewStringProperty(req.Name)
+	if _, ok := req.NewInputs.GetOk("path"); !ok {
+		req.NewInputs = req.NewInputs.Set("path", property.New(req.Name))
 	}
 	args, f, err := infer.DefaultCheck[FileArgs](ctx, req.NewInputs)
 

--- a/examples/random-login/main_test.go
+++ b/examples/random-login/main_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/blang/semver"
 	p "github.com/pulumi/pulumi-go-provider"
 	integration "github.com/pulumi/pulumi-go-provider/integration"
-	presource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -147,25 +147,25 @@ func TestRandomSalt(t *testing.T) {
 	integration.LifeCycleTest{
 		Resource: "random-login:index:RandomSalt",
 		Create: integration.Operation{
-			Inputs: presource.NewPropertyMapFromMap(map[string]interface{}{
-				"password":     "foo",
-				"saltedLength": 3,
+			Inputs: property.NewMap(map[string]property.Value{
+				"password":     property.New("foo"),
+				"saltedLength": property.New(3.0),
 			}),
-			Hook: func(inputs, output presource.PropertyMap) {
+			Hook: func(inputs, output property.Map) {
 				t.Logf("Outputs: %v", output)
-				saltedPassword := output["saltedPassword"].StringValue()
+				saltedPassword := output.Get("saltedPassword").AsString()
 				assert.True(t, strings.HasSuffix(saltedPassword, "foo"), "password wrong")
 				assert.Len(t, saltedPassword, 6)
 			},
 		},
 		Updates: []integration.Operation{
 			{
-				Inputs: presource.NewPropertyMapFromMap(map[string]interface{}{
-					"password":     "bar",
-					"saltedLength": 5,
+				Inputs: property.NewMap(map[string]property.Value{
+					"password":     property.New("bar"),
+					"saltedLength": property.New(5.0),
 				}),
-				Hook: func(inputs, output presource.PropertyMap) {
-					saltedPassword := output["saltedPassword"].StringValue()
+				Hook: func(inputs, output property.Map) {
+					saltedPassword := output.Get("saltedPassword").AsString()
 					assert.True(t, strings.HasSuffix(saltedPassword, "bar"), "password wrong")
 					assert.Len(t, saltedPassword, 8)
 				},

--- a/examples/str/main_test.go
+++ b/examples/str/main_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/blang/semver"
 	p "github.com/pulumi/pulumi-go-provider"
 	integration "github.com/pulumi/pulumi-go-provider/integration"
-	presource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -140,25 +140,25 @@ func TestInvokes(t *testing.T) {
 
 	r, err := server.Invoke(p.InvokeRequest{
 		Token: "str:index:replace",
-		Args: presource.NewPropertyMapFromMap(map[string]interface{}{
-			"s":   "foo!bar",
-			"old": "!",
-			"new": "-",
+		Args: property.NewMap(map[string]property.Value{
+			"s":   property.New("foo!bar"),
+			"old": property.New("!"),
+			"new": property.New("-"),
 		}),
 	})
 	assert.NoError(t, err)
 	assert.Empty(t, r.Failures)
-	assert.Equal(t, "foo-bar", r.Return["out"].StringValue())
+	assert.Equal(t, "foo-bar", r.Return.Get("out").AsString())
 
 	r, err = server.Invoke(p.InvokeRequest{
 		Token: "str:regex:replace",
-		Args: presource.NewPropertyMapFromMap(map[string]interface{}{
-			"s":       "fizz, buzz, zzz...",
-			"pattern": "z+",
-			"new":     "Z",
+		Args: property.NewMap(map[string]property.Value{
+			"s":       property.New("fizz, buzz, zzz..."),
+			"pattern": property.New("z+"),
+			"new":     property.New("Z"),
 		}),
 	})
 	assert.NoError(t, err)
 	assert.Empty(t, r.Failures)
-	assert.Equal(t, "fiZ, buZ, Z...", r.Return["out"].StringValue())
+	assert.Equal(t, "fiZ, buZ, Z...", r.Return.Get("out").AsString())
 }

--- a/infer/apply_secrets.go
+++ b/infer/apply_secrets.go
@@ -20,19 +20,20 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 
 	"github.com/pulumi/pulumi-go-provider/internal/introspect"
 	"github.com/pulumi/pulumi-go-provider/internal/putil"
 )
 
-func applySecrets[I any](inputs resource.PropertyMap) resource.PropertyMap {
+func applySecrets[I any](inputs resource.PropertyMap) property.Map {
 	var walker secretsWalker
 	result := walker.walk(reflect.TypeFor[I](), resource.NewProperty(inputs))
 	contract.AssertNoErrorf(errors.Join(walker.errs...),
 		`secretsWalker only produces errors when the type it walks has invalid property tags
 I can't have invalid property tags because we have gotten to runtime, and it would have failed at
 schema generation time already.`)
-	return result.ObjectValue()
+	return resource.FromResourcePropertyValue(result).AsMap()
 }
 
 // The object that controls secrets application.

--- a/infer/internal/ende/ende.go
+++ b/infer/internal/ende/ende.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/mapper"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // AssetSignature is a unique key for use for assets in the AssetOrArchive union type.
@@ -49,19 +50,22 @@ type Encoder struct{ *ende }
 //
 //	encoder, value, _ := Decode(m)
 //	m, _ = encoder.Encode(value)
-func Decode[T any](m resource.PropertyMap) (Encoder, T, mapper.MappingError) {
+func Decode[T any](m property.Map) (Encoder, T, mapper.MappingError) {
+	rm := resource.ToResourcePropertyValue(property.New(m)).ObjectValue()
 	var dst T
-	enc, err := decode(m, &dst, false, false)
+	enc, err := decode(rm, &dst, false, false)
 	return enc, dst, err
 }
 
 // DecodeTolerateMissing is like Decode, but doesn't return an error for a missing value.
-func DecodeTolerateMissing[T any](m resource.PropertyMap, dst T) (Encoder, mapper.MappingError) {
-	return decode(m, dst, false, true)
+func DecodeTolerateMissing[T any](m property.Map, dst T) (Encoder, mapper.MappingError) {
+	rm := resource.ToResourcePropertyValue(property.New(m)).ObjectValue()
+	return decode(rm, dst, false, true)
 }
 
-func DecodeConfig[T any](m resource.PropertyMap, dst T) (Encoder, mapper.MappingError) {
-	return decode(m, dst, true, false)
+func DecodeConfig[T any](m property.Map, dst T) (Encoder, mapper.MappingError) {
+	rm := resource.ToResourcePropertyValue(property.New(m)).ObjectValue()
+	return decode(rm, dst, true, false)
 }
 
 func decode(
@@ -79,8 +83,9 @@ func decode(
 	}).Decode(m.Mappable(), target.Addr().Interface())
 }
 
-func DecodeAny(m resource.PropertyMap, dst any) (Encoder, mapper.MappingError) {
-	return decode(m, dst, false, false)
+func DecodeAny(m property.Map, dst any) (Encoder, mapper.MappingError) {
+	rm := resource.ToResourcePropertyValue(property.New(m)).ObjectValue()
+	return decode(rm, dst, false, false)
 }
 
 // An ENcoder DEcoder.

--- a/infer/internal/ende/ende_test.go
+++ b/infer/internal/ende/ende_test.go
@@ -36,15 +36,13 @@ import (
 func testRoundTrip[T any](t *testing.T, pMap func() r.PropertyMap) {
 	t.Run("", func(t *testing.T) {
 		t.Parallel()
-		toDecode := pMap()
-		encoder, typeInfo, err := Decode[T](toDecode)
+		pMap := r.FromResourcePropertyValue(r.NewProperty(pMap())).AsMap()
+		encoder, typeInfo, err := Decode[T](pMap)
 		require.NoError(t, err)
-
-		assert.Equalf(t, pMap(), toDecode, "mutated decode map")
 
 		reEncoded, err := encoder.Encode(typeInfo)
 		require.NoError(t, err)
-		assert.Equal(t, pMap(), reEncoded)
+		assert.Equal(t, pMap, r.FromResourcePropertyValue(r.NewProperty(reEncoded)).AsMap())
 	})
 }
 

--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -24,6 +24,7 @@ import (
 	r "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
@@ -231,60 +232,60 @@ func TestDiff(t *testing.T) {
 		Environment map[string]string `pulumi:"environment,optional"`
 	}
 	tests := []struct {
-		olds r.PropertyMap
-		news r.PropertyMap
+		olds property.Map
+		news property.Map
 		diff map[string]p.DiffKind
 	}{
 		{
-			olds: r.PropertyMap{
-				"environment": r.NewObjectProperty(r.PropertyMap{
-					"FOO": r.NewStringProperty("foo"),
+			olds: property.NewMap(map[string]property.Value{
+				"environment": property.New(map[string]property.Value{
+					"FOO": property.New("foo"),
 				}),
-			},
-			news: r.PropertyMap{
-				"environment": r.NewObjectProperty(r.PropertyMap{
-					"FOO": r.NewStringProperty("bar"),
+			}),
+			news: property.NewMap(map[string]property.Value{
+				"environment": property.New(map[string]property.Value{
+					"FOO": property.New("bar"),
 				}),
-			},
+			}),
 			diff: map[string]p.DiffKind{"environment.FOO": "update"},
 		},
 		{
-			olds: r.PropertyMap{},
-			news: r.PropertyMap{
-				"environment": r.NewObjectProperty(r.PropertyMap{
-					"FOO": r.NewStringProperty("bar"),
+			olds: property.Map{},
+			news: property.NewMap(map[string]property.Value{
+				"environment": property.New(map[string]property.Value{
+					"FOO": property.New("bar"),
 				}),
-			},
+			}),
 			diff: map[string]p.DiffKind{"environment": "add"},
 		},
 		{
-			olds: r.PropertyMap{
-				"environment": r.NewObjectProperty(r.PropertyMap{
-					"FOO": r.NewStringProperty("bar"),
+			olds: property.NewMap(map[string]property.Value{
+				"environment": property.New(map[string]property.Value{
+					"FOO": property.New("bar"),
 				}),
-			},
-			news: r.PropertyMap{},
+			}),
+			news: property.Map{},
 			diff: map[string]p.DiffKind{"environment": "delete"},
 		},
 		{
-			olds: r.PropertyMap{
-				"environment": r.NewObjectProperty(r.PropertyMap{
-					"FOO": r.NewStringProperty("bar"),
+			olds: property.NewMap(map[string]property.Value{
+				"environment": property.New(map[string]property.Value{
+					"FOO": property.New("bar"),
 				}),
-				"output": r.NewNumberProperty(42),
-			},
-			news: r.PropertyMap{},
+				"output": property.New(42.0),
+			}),
+			news: property.NewMap(map[string]property.Value{}),
 			diff: map[string]p.DiffKind{"environment": "delete"},
 		},
 		{
-			olds: r.PropertyMap{
-				"output": r.NewNumberProperty(42),
-			},
-			news: r.PropertyMap{
-				"environment": r.NewObjectProperty(r.PropertyMap{
-					"FOO": r.NewStringProperty("bar"),
+			olds: property.NewMap(map[string]property.Value{
+				"output": property.New(42.0),
+			}),
+			news: property.NewMap(map[string]property.Value{
+				"environment": property.New(map[string]property.Value{
+					"FOO": property.New("bar"),
 				}),
-			},
+			}),
 			diff: map[string]p.DiffKind{"environment": "add"},
 		},
 	}
@@ -337,7 +338,7 @@ func (CustomHydrateFromState[O]) StateMigrations(ctx context.Context) []StateMig
 }
 
 func testHydrateFromState[O any](
-	oldState, expected r.PropertyMap, expectedError error,
+	oldState, expected property.Map, expectedError error,
 	migrations ...StateMigrationFunc[O],
 ) func(t *testing.T) {
 	return func(t *testing.T) {
@@ -355,7 +356,7 @@ func testHydrateFromState[O any](
 		}
 		m, err := enc.Encode(actual)
 		require.NoErrorf(t, err, "We should be able to encode the result to a p.Map")
-		assert.Equal(t, expected, m)
+		assert.Equal(t, expected, r.FromResourcePropertyValue(r.NewProperty(m)).AsMap())
 	}
 }
 
@@ -373,12 +374,12 @@ func TestHydrateFromState(t *testing.T) {
 	}
 
 	t.Run("migrate type", testHydrateFromState[numberMigrateTarget](
-		r.PropertyMap{
-			"number": r.NewProperty("42"),
-		},
-		r.PropertyMap{
-			"number": r.NewProperty(42.0),
-		},
+		property.NewMap(map[string]property.Value{
+			"number": property.New("42"),
+		}),
+		property.NewMap(map[string]property.Value{
+			"number": property.New(42.0),
+		}),
 		nil,
 		StateMigration(func(_ context.Context, old numberMigrateSource) (MigrationResult[numberMigrateTarget], error) {
 			n, err := strconv.ParseInt(old.Number, 10, 64)
@@ -394,15 +395,15 @@ func TestHydrateFromState(t *testing.T) {
 	))
 
 	t.Run("migrate-raw", testHydrateFromState[numberMigrateTarget](
-		r.PropertyMap{
-			"number": r.NewProperty("42"),
-		},
-		r.PropertyMap{
-			"number": r.NewProperty(42.0),
-		},
+		property.NewMap(map[string]property.Value{
+			"number": property.New("42"),
+		}),
+		property.NewMap(map[string]property.Value{
+			"number": property.New(42.0),
+		}),
 		nil,
-		StateMigration(func(_ context.Context, old r.PropertyMap) (MigrationResult[numberMigrateTarget], error) {
-			n, err := strconv.ParseInt(old["number"].StringValue(), 10, 64)
+		StateMigration(func(_ context.Context, old property.Map) (MigrationResult[numberMigrateTarget], error) {
+			n, err := strconv.ParseInt(old.Get("number").AsString(), 10, 64)
 			if err != nil {
 				return MigrationResult[numberMigrateTarget]{}, err
 			}
@@ -415,39 +416,39 @@ func TestHydrateFromState(t *testing.T) {
 	))
 
 	t.Run("ordering-success", testHydrateFromState[numberMigrateTarget](
-		r.PropertyMap{
-			"number": r.NewProperty("0"),
-		},
-		r.PropertyMap{
-			"number": r.NewProperty(1.0),
-		},
+		property.NewMap(map[string]property.Value{
+			"number": property.New("0"),
+		}),
+		property.NewMap(map[string]property.Value{
+			"number": property.New(1.0),
+		}),
 		nil,
-		StateMigration(func(context.Context, r.PropertyMap) (MigrationResult[numberMigrateTarget], error) {
+		StateMigration(func(context.Context, property.Map) (MigrationResult[numberMigrateTarget], error) {
 			return MigrationResult[numberMigrateTarget]{
 				Result: &numberMigrateTarget{
 					Number: int(1),
 				},
 			}, nil
 		}),
-		StateMigration(func(context.Context, r.PropertyMap) (MigrationResult[numberMigrateTarget], error) {
+		StateMigration(func(context.Context, property.Map) (MigrationResult[numberMigrateTarget], error) {
 			panic("Should never be called")
 		}),
 	))
 
 	t.Run("ordering", testHydrateFromState[numberMigrateTarget](
-		r.PropertyMap{
-			"number": r.NewProperty("0"),
-		},
-		r.PropertyMap{
-			"number": r.NewProperty(2.0),
-		},
+		property.NewMap(map[string]property.Value{
+			"number": property.New("0"),
+		}),
+		property.NewMap(map[string]property.Value{
+			"number": property.New(2.0),
+		}),
 		nil,
-		StateMigration(func(context.Context, r.PropertyMap) (MigrationResult[numberMigrateTarget], error) {
+		StateMigration(func(context.Context, property.Map) (MigrationResult[numberMigrateTarget], error) {
 			return MigrationResult[numberMigrateTarget]{
 				Result: nil,
 			}, nil
 		}),
-		StateMigration(func(context.Context, r.PropertyMap) (MigrationResult[numberMigrateTarget], error) {
+		StateMigration(func(context.Context, property.Map) (MigrationResult[numberMigrateTarget], error) {
 			return MigrationResult[numberMigrateTarget]{
 				Result: &numberMigrateTarget{
 					Number: int(2),
@@ -465,18 +466,18 @@ func TestHydrateFromState(t *testing.T) {
 	// testHydrateFromState decodes and encodes, so the asset should come back out as a plain asset
 	// after having been decoded to an AssetOrArchive.
 	t.Run("assets", testHydrateFromState[hasAsset](
-		r.PropertyMap{
-			"aa": r.NewPropertyValue(testAsset),
-		},
-		r.PropertyMap{
-			"aa": r.NewObjectProperty(r.PropertyMap{
-				sig.Key: r.NewStringProperty(sig.AssetSig),
-				"text":  r.NewStringProperty("pulumi"),
-				"hash":  r.NewStringProperty(testAsset.Hash),
-				"path":  r.NewStringProperty(""),
-				"uri":   r.NewStringProperty(""),
+		property.NewMap(map[string]property.Value{
+			"aa": property.New(testAsset),
+		}),
+		property.NewMap(map[string]property.Value{
+			"aa": property.New(map[string]property.Value{
+				sig.Key: property.New(sig.AssetSig),
+				"text":  property.New("pulumi"),
+				"hash":  property.New(testAsset.Hash),
+				"path":  property.New(""),
+				"uri":   property.New(""),
 			}),
-		},
+		}),
 		nil,
 	))
 }
@@ -501,14 +502,16 @@ func (c checkResource) Create(context.Context, CreateRequest[checkResource],
 func TestCheck(t *testing.T) {
 	t.Parallel()
 
+	type m = map[string]property.Value
+
 	for tcName, tc := range map[string]struct {
-		input    r.PropertyMap
+		input    property.Map
 		expected string
 	}{
-		"applies default for missing value":     {nil, defaultValue},
-		"applies default for empty value":       {r.PropertyMap{"str": r.NewStringProperty("")}, defaultValue},
-		"no change when default is already set": {r.PropertyMap{"str": r.NewStringProperty(defaultValue)}, defaultValue},
-		"respects non-default value":            {r.PropertyMap{"str": r.NewStringProperty("different")}, "different"},
+		"applies default for missing value":     {property.Map{}, defaultValue},
+		"applies default for empty value":       {property.NewMap(m{"str": property.New("")}), defaultValue},
+		"no change when default is already set": {property.NewMap(m{"str": property.New(defaultValue)}), defaultValue},
+		"respects non-default value":            {property.NewMap(m{"str": property.New("different")}), "different"},
 	} {
 		tc := tc
 
@@ -517,18 +520,19 @@ func TestCheck(t *testing.T) {
 			res := Resource[checkResource]()
 			checkResp, err := res.Check(context.Background(), p.CheckRequest{
 				Urn:  "a:b:c",
-				Olds: r.PropertyMap{},
-				News: tc.input.Copy(),
+				Olds: property.Map{},
+				News: tc.input,
 			})
 			require.NoError(t, err)
 			assert.Empty(t, checkResp.Failures)
-			assert.True(t, checkResp.Inputs.HasValue("str"))
-			assert.Equal(t, tc.expected, checkResp.Inputs["str"].StringValue())
+			v, ok := checkResp.Inputs.GetOk("str")
+			assert.True(t, ok)
+			assert.Equal(t, tc.expected, v.AsString())
 		})
 
 		t.Run("DefaultCheck "+tcName, func(t *testing.T) {
 			t.Parallel()
-			in, failures, err := DefaultCheck[checkResource](context.Background(), tc.input.Copy())
+			in, failures, err := DefaultCheck[checkResource](context.Background(), tc.input)
 			require.NoError(t, err)
 			assert.Empty(t, failures)
 			assert.Equal(t, tc.expected, in.P1)

--- a/infer/tests/configure_test.go
+++ b/infer/tests/configure_test.go
@@ -17,7 +17,7 @@ package tests
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -26,15 +26,13 @@ import (
 
 func TestConfigure(t *testing.T) {
 	t.Parallel()
-	pString := resource.NewStringProperty
-	type pMap = resource.PropertyMap
 
 	prov := providerWithConfig[Config](t)
 	err := prov.Configure(p.ConfigureRequest{
-		Args: pMap{
-			"value":        pString("foo"),
-			"unknownField": pString("bar"),
-		},
+		Args: property.NewMap(map[string]property.Value{
+			"value":        property.New("foo"),
+			"unknownField": property.New("bar"),
+		}),
 	})
 	require.NoError(t, err)
 
@@ -42,18 +40,15 @@ func TestConfigure(t *testing.T) {
 		Urn: urn("ReadConfig", "config"),
 	})
 	require.NoError(t, err)
-	assert.Equal(t, pMap{
-		"config": pString("{\"Value\":\"foo\"}"),
-	}, resp.Properties)
+	assert.Equal(t, property.NewMap(map[string]property.Value{
+		"config": property.New("{\"Value\":\"foo\"}"),
+	}), resp.Properties)
 }
 
 func TestConfigureCustom(t *testing.T) {
 	t.Parallel()
-	pString := resource.NewStringProperty
-	pNumber := resource.NewNumberProperty
-	type pMap = resource.PropertyMap
 
-	test := func(inputs, expected pMap) func(t *testing.T) {
+	test := func(inputs, expected property.Map) func(t *testing.T) {
 		return func(t *testing.T) {
 			t.Parallel()
 
@@ -72,12 +67,12 @@ func TestConfigureCustom(t *testing.T) {
 	}
 
 	t.Run("empty", test( //nolint:paralleltest // test already calls t.Parallel.
-		nil,
-		pMap{"config": pString(`{"Number":null,"Squared":0}`)}))
+		property.Map{},
+		property.NewMap(map[string]property.Value{"config": property.New(`{"Number":null,"Squared":0}`)})))
 	t.Run("unknown", test( //nolint:paralleltest // test already calls t.Parallel.
-		pMap{"unknownField": pString("bar")},
-		pMap{"config": pString(`{"Number":null,"Squared":0}`)}))
+		property.NewMap(map[string]property.Value{"unknownField": property.New("bar")}),
+		property.NewMap(map[string]property.Value{"config": property.New(`{"Number":null,"Squared":0}`)})))
 	t.Run("number", test( //nolint:paralleltest // test already calls t.Parallel.
-		pMap{"number": pNumber(42)},
-		pMap{"config": pString(`{"Number":42,"Squared":1764}`)}))
+		property.NewMap(map[string]property.Value{"number": property.New(42.0)}),
+		property.NewMap(map[string]property.Value{"config": property.New(`{"Number":42,"Squared":1764}`)})))
 }

--- a/infer/tests/construct_test.go
+++ b/infer/tests/construct_test.go
@@ -22,6 +22,7 @@ import (
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/integration"
 	r "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -36,20 +37,15 @@ func TestConstruct(t *testing.T) {
 		},
 	})
 
-	prefix := r.NewProperty(r.Output{
-		Secret:       true,
-		Dependencies: []r.URN{urn("Other", "other")},
-		Known:        true,
-		Element:      r.NewStringProperty("foo-"),
-	})
+	prefix := property.New("foo-").WithSecret(true).WithDependencies([]r.URN{urn("Other", "other")})
 
 	resp, err := prov.Construct(p.ConstructRequest{
 		Urn:    childUrn("RandomComponent", "test-component", "test-parent"),
 		Parent: urn("Parent", "test-parent"),
-		Inputs: r.PropertyMap{
+		Inputs: property.NewMap(map[string]property.Value{
 			"prefix": prefix,
-		},
-		InputDependencies: map[r.PropertyKey][]r.URN{
+		}),
+		InputDependencies: map[string][]r.URN{
 			"prefix": {urn("Other", "more")},
 		},
 	})
@@ -58,7 +54,7 @@ func TestConstruct(t *testing.T) {
 	assert.Equal(t, r.URN("urn:pulumi:stack::project::test:index:Parent$test:index:RandomComponent::test-component"),
 		resp.Urn)
 
-	assert.Equal(t, r.PropertyMap{
-		"result": r.MakeSecret(r.NewStringProperty("foo-12345")),
-	}, resp.State)
+	assert.Equal(t, property.NewMap(map[string]property.Value{
+		"result": property.New("foo-12345").WithSecret(true),
+	}), resp.State)
 }

--- a/infer/tests/invoke_test.go
+++ b/infer/tests/invoke_test.go
@@ -17,7 +17,7 @@ package tests
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -26,16 +26,13 @@ import (
 
 func TestInvoke(t *testing.T) {
 	t.Parallel()
-	pString := resource.NewStringProperty
-	type pMap = resource.PropertyMap
-	type pValue = resource.PropertyValue
 
 	t.Run("missing-arg", func(t *testing.T) {
 		t.Parallel()
 		prov := provider(t)
 		resp, err := prov.Invoke(p.InvokeRequest{
 			Token: "test:index:getJoin",
-			Args:  pMap{},
+			Args:  property.Map{},
 		})
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(resp.Failures)) // Missing required field `elems`
@@ -46,20 +43,20 @@ func TestInvoke(t *testing.T) {
 		prov := provider(t)
 		resp, err := prov.Invoke(p.InvokeRequest{
 			Token: "test:index:getJoin",
-			Args: pMap{
-				"elems": pValue{V: []pValue{
-					pString("foo"),
-					pString("bar"),
-				}},
-				"sep": pString("-"),
-			},
+			Args: property.NewMap(map[string]property.Value{
+				"elems": property.New([]property.Value{
+					property.New("foo"),
+					property.New("bar"),
+				}),
+				"sep": property.New("-"),
+			}),
 		})
 		require.NoError(t, err)
 		assert.Empty(t, resp.Failures)
 
-		assert.Equal(t, pMap{
-			"result": pString("foo-bar"),
-		}, resp.Return)
+		assert.Equal(t, property.NewMap(map[string]property.Value{
+			"result": property.New("foo-bar"),
+		}), resp.Return)
 	})
 
 	t.Run("default-args", func(t *testing.T) {
@@ -67,39 +64,39 @@ func TestInvoke(t *testing.T) {
 		prov := provider(t)
 		resp, err := prov.Invoke(p.InvokeRequest{
 			Token: "test:index:getJoin",
-			Args: pMap{
-				"elems": pValue{V: []pValue{
-					pString("foo"),
-					pString("bar"),
-				}},
-			},
+			Args: property.NewMap(map[string]property.Value{
+				"elems": property.New([]property.Value{
+					property.New("foo"),
+					property.New("bar"),
+				}),
+			}),
 		})
 		require.NoError(t, err)
 		assert.Empty(t, resp.Failures)
 
-		assert.Equal(t, pMap{
-			"result": pString("foo,bar"), // default value is ","
-		}, resp.Return)
+		assert.Equal(t, property.NewMap(map[string]property.Value{
+			"result": property.New("foo,bar"), // default value is ","
+		}), resp.Return)
 	})
 	t.Run("zero-args", func(t *testing.T) {
 		t.Parallel()
 		prov := provider(t)
 		resp, err := prov.Invoke(p.InvokeRequest{
 			Token: "test:index:getJoin",
-			Args: pMap{
-				"elems": pValue{V: []pValue{
-					pString("foo"),
-					pString("bar"),
-				}},
-				"sep": pString(""),
-			},
+			Args: property.NewMap(map[string]property.Value{
+				"elems": property.New([]property.Value{
+					property.New("foo"),
+					property.New("bar"),
+				}),
+				"sep": property.New(""),
+			}),
 		})
 		require.NoError(t, err)
 		assert.Empty(t, resp.Failures)
 
-		assert.Equal(t, pMap{
-			"result": pString("foobar"), // The default doesn't apply here
-		}, resp.Return)
+		assert.Equal(t, property.NewMap(map[string]property.Value{
+			"result": property.New("foobar"), // The default doesn't apply here
+		}), resp.Return)
 	})
 
 }

--- a/infer/tests/migrate_test.go
+++ b/infer/tests/migrate_test.go
@@ -19,8 +19,8 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -48,17 +48,17 @@ func (*MigrateR) StateMigrations(context.Context) []infer.StateMigrationFunc[Mig
 	}
 }
 
-func migrateFromRaw(_ context.Context, m resource.PropertyMap) (infer.MigrationResult[MigrateStateV2], error) {
-	inputs, ok := m["__inputs"]
-	if !ok || !inputs.IsObject() {
+func migrateFromRaw(_ context.Context, m property.Map) (infer.MigrationResult[MigrateStateV2], error) {
+	inputs, ok := m.GetOk("__inputs")
+	if !ok || !inputs.IsMap() {
 		return infer.MigrationResult[MigrateStateV2]{}, nil
 	}
-	m = inputs.ObjectValue()
+	m = inputs.AsMap()
 
 	return infer.MigrationResult[MigrateStateV2]{
 		Result: &MigrateStateV2{
-			AString: m["aString"].StringValue(),
-			AInt:    int(m["aInt"].NumberValue()),
+			AString: m.Get("aString").AsString(),
+			AInt:    int(m.Get("aInt").AsNumber()),
 		},
 	}, nil
 }
@@ -114,37 +114,35 @@ func migrationServer() integration.Server {
 }
 
 // Test f on some old states that should be equivalent after upgrades.
-func testMigrationEquivalentStates(t *testing.T, f func(t *testing.T, state, v2State resource.PropertyMap)) {
+func testMigrationEquivalentStates(t *testing.T, f func(t *testing.T, state, v2State property.Map)) {
 	t.Run("defaults", func(t *testing.T) {
 
-		v2 := func() resource.PropertyMap {
-			return resource.PropertyMap{
-				"aString": resource.NewProperty("default-string"),
-				"aInt":    resource.NewProperty(-7.0),
-			}
-		}
+		v2 := property.NewMap(map[string]property.Value{
+			"aString": property.New("default-string"),
+			"aInt":    property.New(-7.0),
+		})
 
 		t.Run("raw", func(t *testing.T) {
-			f(t, resource.PropertyMap{
-				"__inputs": resource.NewProperty(resource.PropertyMap{
-					"aString": resource.NewProperty("default-string"),
-					"aInt":    resource.NewProperty(-7.0),
+			f(t, property.NewMap(map[string]property.Value{
+				"__inputs": property.New(map[string]property.Value{
+					"aString": property.New("default-string"),
+					"aInt":    property.New(-7.0),
 				}),
-			}, v2())
+			}), v2)
 		})
 
 		t.Run("v0", func(t *testing.T) {
-			f(t, resource.PropertyMap{}, v2())
+			f(t, property.Map{}, v2)
 		})
 
 		t.Run("v1", func(t *testing.T) {
-			f(t, resource.PropertyMap{
-				"aString": resource.NewProperty("default-string"),
-			}, v2())
+			f(t, property.NewMap(map[string]property.Value{
+				"aString": property.New("default-string"),
+			}), v2)
 		})
 
 		t.Run("v2", func(t *testing.T) {
-			f(t, v2(), v2())
+			f(t, v2, v2)
 		})
 	})
 
@@ -154,31 +152,29 @@ func testMigrationEquivalentStates(t *testing.T, f func(t *testing.T, state, v2S
 			aInt    = 33.0
 		)
 
-		v2 := func() resource.PropertyMap {
-			return resource.PropertyMap{
-				"aString": resource.NewProperty(aString),
-				"aInt":    resource.NewProperty(aInt),
-			}
-		}
+		v2 := property.NewMap(map[string]property.Value{
+			"aString": property.New(aString),
+			"aInt":    property.New(aInt),
+		})
 
 		t.Run("raw", func(t *testing.T) {
-			f(t, resource.PropertyMap{
-				"__inputs": resource.NewProperty(resource.PropertyMap{
-					"aString": resource.NewProperty(aString),
-					"aInt":    resource.NewProperty(aInt),
+			f(t, property.NewMap(map[string]property.Value{
+				"__inputs": property.New(map[string]property.Value{
+					"aString": property.New(aString),
+					"aInt":    property.New(aInt),
 				}),
-			}, v2())
+			}), v2)
 		})
 
 		t.Run("v1", func(t *testing.T) {
-			f(t, resource.PropertyMap{
-				"aString": resource.NewProperty(aString),
-				"someInt": resource.NewProperty(aInt),
-			}, v2())
+			f(t, property.NewMap(map[string]property.Value{
+				"aString": property.New(aString),
+				"someInt": property.New(aInt),
+			}), v2)
 		})
 
 		t.Run("v2", func(t *testing.T) {
-			f(t, v2(), v2())
+			f(t, v2, v2)
 		})
 	})
 }
@@ -186,7 +182,7 @@ func testMigrationEquivalentStates(t *testing.T, f func(t *testing.T, state, v2S
 func TestMigrateUpdate(t *testing.T) {
 	t.Parallel()
 
-	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State resource.PropertyMap) {
+	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State property.Map) {
 		resp, err := migrationServer().Update(p.UpdateRequest{
 			ID:   "some-id",
 			Urn:  urn("MigrateR", "update"),
@@ -200,7 +196,7 @@ func TestMigrateUpdate(t *testing.T) {
 func TestMigrateDiff(t *testing.T) {
 	t.Parallel()
 
-	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State resource.PropertyMap) {
+	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State property.Map) {
 		_, err := migrationServer().Diff(p.DiffRequest{
 			ID:   "some-id",
 			Urn:  urn("MigrateR", "diff"),
@@ -208,17 +204,17 @@ func TestMigrateDiff(t *testing.T) {
 		})
 		var via viaError[MigrateStateV2]
 		require.ErrorAs(t, err, &via)
-		assert.Equal(t, v2State, resource.PropertyMap{
-			"aString": resource.NewProperty(via.t.AString),
-			"aInt":    resource.NewProperty(float64(via.t.AInt)),
-		})
+		assert.Equal(t, v2State, property.NewMap(map[string]property.Value{
+			"aString": property.New(via.t.AString),
+			"aInt":    property.New(float64(via.t.AInt)),
+		}))
 	})
 }
 
 func TestMigrateDelete(t *testing.T) {
 	t.Parallel()
 
-	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State resource.PropertyMap) {
+	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State property.Map) {
 		err := migrationServer().Delete(p.DeleteRequest{
 			ID:         "some-id",
 			Urn:        urn("MigrateR", "delete"),
@@ -226,17 +222,17 @@ func TestMigrateDelete(t *testing.T) {
 		})
 		var via viaError[MigrateStateV2]
 		require.ErrorAs(t, err, &via)
-		assert.Equal(t, v2State, resource.PropertyMap{
-			"aString": resource.NewProperty(via.t.AString),
-			"aInt":    resource.NewProperty(float64(via.t.AInt)),
-		})
+		assert.Equal(t, v2State, property.NewMap(map[string]property.Value{
+			"aString": property.New(via.t.AString),
+			"aInt":    property.New(float64(via.t.AInt)),
+		}))
 	})
 }
 
 func TestMigrateRead(t *testing.T) {
 	t.Parallel()
 
-	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State resource.PropertyMap) {
+	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State property.Map) {
 		resp, err := migrationServer().Read(p.ReadRequest{
 			ID:         "some-id",
 			Urn:        urn("MigrateR", "read"),

--- a/infer/tests/provider_test.go
+++ b/infer/tests/provider_test.go
@@ -438,8 +438,8 @@ func (*ConfigCustom) Check(ctx context.Context,
 	req infer.CheckRequest,
 ) (infer.CheckResponse[*ConfigCustom], error) {
 	var c ConfigCustom
-	if v, ok := req.NewInputs["number"]; ok {
-		number := v.NumberValue() + 0.5
+	if v, ok := req.NewInputs.GetOk("number"); ok {
+		number := v.AsNumber() + 0.5
 		c.Number = &number
 	}
 
@@ -533,7 +533,7 @@ type (
 func (w *CustomCheckNoDefaults) Check(_ context.Context,
 	req infer.CheckRequest,
 ) (infer.CheckResponse[CustomCheckNoDefaultsArgs], error) {
-	input := req.NewInputs["input"].StringValue()
+	input := req.NewInputs.Get("input").AsString()
 	return infer.CheckResponse[CustomCheckNoDefaultsArgs]{
 		Inputs: CustomCheckNoDefaultsArgs{Input: input},
 	}, nil

--- a/infer/tests/update_test.go
+++ b/infer/tests/update_test.go
@@ -17,23 +17,19 @@ package tests
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 
 	p "github.com/pulumi/pulumi-go-provider"
 )
 
+//nolint:lll
 func TestUpdateManualDeps(t *testing.T) {
 	t.Parallel()
 
-	type m = resource.PropertyMap
-	c := resource.MakeComputed
-	s := resource.NewStringProperty
-	n := resource.NewNumberProperty
-
 	test := func(
 		testName, resource string,
-		olds, newsPreview, newsUpdate, expectedPreview, expectedUp m,
+		olds, newsPreview, newsUpdate, expectedPreview, expectedUp property.Map,
 	) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
@@ -41,9 +37,10 @@ func TestUpdateManualDeps(t *testing.T) {
 				t.Parallel()
 				prov := provider(t)
 				resp, err := prov.Update(p.UpdateRequest{
-					ID:   "some-id",
-					Urn:  urn(resource, "test"),
-					Olds: olds, News: newsPreview,
+					ID:      "some-id",
+					Urn:     urn(resource, "test"),
+					Olds:    olds,
+					News:    newsPreview,
 					Preview: true,
 				})
 				assert.NoError(t, err)
@@ -67,86 +64,85 @@ func TestUpdateManualDeps(t *testing.T) {
 		})
 	}
 
+	type m = map[string]property.Value
+
 	test("unchanged", "Wired",
-		m{"name": s("some-id"), "stringAndInt": s("str-5"), "stringPlus": s("str+")},  // Old Input
-		m{"string": s("str"), "int": n(5)},                                            // New Preview
-		m{"string": s("str"), "int": n(5)},                                            // New Update
-		m{"name": s("some-id"), "stringAndInt": s("str-5"), "stringPlus": s("str++")}, // Preview inputs
-		m{"name": s("some-id"), "stringAndInt": s("str-5"), "stringPlus": s("str++")}) // Full inputs
+		property.NewMap(m{"name": property.New("some-id"), "stringAndInt": property.New("str-5"), "stringPlus": property.New("str+")}),  // Old Input
+		property.NewMap(m{"string": property.New("str"), "int": property.New(5.0)}),                                                     // New Preview
+		property.NewMap(m{"string": property.New("str"), "int": property.New(5.0)}),                                                     // New Update
+		property.NewMap(m{"name": property.New("some-id"), "stringAndInt": property.New("str-5"), "stringPlus": property.New("str++")}), // Preview inputs
+		property.NewMap(m{"name": property.New("some-id"), "stringAndInt": property.New("str-5"), "stringPlus": property.New("str++")})) // Full inputs
 
 	test("int-computed", "Wired",
-		m{"name": s("some-id"), "stringAndInt": s("str-5"), "stringPlus": s("str+")},     // Old Input
-		m{"string": s("str"), "int": c(n(5))},                                            // New Input
-		m{"string": s("str"), "int": n(10)},                                              // New Update
-		m{"name": s("some-id"), "stringAndInt": c(s("str-5")), "stringPlus": s("str++")}, // Preview inputs
-		m{"name": s("some-id"), "stringAndInt": s("str-10"), "stringPlus": s("str++")})   // Full inputs
+		property.NewMap(m{"name": property.New("some-id"), "stringAndInt": property.New("str-5"), "stringPlus": property.New("str+")}),            // Old Input
+		property.NewMap(m{"string": property.New("str"), "int": property.New(property.Computed)}),                                                 // New Input
+		property.NewMap(m{"string": property.New("str"), "int": property.New(10.0)}),                                                              // New Update
+		property.NewMap(m{"name": property.New("some-id"), "stringAndInt": property.New(property.Computed), "stringPlus": property.New("str++")}), // Preview inputs
+		property.NewMap(m{"name": property.New("some-id"), "stringAndInt": property.New("str-10"), "stringPlus": property.New("str++")}))          // Full inputs
 
 	test("string-computed", "Wired",
-		m{"name": s("some-id"), "stringAndInt": s("str-5"), "stringPlus": s("str+")},        // Old Input
-		m{"string": c(s("str")), "int": n(5)},                                               // New Input
-		m{"string": s("foo"), "int": n(5)},                                                  // New Update
-		m{"name": s("some-id"), "stringAndInt": c(s("str-5")), "stringPlus": c(s("str++"))}, // Preview inputs
-		m{"name": s("some-id"), "stringAndInt": s("foo-5"), "stringPlus": s("foo++")})       // Full inputs
+		property.NewMap(m{"name": property.New("some-id"), "stringAndInt": property.New("str-5"), "stringPlus": property.New("str+")}),                      // Old Input
+		property.NewMap(m{"string": property.New(property.Computed), "int": property.New(5.0)}),                                                             // New Input
+		property.NewMap(m{"string": property.New("foo"), "int": property.New(5.0)}),                                                                         // New Update
+		property.NewMap(m{"name": property.New("some-id"), "stringAndInt": property.New(property.Computed), "stringPlus": property.New(property.Computed)}), // Preview inputs
+		property.NewMap(m{"name": property.New("some-id"), "stringAndInt": property.New("foo-5"), "stringPlus": property.New("foo++")}))                     // Full inputs
 
 	test("int-changed", "WiredPlus",
-		m{ // Old Input
-			"name": s("some-id"), "stringAndInt": s("str-5"), "stringPlus": s("str+"),
-			"string": s("str"), "int": n(5),
-		},
-		m{"string": s("str"), "int": n(10)}, // New Input
-		m{"string": s("str"), "int": n(10)}, // New Update
-		m{ // Preview inputs: int changed -> stringAndInt is now computed
-			"name": s("some-id"), "stringAndInt": c(s("str-10")), "stringPlus": s("str++"),
-			"string": s("str"), "int": n(10),
-		},
-		m{ // Full inputs
-			"name": s("some-id"), "stringAndInt": s("str-10"), "stringPlus": s("str++"),
-			"string": s("str"), "int": n(10),
-		})
+		property.NewMap(m{ // Old Input
+			"name": property.New("some-id"), "stringAndInt": property.New("str-5"), "stringPlus": property.New("str+"),
+			"string": property.New("str"), "int": property.New(5.0),
+		}),
+		property.NewMap(m{"string": property.New("str"), "int": property.New(10.0)}), // New Input
+		property.NewMap(m{"string": property.New("str"), "int": property.New(10.0)}), // New Update
+		property.NewMap(m{ // Preview inputs: int changed -> stringAndInt is now computed
+			"name": property.New("some-id"), "stringAndInt": property.New(property.Computed), "stringPlus": property.New("str++"),
+			"string": property.New("str"), "int": property.New(10.0),
+		}),
+		property.NewMap(m{ // Full inputs
+			"name": property.New("some-id"), "stringAndInt": property.New("str-10"), "stringPlus": property.New("str++"),
+			"string": property.New("str"), "int": property.New(10.0),
+		}))
 
 	test("string-changed", "WiredPlus",
-		m{ // Old Input
-			"name": s("some-id"), "stringAndInt": s("str-5"), "stringPlus": s("str+"),
-			"string": s("old-str"), "int": n(5),
-		},
-		m{"string": s("new-str"), "int": n(5)}, // New Input
-		m{"string": s("new-str"), "int": n(5)}, // New Update
-		m{ // Preview inputs
-			"name": s("some-id"), "stringAndInt": c(s("new-str-5")), "stringPlus": c(s("new-str++")),
-			"string": s("new-str"), "int": n(5),
-		},
-		m{ // Full inputs
-			"name": s("some-id"), "stringAndInt": s("new-str-5"), "stringPlus": s("new-str++"),
-			"string": s("new-str"), "int": n(5),
-		})
+		property.NewMap(m{ // Old Input
+			"name": property.New("some-id"), "stringAndInt": property.New("str-5"), "stringPlus": property.New("str+"),
+			"string": property.New("old-str"), "int": property.New(5.0),
+		}),
+		property.NewMap(m{"string": property.New("new-str"), "int": property.New(5.0)}), // New Input
+		property.NewMap(m{"string": property.New("new-str"), "int": property.New(5.0)}), // New Update
+		property.NewMap(m{ // Preview inputs
+			"name": property.New("some-id"), "stringAndInt": property.New(property.Computed), "stringPlus": property.New(property.Computed),
+			"string": property.New("new-str"), "int": property.New(5.0),
+		}),
+		property.NewMap(m{ // Full inputs
+			"name": property.New("some-id"), "stringAndInt": property.New("new-str-5"), "stringPlus": property.New("new-str++"),
+			"string": property.New("new-str"), "int": property.New(5.0),
+		}))
 }
 
 func TestUpdateDefaultDeps(t *testing.T) {
 	t.Parallel()
-	c := resource.MakeComputed
-	s := resource.NewStringProperty
-	n := resource.NewNumberProperty
 
-	test := func(t *testing.T, newString resource.PropertyValue,
-		expectedPreview, expectedUp resource.PropertyMap) {
+	test := func(t *testing.T, newString property.Value,
+		expectedPreview, expectedUp property.Map) {
 		t.Run("preview", func(t *testing.T) {
 			t.Parallel()
 			prov := provider(t)
 			resp, err := prov.Update(p.UpdateRequest{
 				ID:  "some-id",
 				Urn: urn("Echo", "preview"),
-				Olds: resource.PropertyMap{
-					"string":    s("old-string"),
-					"int":       n(1),
-					"intOut":    n(1),
-					"nameOut":   s("old-name"),
-					"stringOut": s("old-string"),
-				},
-				News: resource.PropertyMap{
+				Olds: property.NewMap(map[string]property.Value{
+					"string":    property.New("old-string"),
+					"int":       property.New(1.0),
+					"intOut":    property.New(1.0),
+					"nameOut":   property.New("old-name"),
+					"stringOut": property.New("old-string"),
+				}),
+				News: property.NewMap(map[string]property.Value{
 					// Became computed
 					"string": newString,
-					"int":    n(1),
-				},
+					"int":    property.New(1.0),
+				}),
 				Preview: true,
 			})
 			assert.NoError(t, err)
@@ -154,24 +150,29 @@ func TestUpdateDefaultDeps(t *testing.T) {
 				Properties: expectedPreview,
 			}, resp)
 		})
+		if newString.IsComputed() {
+			// We can't run the update with newString if it's computed, since
+			// providers should never receive computed values on a non-preview
+			// update.
+			return
+		}
 		t.Run("update", func(t *testing.T) {
 			t.Parallel()
 			prov := provider(t)
 			resp, err := prov.Update(p.UpdateRequest{
 				ID:  "some-id",
 				Urn: urn("Echo", "update"),
-				Olds: resource.PropertyMap{
-					"string":    s("old-string"),
-					"int":       n(1),
-					"intOut":    n(1),
-					"nameOut":   s("old-name"),
-					"stringOut": s("old-string"),
-				},
-				News: resource.PropertyMap{
-					// Became computed
+				Olds: property.NewMap(map[string]property.Value{
+					"string":    property.New("old-string"),
+					"int":       property.New(1.0),
+					"intOut":    property.New(1.0),
+					"nameOut":   property.New("old-name"),
+					"stringOut": property.New("old-string"),
+				}),
+				News: property.NewMap(map[string]property.Value{
 					"string": newString,
-					"int":    n(1),
-				},
+					"int":    property.New(1.0),
+				}),
 			})
 			assert.NoError(t, err)
 			assert.Equal(t, p.UpdateResponse{
@@ -181,59 +182,59 @@ func TestUpdateDefaultDeps(t *testing.T) {
 	}
 	t.Run("computed", func(t *testing.T) {
 		t.Parallel()
-		test(t, c(s("old-string")),
-			resource.PropertyMap{
-				"string":    c(s("old-string")),
-				"int":       n(1),
-				"stringOut": c(s("old-string")),
-				"intOut":    c(n(1)),
-				"nameOut":   c(s("old-name")),
-			},
-			resource.PropertyMap{
-				"string":    s("old-string"),
-				"int":       n(1),
-				"stringOut": s("old-string"),
-				"intOut":    n(1),
-				"nameOut":   s("old-name"),
-			},
+		test(t, property.New(property.Computed),
+			property.NewMap(map[string]property.Value{
+				"string":    property.New(property.Computed),
+				"int":       property.New(1.0),
+				"stringOut": property.New(property.Computed),
+				"intOut":    property.New(property.Computed),
+				"nameOut":   property.New(property.Computed),
+			}),
+			property.NewMap(map[string]property.Value{
+				"string":    property.New("old-string"),
+				"int":       property.New(1.0),
+				"stringOut": property.New("old-string"),
+				"intOut":    property.New(1.0),
+				"nameOut":   property.New("old-name"),
+			}),
 		)
 	})
 	t.Run("changed", func(t *testing.T) {
 		t.Parallel()
-		test(t, s("new-string"),
-			resource.PropertyMap{
-				"string":    c(s("old-string")),
-				"int":       n(1),
-				"stringOut": c(s("old-string")),
-				"intOut":    c(n(1)),
-				"nameOut":   c(s("old-name")),
-			},
-			resource.PropertyMap{
-				"string":    s("new-string"),
-				"int":       n(1),
-				"stringOut": s("new-string"),
-				"intOut":    n(1),
-				"nameOut":   s("old-name"),
-			},
+		test(t, property.New("new-string"),
+			property.NewMap(map[string]property.Value{
+				"string":    property.New(property.Computed),
+				"int":       property.New(1.0),
+				"stringOut": property.New(property.Computed),
+				"intOut":    property.New(property.Computed),
+				"nameOut":   property.New(property.Computed),
+			}),
+			property.NewMap(map[string]property.Value{
+				"string":    property.New("new-string"),
+				"int":       property.New(1.0),
+				"stringOut": property.New("new-string"),
+				"intOut":    property.New(1.0),
+				"nameOut":   property.New("old-name"),
+			}),
 		)
 	})
 	t.Run("unchanged", func(t *testing.T) {
 		t.Parallel()
-		test(t, s("old-string"),
-			resource.PropertyMap{
-				"string":    s("old-string"),
-				"int":       n(1),
-				"stringOut": s("old-string"),
-				"intOut":    n(1),
-				"nameOut":   s("old-name"),
-			},
-			resource.PropertyMap{
-				"string":    s("old-string"),
-				"int":       n(1),
-				"stringOut": s("old-string"),
-				"intOut":    n(1),
-				"nameOut":   s("old-name"),
-			},
+		test(t, property.New("old-string"),
+			property.NewMap(map[string]property.Value{
+				"string":    property.New("old-string"),
+				"int":       property.New(1.0),
+				"stringOut": property.New("old-string"),
+				"intOut":    property.New(1.0),
+				"nameOut":   property.New("old-name"),
+			}),
+			property.NewMap(map[string]property.Value{
+				"string":    property.New("old-string"),
+				"int":       property.New(1.0),
+				"stringOut": property.New("old-string"),
+				"intOut":    property.New(1.0),
+				"nameOut":   property.New("old-name"),
+			}),
 		)
 	})
 }

--- a/integration/provider_linked.go
+++ b/integration/provider_linked.go
@@ -19,11 +19,11 @@ import (
 
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	p "github.com/pulumi/pulumi-go-provider"
-	presource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
-type propertyToRPC func(m presource.PropertyMap) (*structpb.Struct, error)
+type propertyToRPC func(m property.Map) (*structpb.Struct, error)
 
 //go:linkname linkedConstructRequestToRPC github.com/pulumi/pulumi-go-provider.linkedConstructRequestToRPC
 func linkedConstructRequestToRPC(req *p.ConstructRequest, marshal propertyToRPC) *rpc.ConstructRequest

--- a/internal/rpc/marshal.go
+++ b/internal/rpc/marshal.go
@@ -16,27 +16,30 @@
 package rpc
 
 import (
-	presource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // UnmarshalProperties unmarshals a structpb.Struct into a PropertyMap.
 // This implementation is guaranteed to be lossless.
-func UnmarshalProperties(s *structpb.Struct) (presource.PropertyMap, error) {
-	return plugin.UnmarshalProperties(s, plugin.MarshalOptions{
+func UnmarshalProperties(s *structpb.Struct) (property.Map, error) {
+	rm, err := plugin.UnmarshalProperties(s, plugin.MarshalOptions{
 		SkipNulls:        false,
 		KeepUnknowns:     true,
 		KeepResources:    true,
 		KeepSecrets:      true,
 		KeepOutputValues: true,
 	})
+	return resource.FromResourcePropertyValue(resource.NewProperty(rm)).AsMap(), err
 }
 
 // MarshalProperties marshals a PropertyMap into a structpb.Struct.
 // This implementation is guaranteed to be lossless.
-func MarshalProperties(m presource.PropertyMap) (*structpb.Struct, error) {
-	return plugin.MarshalProperties(m, plugin.MarshalOptions{
+func MarshalProperties(m property.Map) (*structpb.Struct, error) {
+	rm := resource.ToResourcePropertyValue(property.New(m)).ObjectValue()
+	return plugin.MarshalProperties(rm, plugin.MarshalOptions{
 		SkipNulls:        false,
 		KeepUnknowns:     true,
 		KeepSecrets:      true,

--- a/middleware/complexconfig/provider.go
+++ b/middleware/complexconfig/provider.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 
 	p "github.com/pulumi/pulumi-go-provider"
 )
@@ -58,7 +59,7 @@ func encodeCheckConfig(check checkConfig, getSchema getSchema) checkConfig {
 		// and thus went through a previous normalizing pass of CheckConfig.
 
 		// If there are no inputs, then we can just return.
-		if len(req.News) == 0 {
+		if req.News.Len() == 0 {
 			return check(ctx, req)
 		}
 
@@ -73,23 +74,26 @@ func encodeCheckConfig(check checkConfig, getSchema getSchema) checkConfig {
 				p.InternalErrorf("unable to decode config: invalid schema: %w", err)
 		}
 
+		news := resource.ToResourcePropertyValue(property.New(req.News)).ObjectValue()
+
 		for k, spec := range spec.Config.Variables {
-			v, ok := req.News[resource.PropertyKey(k)]
+			v, ok := news[resource.PropertyKey(k)]
 			if !ok {
 				continue
 			}
 
-			req.News[resource.PropertyKey(k)] = fixEncoding(v, spec)
+			news[resource.PropertyKey(k)] = fixEncoding(v, spec)
 		}
 
 		// Attempt to decode any inputs that don't have a matching config schema.
-		for k, v := range req.News {
+		for k, v := range news {
 			if _, ok := spec.Config.Variables[string(k)]; ok {
 				continue
 			}
-			req.News[k] = fixEncoding(v, schema.PropertySpec{})
+			news[k] = fixEncoding(v, schema.PropertySpec{})
 		}
 
+		req.News = resource.FromResourcePropertyValue(resource.NewProperty(news)).AsMap()
 		return check(ctx, req)
 	}
 }

--- a/middleware/rpc/provider_linked.go
+++ b/middleware/rpc/provider_linked.go
@@ -19,11 +19,11 @@ import (
 
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	p "github.com/pulumi/pulumi-go-provider"
-	presource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
-type propertyToRPC func(m presource.PropertyMap) (*structpb.Struct, error)
+type propertyToRPC func(m property.Map) (*structpb.Struct, error)
 
 //go:linkname linkedConstructRequestToRPC github.com/pulumi/pulumi-go-provider.linkedConstructRequestToRPC
 func linkedConstructRequestToRPC(req *p.ConstructRequest, marshal propertyToRPC) *rpc.ConstructRequest

--- a/tests/cancel_test.go
+++ b/tests/cancel_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -43,7 +43,7 @@ func TestGlobalCancel(t *testing.T) {
 			Create: func(ctx context.Context, req p.CreateRequest) (p.CreateResponse, error) {
 
 				// If a request is set to wait, then it pauses until it is canceled.
-				if req.Properties["wait"].BoolValue() {
+				if req.Properties.Get("wait").AsBool() {
 					<-ctx.Done()
 
 					return p.CreateResponse{}, ctx.Err()
@@ -71,9 +71,9 @@ func TestGlobalCancel(t *testing.T) {
 		for i := 0; i < testSize/2; i++ {
 			go func() {
 				_, err := provider.Create(p.CreateRequest{
-					Properties: resource.PropertyMap{
-						"wait": resource.NewProperty(true),
-					},
+					Properties: property.NewMap(map[string]property.Value{
+						"wait": property.New(true),
+					}),
 				})
 				assert.ErrorIs(t, err, context.Canceled)
 				finished.Done()
@@ -88,9 +88,9 @@ func TestGlobalCancel(t *testing.T) {
 		shouldWait := i%2 == 0
 		go func() {
 			_, err := provider.Create(p.CreateRequest{
-				Properties: resource.PropertyMap{
-					"wait": resource.NewProperty(shouldWait),
-				},
+				Properties: property.NewMap(map[string]property.Value{
+					"wait": property.New(shouldWait),
+				}),
 			})
 			if shouldWait {
 				assert.ErrorIs(t, err, context.Canceled)

--- a/tests/component_test.go
+++ b/tests/component_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -71,18 +72,18 @@ func TestConstruct(t *testing.T) {
 
 	resp, err := provider(t).Construct(p.ConstructRequest{
 		Urn: resource.CreateURN("name", "foo:tests:Foo", "", "proj", "stack"),
-		Inputs: map[resource.PropertyKey]resource.PropertyValue{
-			"foo": resource.NewProperty("foo"),
-			"bundle": resource.NewObjectProperty(resource.PropertyMap{
-				"v1": resource.NewProperty("3.14"),
-				"v2": resource.NewProperty(3.14),
+		Inputs: property.NewMap(map[string]property.Value{
+			"foo": property.New("foo"),
+			"bundle": property.New(map[string]property.Value{
+				"v1": property.New("3.14"),
+				"v2": property.New(3.14),
 			}),
-		},
+		}),
 	})
 	require.NoError(t, err)
-	assert.Equal(t, resource.PropertyMap{
-		"bar": resource.NewProperty("foobar"),
-	}, resp.State)
+	assert.Equal(t, property.NewMap(map[string]property.Value{
+		"bar": property.New("foobar"),
+	}), resp.State)
 }
 
 func TestComponentSchema(t *testing.T) {

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi-go-provider/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 type testConfig struct {
@@ -57,7 +58,7 @@ func TestInferConfigWrap(t *testing.T) {
 		"test", semver.MustParse("1.2.3"),
 		infer.Wrap(p.Provider{
 			Configure: func(ctx context.Context, req p.ConfigureRequest) error {
-				assert.Equal(t, "foo", req.Args["field"].StringValue())
+				assert.Equal(t, "foo", req.Args.Get("field").AsString())
 				baseConfigureWasCalled = true
 				return nil
 			},
@@ -74,7 +75,9 @@ func TestInferConfigWrap(t *testing.T) {
 	)
 
 	err := s.Configure(p.ConfigureRequest{
-		Args: resource.PropertyMap{"field": resource.NewProperty("foo")},
+		Args: property.NewMap(map[string]property.Value{
+			"field": property.New("foo"),
+		}),
 	})
 	require.NoError(t, err)
 
@@ -109,46 +112,46 @@ func TestInferCheckConfigSecrets(t *testing.T) {
 	resp, err := integration.NewServer("test", semver.MustParse("0.0.0"), infer.Provider(infer.Options{
 		Config: infer.Config[config](),
 	})).CheckConfig(p.CheckRequest{
-		News: resource.PropertyMap{
-			"field": resource.NewProperty("value"),
-			"nested": resource.NewProperty(resource.PropertyMap{
-				"int":        resource.NewProperty(1.0),
-				"not-nested": resource.NewProperty("not-secret"),
+		News: property.NewMap(map[string]property.Value{
+			"field": property.New("value"),
+			"nested": property.New(map[string]property.Value{
+				"int":        property.New(1.0),
+				"not-nested": property.New("not-secret"),
 			}),
-			"arrayNested": resource.NewProperty([]resource.PropertyValue{
-				resource.NewProperty(resource.PropertyMap{
-					"field": resource.NewProperty("123"),
+			"arrayNested": property.New([]property.Value{
+				property.New(map[string]property.Value{
+					"field": property.New("123"),
 				}),
 			}),
-			"mapNested": resource.NewProperty(resource.PropertyMap{
-				"key": resource.NewProperty(resource.PropertyMap{
-					"field": resource.NewProperty("123"),
+			"mapNested": property.New(map[string]property.Value{
+				"key": property.New(map[string]property.Value{
+					"field": property.New("123"),
 				}),
 			}),
-			"not": resource.NewProperty("not-secret"),
-		},
+			"not": property.New("not-secret"),
+		}),
 	})
 	require.NoError(t, err)
 	require.Empty(t, resp.Failures)
-	assert.Equal(t, resource.PropertyMap{
-		"__pulumi-go-provider-infer": resource.NewBoolProperty(true),
-		"field":                      resource.MakeSecret(resource.NewProperty("value")),
-		"nested": resource.NewProperty(resource.PropertyMap{
-			"int":        resource.MakeSecret(resource.NewProperty(1.0)),
-			"not-nested": resource.NewProperty("not-secret"),
+	assert.Equal(t, property.NewMap(map[string]property.Value{
+		"__pulumi-go-provider-infer": property.New(true),
+		"field":                      property.New("value").WithSecret(true),
+		"nested": property.New(map[string]property.Value{
+			"int":        property.New(1.0).WithSecret(true),
+			"not-nested": property.New("not-secret"),
 		}),
-		"arrayNested": resource.NewProperty([]resource.PropertyValue{
-			resource.NewProperty(resource.PropertyMap{
-				"field": resource.MakeSecret(resource.NewProperty("123")),
+		"arrayNested": property.New([]property.Value{
+			property.New(map[string]property.Value{
+				"field": property.New("123").WithSecret(true),
 			}),
 		}),
-		"mapNested": resource.NewProperty(resource.PropertyMap{
-			"key": resource.NewProperty(resource.PropertyMap{
-				"field": resource.MakeSecret(resource.NewProperty("123")),
+		"mapNested": property.New(map[string]property.Value{
+			"key": property.New(map[string]property.Value{
+				"field": property.New("123").WithSecret(true),
 			}),
 		}),
-		"not": resource.NewProperty("not-secret"),
-	}, resp.Inputs)
+		"not": property.New("not-secret"),
+	}), resp.Inputs)
 }
 
 type config struct {
@@ -162,25 +165,25 @@ var _ infer.CustomCheck[*config] = &config{}
 func (c *config) Check(
 	ctx context.Context, req infer.CheckRequest,
 ) (infer.CheckResponse[*config], error) {
-	if req.NewInputs.ContainsSecrets() {
+	if property.New(req.NewInputs).HasSecrets() {
 		return infer.CheckResponse[*config]{Inputs: c}, fmt.Errorf("found secrets")
 	}
 
-	if v, ok := req.NewInputs["applyDefaults"]; ok && v.IsBool() && v.BoolValue() {
+	if v, ok := req.NewInputs.GetOk("applyDefaults"); ok && v.IsBool() && v.AsBool() {
 		d, f, err := infer.DefaultCheck[config](ctx, req.NewInputs)
 		*c = d
 		return infer.CheckResponse[*config]{Inputs: &d, Failures: f}, err
 	}
 
 	// No defaults, so apply manually
-	if v := req.NewInputs["field"]; v.IsString() {
-		c.Field = v.StringValue()
+	if v := req.NewInputs.Get("field"); v.IsString() {
+		c.Field = v.AsString()
 	}
-	if v := req.NewInputs["not"]; v.IsString() {
-		c.NotSecret = v.StringValue()
+	if v := req.NewInputs.Get("not"); v.IsString() {
+		c.NotSecret = v.AsString()
 	}
-	if v := req.NewInputs["apply-defaults"]; v.IsBool() {
-		c.ApplyDefaults = v.BoolValue()
+	if v := req.NewInputs.Get("apply-defaults"); v.IsBool() {
+		c.ApplyDefaults = v.AsBool()
 	}
 	return infer.CheckResponse[*config]{Inputs: c}, nil
 }
@@ -200,20 +203,20 @@ func TestInferCustomCheckConfig(t *testing.T) {
 			t.Parallel()
 			resp, err := s.CheckConfig(p.CheckRequest{
 				Urn: resource.CreateURN("p", "pulumi:providers:test", "", "test", "dev"),
-				News: resource.PropertyMap{
-					"field":         resource.NewProperty("value"),
-					"not":           resource.NewProperty("not-secret"),
-					"applyDefaults": resource.NewProperty(applyDefaults),
-				},
+				News: property.NewMap(map[string]property.Value{
+					"field":         property.New("value"),
+					"not":           property.New("not-secret"),
+					"applyDefaults": property.New(applyDefaults),
+				}),
 			})
 			require.NoError(t, err)
 			require.Empty(t, resp.Failures)
-			assert.Equal(t, resource.PropertyMap{
-				"__pulumi-go-provider-infer": resource.NewBoolProperty(true),
-				"field":                      resource.MakeSecret(resource.NewProperty("value")),
-				"not":                        resource.NewProperty("not-secret"),
-				"applyDefaults":              resource.NewProperty(applyDefaults),
-			}, resp.Inputs)
+			assert.Equal(t, property.NewMap(map[string]property.Value{
+				"__pulumi-go-provider-infer": property.New(true),
+				"field":                      property.New("value").WithSecret(true),
+				"not":                        property.New("not-secret"),
+				"applyDefaults":              property.New(applyDefaults),
+			}), resp.Inputs)
 		})
 	}
 }

--- a/tests/grpc/call_test.go
+++ b/tests/grpc/call_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -91,11 +92,11 @@ func TestCall(t *testing.T) {
 }`
 
 	call := func(_ context.Context, req p.CallRequest) (p.CallResponse, error) {
-		assert.Equal(t, resource.PropertyMap{
-			"k1": resource.NewProperty("s"),
-			"k2": resource.NewProperty(3.14),
-		}, req.Args)
-		assert.Equal(t, map[resource.PropertyKey][]resource.URN{
+		assert.Equal(t, property.NewMap(map[string]property.Value{
+			"k1": property.New("s"),
+			"k2": property.New(3.14),
+		}), req.Args)
+		assert.Equal(t, map[string][]resource.URN{
 			"k1": {resource.URN("urn1"), resource.URN("urn2")},
 		}, req.ArgDependencies)
 		assert.Equal(t, tokens.ModuleMember("some-token"), req.Tok)
@@ -110,14 +111,11 @@ func TestCall(t *testing.T) {
 		assert.Equal(t, true, req.AcceptsOutputValues)
 
 		return p.CallResponse{
-			Return: resource.PropertyMap{
-				"r1": resource.NewProperty(resource.Output{
-					Element: resource.NewProperty("e1"),
-					Dependencies: []resource.URN{
-						"urn1", "urn2",
-					},
+			Return: property.NewMap(map[string]property.Value{
+				"r1": property.New(property.Computed).WithDependencies([]resource.URN{
+					"urn1", "urn2",
 				}),
-			},
+			}),
 		}, nil
 	}
 

--- a/tests/grpc/construct_test.go
+++ b/tests/grpc/construct_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -129,10 +130,10 @@ func TestConstruct(t *testing.T) {
 				ID:  "09e6d266-58b0-4452-8395-7bbe03011fad",
 			},
 		}, req.Providers)
-		assert.Equal(t, map[resource.PropertyKey][]resource.URN{
+		assert.Equal(t, map[string][]resource.URN{
 			"k1": {resource.URN("urn4"), resource.URN("urn5")},
 		}, req.InputDependencies)
-		assert.Equal(t, []resource.PropertyKey{"r1"}, req.AdditionalSecretOutputs)
+		assert.Equal(t, []string{"r1"}, req.AdditionalSecretOutputs)
 		assert.Equal(t, &resource.CustomTimeouts{Create: 60, Update: 120, Delete: 180}, req.CustomTimeouts)
 		assert.Equal(t, resource.URN("urn6"), req.DeletedWith)
 		assert.Equal(t, &_true, req.DeleteBeforeReplace)
@@ -140,25 +141,21 @@ func TestConstruct(t *testing.T) {
 		assert.Equal(t, []string{"k2"}, req.ReplaceOnChanges)
 		assert.Equal(t, true, req.AcceptsOutputValues)
 
-		assert.Equal(t, resource.PropertyMap{
-			"k1": resource.NewProperty("s"),
-		}, req.Inputs)
-		assert.Equal(t, map[resource.PropertyKey][]resource.URN{
+		assert.Equal(t, property.NewMap(map[string]property.Value{
+			"k1": property.New("s"),
+		}), req.Inputs)
+		assert.Equal(t, map[string][]resource.URN{
 			"k1": {resource.URN("urn4"), resource.URN("urn5")},
 		}, req.InputDependencies)
 
 		return p.ConstructResponse{
 			Urn: resource.URN("urn:pulumi:test::test::test:index:Parent$test:index:Component::test-component"),
-			State: resource.PropertyMap{
-				"r1": resource.NewProperty(resource.Output{
-					// Element: resource.NewProperty("e1"),
-					// Known:   true,
-					Dependencies: []resource.URN{
-						"urn7", "urn8",
-					},
+			State: property.NewMap(map[string]property.Value{
+				"r1": property.New(property.Computed).WithDependencies([]resource.URN{
+					"urn7", "urn8",
 				}),
-			},
-			StateDependencies: map[resource.PropertyKey][]resource.URN{
+			}),
+			StateDependencies: map[string][]resource.URN{
 				"r1": {resource.URN("urn7"), resource.URN("urn8")},
 			},
 		}, nil

--- a/tests/invoke_test.go
+++ b/tests/invoke_test.go
@@ -25,7 +25,7 @@ import (
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi-go-provider/integration"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 type inv struct{}
@@ -59,13 +59,13 @@ func TestInferInvokeSecrets(t *testing.T) {
 		},
 	})).Invoke(p.InvokeRequest{
 		Token: "test:index:inv",
-		Args: map[resource.PropertyKey]resource.PropertyValue{
-			"field": resource.NewProperty("value"),
-		},
+		Args: property.NewMap(map[string]property.Value{
+			"field": property.New("value"),
+		}),
 	})
 	require.NoError(t, err)
 	require.Empty(t, resp.Failures)
-	assert.Equal(t, resource.PropertyMap{
-		"out": resource.MakeSecret(resource.NewProperty("value-secret")),
-	}, resp.Return)
+	assert.Equal(t, property.NewMap(map[string]property.Value{
+		"out": property.New("value-secret").WithSecret(true),
+	}), resp.Return)
 }

--- a/tests/resource_test.go
+++ b/tests/resource_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi-go-provider/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 type res struct{}
@@ -53,13 +54,13 @@ func TestInferCheckSecrets(t *testing.T) {
 		},
 	})).Check(p.CheckRequest{
 		Urn: resource.CreateURN("name", "test:index:res", "", "proj", "stack"),
-		News: map[resource.PropertyKey]resource.PropertyValue{
-			"field": resource.NewProperty("value"),
-		},
+		News: property.NewMap(map[string]property.Value{
+			"field": property.New("value"),
+		}),
 	})
 	require.NoError(t, err)
 	require.Empty(t, resp.Failures)
-	assert.Equal(t, resource.PropertyMap{
-		"field": resource.MakeSecret(resource.NewProperty("value")),
-	}, resp.Inputs)
+	assert.Equal(t, property.NewMap(map[string]property.Value{
+		"field": property.New("value").WithSecret(true),
+	}), resp.Inputs)
 }

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -687,11 +687,11 @@ func exampleCallReturns() (map[string]any, resource.PropertyMap) {
 		}
 }
 
-func exampleCallReturnDependencies() (map[string]*rpc.CallResponse_ReturnDependencies, map[resource.PropertyKey][]resource.URN) {
+func exampleCallReturnDependencies() (map[string]*rpc.CallResponse_ReturnDependencies, map[string][]resource.URN) {
 	return map[string]*rpc.CallResponse_ReturnDependencies{
 			"r1": {Urns: []string{"urn1", "urn2"}},
 		},
-		map[resource.PropertyKey][]resource.URN{
+		map[string][]resource.URN{
 			"r1": {"urn1", "urn2"},
 		}
 }


### PR DESCRIPTION
We believe that `property.Value` is a safer and less mistake prone API compared to `resource.PropertyValue`. While we break all the things, let's take the opportunity to use the better representation of pulumi values. Critically, `property.Value` is an immutable data type. **We require an immutable value representation to handle a native set type**, which we would like to add in the future.

This PR changes all public APIs in this repo to use `property.Value` and `property.Map` instead of `resource.PropertyValue` and `resource.PropertyMap`. Internal values were migrated only as convenient, primarily to reduce the size of this already large PR. 

Fixes https://github.com/pulumi/pulumi-go-provider/issues/347