### PR TITLE
Remove `InputDependencies` from Provider interface

### DIFF
--- a/infer/tests/construct_test.go
+++ b/infer/tests/construct_test.go
@@ -45,9 +45,6 @@ func TestConstruct(t *testing.T) {
 		Inputs: property.NewMap(map[string]property.Value{
 			"prefix": prefix,
 		}),
-		InputDependencies: map[string][]r.URN{
-			"prefix": {urn("Other", "more")},
-		},
 	})
 
 	assert.NoError(t, err)

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -251,7 +251,6 @@ func (h *host) Construct(ctx context.Context, req p.ConstructRequest, construct 
 
 func (s *server) Call(req p.CallRequest) (p.CallResponse, error) {
 	// apply some defaults for convenience
-	req.AcceptsOutputValues = true
 	if req.Parallel < 1 {
 		req.Parallel = 1
 	}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -219,7 +219,6 @@ func (s *server) Delete(req p.DeleteRequest) error {
 
 func (s *server) Construct(req p.ConstructRequest) (p.ConstructResponse, error) {
 	// apply some defaults for convenenience
-	req.AcceptsOutputValues = true
 	if req.Parallel < 1 {
 		req.Parallel = 1
 	}

--- a/internal/putil/putil.go
+++ b/internal/putil/putil.go
@@ -231,3 +231,12 @@ func ParseProviderReference(s string) (resource.URN, resource.ID, error) {
 func FormatProviderReference(urn resource.URN, id resource.ID) string {
 	return fmt.Sprintf("%s%s%s", urn, resource.URNNameDelimiter, id)
 }
+
+// ToUrns converts a slice of strings to a slice of URNs.
+func ToUrns(s []string) []resource.URN {
+	r := make([]resource.URN, len(s))
+	for i, a := range s {
+		r[i] = resource.URN(a)
+	}
+	return r
+}

--- a/internal/putil/putil.go
+++ b/internal/putil/putil.go
@@ -236,14 +236,7 @@ func FormatProviderReference(urn resource.URN, id resource.ID) string {
 }
 
 // ToUrns converts a slice of strings to a slice of URNs.
-func ToUrns(s []string) []resource.URN {
-	r := make([]resource.URN, len(s))
-	for i, a := range s {
-		r[i] = resource.URN(a)
-	}
-	return r
-}
-func ToUrns2(s []string) []urn.URN {
+func ToUrns(s []string) []urn.URN {
 	r := make([]urn.URN, len(s))
 	for i, a := range s {
 		r[i] = urn.URN(a)
@@ -251,15 +244,7 @@ func ToUrns2(s []string) []urn.URN {
 	return r
 }
 
-func FromUrns(urns []resource.URN) []string {
-	r := make([]string, len(urns))
-	for i, urn := range urns {
-		r[i] = string(urn)
-	}
-	return r
-}
-
-func FromUrns2(urns []urn.URN) []string {
+func FromUrns(urns []urn.URN) []string {
 	r := make([]string, len(urns))
 	for i, urn := range urns {
 		r[i] = string(urn)

--- a/internal/putil/putil.go
+++ b/internal/putil/putil.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // IsComputed checks if v is some form of a computed/unknown value.
@@ -239,4 +240,27 @@ func ToUrns(s []string) []resource.URN {
 		r[i] = resource.URN(a)
 	}
 	return r
+}
+
+// Walk traverses a property value along all paths, performing a depth first search.
+func Walk(v property.Value, f func(property.Value) (continueWalking bool)) bool {
+	cont := f(v)
+	if !cont {
+		return false
+	}
+	switch {
+	case v.IsArray():
+		for _, v := range v.AsArray().All {
+			if !Walk(v, f) {
+				return false
+			}
+		}
+	case v.IsMap():
+		for _, v := range v.AsMap().All {
+			if !Walk(v, f) {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/internal/putil/putil_test.go
+++ b/internal/putil/putil_test.go
@@ -330,6 +330,7 @@ func TestMergePropertyDependencies(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got := putil.MergePropertyDependencies(tc.m, tc.deps)
 			assert.Equal(t, tc.want, got)
 		})

--- a/internal/putil/putil_test.go
+++ b/internal/putil/putil_test.go
@@ -287,7 +287,7 @@ func TestMergePropertyDependencies(t *testing.T) {
 		{
 			name: "output value with extra dependencies",
 			m:    property.NewMap(map[string]property.Value{"k1": s.WithDependencies([]r.URN{"urn1"})}),
-			deps: map[string][]urn.URN{"k1": {"urn2"}},
+			deps: map[string][]urn.URN{"k1": {"urn2"}}, // an extra dependency
 			want: property.NewMap(map[string]property.Value{"k1": s.WithDependencies([]r.URN{"urn1", "urn2"})}),
 		},
 		{
@@ -297,14 +297,32 @@ func TestMergePropertyDependencies(t *testing.T) {
 			want: property.NewMap(map[string]property.Value{"k1": s.WithDependencies([]r.URN{"urn1"})}),
 		},
 		{
-			name: "output value with folded dependencies (from children)",
-			m: property.NewMap(map[string]property.Value{"k1": property.New(map[string]property.Value{
-				"k2": s.WithDependencies([]r.URN{"urn1"}),
-			})}),
+			name: "output value with folded dependencies (from child)",
+			m: property.NewMap(map[string]property.Value{
+				"k1": property.New(map[string]property.Value{
+					"k2": s.WithDependencies([]r.URN{"urn1"}),
+				}),
+			}),
 			deps: map[string][]urn.URN{"k1": {"urn1"}}, // a folded dependency from k2
-			want: property.NewMap(map[string]property.Value{"k1": property.New(map[string]property.Value{
-				"k2": s.WithDependencies([]r.URN{"urn1"}),
-			})}),
+			want: property.NewMap(map[string]property.Value{
+				"k1": property.New(map[string]property.Value{
+					"k2": s.WithDependencies([]r.URN{"urn1"}),
+				}),
+			}),
+		},
+		{
+			name: "output value with extra dependencies and folded dependencies",
+			m: property.NewMap(map[string]property.Value{
+				"k1": property.New(map[string]property.Value{
+					"k2": s.WithDependencies([]r.URN{"urn1"}),
+				}),
+			}),
+			deps: map[string][]urn.URN{"k1": {"urn1", "urn2"}}, // a folded dependency from k2 and an extra dependency
+			want: property.NewMap(map[string]property.Value{
+				"k1": property.New(map[string]property.Value{
+					"k2": s.WithDependencies([]r.URN{"urn1"}),
+				}).WithDependencies([]r.URN{"urn2"}),
+			}),
 		},
 	}
 

--- a/internal/putil/putil_test.go
+++ b/internal/putil/putil_test.go
@@ -15,6 +15,7 @@
 package putil_test
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/pulumi/pulumi-go-provider/internal/putil"
@@ -191,7 +192,7 @@ func TestWalk(t *testing.T) {
 					"k1": property.New("k1").WithDependencies([]r.URN{"k1"}),
 					"k2": property.New("k2").WithDependencies([]r.URN{"k2"}),
 				}).WithDependencies([]r.URN{"m"}),
-				want: []r.URN{"m", "k1", "k2"},
+				want: []r.URN{"k1", "k2", "m"},
 			},
 			{
 				v: property.New([]property.Value{
@@ -209,6 +210,7 @@ func TestWalk(t *testing.T) {
 					got = append(got, v.Dependencies()...)
 					return true
 				})
+				slices.Sort(got)
 				assert.Equal(t, tc.want, got)
 				assert.True(t, continueWalking)
 			})

--- a/middleware/rpc/provider.go
+++ b/middleware/rpc/provider.go
@@ -267,16 +267,16 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 
 			// downgrade the input dependencies if the provider doesn't support output values,
 			// in which case the [runtime.propertyToRPC] function discarded the dependency information.
+			inputDependencies := map[string]*rpc.ConstructRequest_PropertyDependencies{}
 			if !runtime.configuration.AcceptOutputs {
-				inputDependencies := map[string]*rpc.ConstructRequest_PropertyDependencies{}
 				for name, v := range req.Inputs.All {
 					urns := getPropertyDependencies(v)
 					if len(urns) != 0 {
 						inputDependencies[name] = &rpc.ConstructRequest_PropertyDependencies{Urns: urns}
 					}
 				}
-				rpcReq.InputDependencies = inputDependencies
 			}
+			rpcReq.InputDependencies = inputDependencies
 
 			rpcResp, err := server.Construct(ctx, rpcReq)
 			if err != nil {
@@ -306,20 +306,19 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 			}
 
 			rpcReq := linkedCallRequestToRPC(&req, runtime.propertyToRPC)
-			rpcReq.AcceptsOutputValues = true
 
 			// downgrade the arg dependencies if the provider doesn't support output values,
 			// in which case the [runtime.propertyToRPC] function discarded the dependency information.
+			argDependencies := map[string]*rpc.CallRequest_ArgumentDependencies{}
 			if !runtime.configuration.AcceptOutputs {
-				argDependencies := map[string]*rpc.CallRequest_ArgumentDependencies{}
 				for name, v := range req.Args.All {
 					urns := getPropertyDependencies(v)
 					if len(urns) != 0 {
 						argDependencies[name] = &rpc.CallRequest_ArgumentDependencies{Urns: urns}
 					}
 				}
-				rpcReq.ArgDependencies = argDependencies
 			}
+			rpcReq.ArgDependencies = argDependencies
 
 			rpcResp, err := server.Call(ctx, rpcReq)
 			if err != nil {

--- a/middleware/rpc/provider.go
+++ b/middleware/rpc/provider.go
@@ -271,7 +271,7 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 				for name, v := range req.Inputs.All {
 					urns := putil.GetPropertyDependencies(v)
 					if len(urns) != 0 {
-						inputDependencies[name] = &rpc.ConstructRequest_PropertyDependencies{Urns: putil.FromUrns2(urns)}
+						inputDependencies[name] = &rpc.ConstructRequest_PropertyDependencies{Urns: putil.FromUrns(urns)}
 					}
 				}
 			}
@@ -291,7 +291,7 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 			// in which case [rpcResp.StateDependencies] has meaningful information.
 			stateDeps := make(map[string][]urn.URN, len(rpcResp.GetStateDependencies()))
 			for name, deps := range rpcResp.GetStateDependencies() {
-				stateDeps[name] = putil.ToUrns2(deps.GetUrns())
+				stateDeps[name] = putil.ToUrns(deps.GetUrns())
 			}
 			resp.State = putil.MergePropertyDependencies(resp.State, stateDeps)
 
@@ -311,7 +311,7 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 				for name, v := range req.Args.All {
 					urns := putil.GetPropertyDependencies(v)
 					if len(urns) != 0 {
-						argDependencies[name] = &rpc.CallRequest_ArgumentDependencies{Urns: putil.FromUrns2(urns)}
+						argDependencies[name] = &rpc.CallRequest_ArgumentDependencies{Urns: putil.FromUrns(urns)}
 					}
 				}
 			}
@@ -331,7 +331,7 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 			// in which case [rpcResp.ReturnDependencies] has meaningful information.
 			returnDeps := make(map[string][]urn.URN, len(rpcResp.GetReturnDependencies()))
 			for name, deps := range rpcResp.GetReturnDependencies() {
-				returnDeps[name] = putil.ToUrns2(deps.GetUrns())
+				returnDeps[name] = putil.ToUrns(deps.GetUrns())
 			}
 			resp.Return = putil.MergePropertyDependencies(resp.Return, returnDeps)
 

--- a/provider.go
+++ b/provider.go
@@ -795,7 +795,10 @@ func (h *host) Call(ctx context.Context, req CallRequest, call comProvider.CallF
 	if err != nil {
 		return CallResponse{}, err
 	}
-	// note that r.ReturnDependencies is ignored because req.AcceptsOutputValues is true
+
+	// note that req.ReturnDependencies is silently discarded
+	// because the information is simply derived from the property values in r.Return.
+
 	return newCallResponse(r)
 }
 
@@ -947,8 +950,6 @@ func newCallResponse(req *rpc.CallResponse) (CallResponse, error) {
 			return failures
 		}(),
 	}
-
-	// note that req.ReturnDependencies is ignored
 
 	return r, nil
 }
@@ -1436,8 +1437,6 @@ func newConstructResponse(req *rpc.ConstructResponse) (ConstructResponse, error)
 		return ConstructResponse{}, err
 	}
 
-	// note that req.StateDependencies is ignored
-
 	r := ConstructResponse{
 		Urn:   presource.URN(req.Urn),
 		State: state,
@@ -1476,7 +1475,10 @@ func (h *host) Construct(ctx context.Context, req ConstructRequest, construct co
 	if err != nil {
 		return ConstructResponse{}, err
 	}
-	// note that r.StateDependencies is ignored because req.AcceptsOutputValues is true
+
+	// note that req.StateDependencies is silently discarded
+	// because the information is simply derived from the property values in req.State.
+
 	return newConstructResponse(r)
 }
 

--- a/provider.go
+++ b/provider.go
@@ -846,8 +846,6 @@ type CallRequest struct {
 	MonitorEndpoint string
 	// the organization of the stack being deployed into.
 	Organization string
-	// AcceptsOutputValues is true if the caller is capable of accepting output values in response to the call.
-	AcceptsOutputValues bool
 }
 
 func newCallRequest(req *rpc.CallRequest,
@@ -893,11 +891,10 @@ func newCallRequest(req *rpc.CallRequest,
 			}
 			return keys
 		}(),
-		DryRun:              req.GetDryRun(),
-		Parallel:            req.GetParallel(),
-		MonitorEndpoint:     req.GetMonitorEndpoint(),
-		Organization:        req.GetOrganization(),
-		AcceptsOutputValues: req.GetAcceptsOutputValues(),
+		DryRun:          req.GetDryRun(),
+		Parallel:        req.GetParallel(),
+		MonitorEndpoint: req.GetMonitorEndpoint(),
+		Organization:    req.GetOrganization(),
 	}
 
 	args, err := unmarshal(req.GetArgs())
@@ -957,7 +954,7 @@ func (c CallRequest) rpc(marshal propertyToRPC) *rpc.CallRequest {
 		Parallel:            c.Parallel,
 		MonitorEndpoint:     c.MonitorEndpoint,
 		Organization:        c.Organization,
-		AcceptsOutputValues: c.AcceptsOutputValues,
+		AcceptsOutputValues: true,
 	}
 
 	return req

--- a/provider.go
+++ b/provider.go
@@ -785,14 +785,6 @@ func (p *provider) Call(ctx context.Context, req *rpc.CallRequest) (*rpc.CallRes
 		}
 		returnDependencies[name] = &rpc.CallResponse_ReturnDependencies{Urns: urns}
 	}
-	for name, v := range resp.Return.All {
-		deps := v.Dependencies()
-		urns := make([]string, 0, len(deps))
-		for _, u := range v.Dependencies() {
-			urns = append(urns, string(u))
-		}
-		returnDependencies[name] = &rpc.CallResponse_ReturnDependencies{Urns: urns}
-	}
 
 	_return, err := p.asStruct(resp.Return)
 	if err != nil {

--- a/provider.go
+++ b/provider.go
@@ -875,7 +875,7 @@ func newCallRequest(req *rpc.CallRequest,
 		// upgrade the args to include the dependencies
 		argDeps := make(map[string][]urn.URN, len(req.GetArgDependencies()))
 		for name, deps := range req.GetArgDependencies() {
-			argDeps[name] = putil.ToUrns2(deps.GetUrns())
+			argDeps[name] = putil.ToUrns(deps.GetUrns())
 		}
 		r.Args = putil.MergePropertyDependencies(args, argDeps)
 	}
@@ -1225,6 +1225,14 @@ type ProviderReference struct {
 	ID  presource.ID
 }
 
+func toUrns(s []string) []presource.URN {
+	r := make([]presource.URN, len(s))
+	for i, a := range s {
+		r[i] = presource.URN(a)
+	}
+	return r
+}
+
 func newConstructRequest(req *rpc.ConstructRequest,
 	unmarshal func(s *structpb.Struct) (property.Map, error),
 ) (ConstructRequest, error) {
@@ -1305,8 +1313,8 @@ func newConstructRequest(req *rpc.ConstructRequest,
 			}
 			return m
 		}(),
-		Aliases:      putil.ToUrns(req.GetAliases()),
-		Dependencies: putil.ToUrns(req.GetDependencies()),
+		Aliases:      toUrns(req.GetAliases()),
+		Dependencies: toUrns(req.GetDependencies()),
 		AdditionalSecretOutputs: func() []string {
 			r := make([]string, len(req.GetAdditionalSecretOutputs()))
 			for i, k := range req.GetAdditionalSecretOutputs() {
@@ -1339,7 +1347,7 @@ func newConstructRequest(req *rpc.ConstructRequest,
 		// upgrade the inputs to include the dependencies
 		inputDeps := make(map[string][]urn.URN, len(req.GetInputDependencies()))
 		for name, deps := range req.GetInputDependencies() {
-			inputDeps[name] = putil.ToUrns2(deps.GetUrns())
+			inputDeps[name] = putil.ToUrns(deps.GetUrns())
 		}
 		r.Inputs = putil.MergePropertyDependencies(inputs, inputDeps)
 	}

--- a/provider.go
+++ b/provider.go
@@ -1191,9 +1191,6 @@ type ConstructRequest struct {
 	// Providers is a map from package name to provider reference.
 	Providers map[tokens.Package]ProviderReference
 
-	// InputDependencies is a map from property name to a list of resources that property depends on.
-	InputDependencies map[string][]presource.URN
-
 	// AdditionalSecretOutputs lists extra output properties
 	// that should be treated as secrets.
 	AdditionalSecretOutputs []string
@@ -1308,13 +1305,6 @@ func newConstructRequest(req *rpc.ConstructRequest,
 			}
 			return m
 		}(),
-		InputDependencies: func() map[string][]presource.URN {
-			m := make(map[string][]presource.URN, len(req.GetInputDependencies()))
-			for k, v := range req.GetInputDependencies() {
-				m[k] = putil.ToUrns(v.Urns)
-			}
-			return m
-		}(),
 		Aliases:      putil.ToUrns(req.GetAliases()),
 		Dependencies: putil.ToUrns(req.GetDependencies()),
 		AdditionalSecretOutputs: func() []string {
@@ -1407,15 +1397,6 @@ func (c ConstructRequest) rpc(marshal propertyToRPC) *rpc.ConstructRequest {
 			m := make(map[string]string, len(c.Providers))
 			for k, v := range c.Providers {
 				m[string(k)] = putil.FormatProviderReference(v.Urn, v.ID)
-			}
-			return m
-		}(),
-		InputDependencies: func() map[string]*rpc.ConstructRequest_PropertyDependencies {
-			m := make(map[string]*rpc.ConstructRequest_PropertyDependencies, len(c.InputDependencies))
-			for k, v := range c.InputDependencies {
-				m[k] = &rpc.ConstructRequest_PropertyDependencies{
-					Urns: fromUrns(v),
-				}
 			}
 			return m
 		}(),

--- a/provider_linked.go
+++ b/provider_linked.go
@@ -23,22 +23,22 @@ import (
 // We want to make low-level rpc functionality available to the middleware for implementation purposes.
 // To achieve this, go:linkname is used by various packages to link to the below function(s).
 
-//nolint:unused
+//go:linkname linkedConstructRequestToRPC github.com/pulumi/pulumi-go-provider.linkedConstructRequestToRPC
 func linkedConstructRequestToRPC(req *ConstructRequest, marshal propertyToRPC) *pulumirpc.ConstructRequest {
 	return req.rpc(marshal)
 }
 
-//nolint:unused
+//go:linkname linkedConstructResponseFromRPC github.com/pulumi/pulumi-go-provider.linkedConstructResponseFromRPC
 func linkedConstructResponseFromRPC(resp *pulumirpc.ConstructResponse) (ConstructResponse, error) {
 	return newConstructResponse(resp)
 }
 
-//nolint:unused
+//go:linkname linkedCallRequestToRPC github.com/pulumi/pulumi-go-provider.linkedCallRequestToRPC
 func linkedCallRequestToRPC(req *CallRequest, marshal propertyToRPC) *pulumirpc.CallRequest {
 	return req.rpc(marshal)
 }
 
-//nolint:unused
+//go:linkname linkedCallResponseFromRPC github.com/pulumi/pulumi-go-provider.linkedCallResponseFromRPC
 func linkedCallResponseFromRPC(resp *pulumirpc.CallResponse) (CallResponse, error) {
 	return newCallResponse(resp)
 }

--- a/tests/grpc/call_test.go
+++ b/tests/grpc/call_test.go
@@ -80,9 +80,10 @@ func TestCall(t *testing.T) {
           "r2": "s"
        },
        "returnDependencies": {
-           "r2": {
+           "r1": {
               "urns": ["urn1", "urn2"]
-           }
+           },
+           "r2": {}
         }
     },
     "metadata": {
@@ -94,12 +95,9 @@ func TestCall(t *testing.T) {
 
 	call := func(_ context.Context, req p.CallRequest) (p.CallResponse, error) {
 		assert.Equal(t, property.NewMap(map[string]property.Value{
-			"k1": property.New("s"),
+			"k1": property.New("s").WithDependencies([]resource.URN{"urn1", "urn2"}),
 			"k2": property.New(3.14),
 		}), req.Args)
-		assert.Equal(t, map[string][]resource.URN{
-			"k1": {resource.URN("urn1"), resource.URN("urn2")},
-		}, req.ArgDependencies)
 		assert.Equal(t, tokens.ModuleMember("some-token"), req.Tok)
 		assert.Equal(t, "some-project", req.Project)
 		assert.Equal(t, "some-stack", req.Stack)
@@ -109,7 +107,6 @@ func TestCall(t *testing.T) {
 			config.MustParseKey("test:c2"): "3.14",
 		}, req.Config)
 		assert.Equal(t, []config.Key{config.MustParseKey("test:c1")}, req.ConfigSecretKeys)
-		assert.Equal(t, true, req.AcceptsOutputValues)
 
 		return p.CallResponse{
 			Return: property.NewMap(map[string]property.Value{
@@ -118,9 +115,7 @@ func TestCall(t *testing.T) {
 				}),
 				"r2": property.New("s"),
 			}),
-			ReturnDependencies: map[string][]resource.URN{
-				"r2": {resource.URN("urn1"), resource.URN("urn2")},
-			},
+			ReturnDependencies: map[string][]resource.URN{},
 		}, nil
 	}
 

--- a/tests/grpc/call_test.go
+++ b/tests/grpc/call_test.go
@@ -78,13 +78,7 @@ func TestCall(t *testing.T) {
               "dependencies": ["urn1","urn2"]
           },
           "r2": "s"
-       },
-       "returnDependencies": {
-           "r1": {
-              "urns": ["urn1", "urn2"]
-           },
-           "r2": {}
-        }
+       }
     },
     "metadata": {
         "kind": "resource",
@@ -115,7 +109,6 @@ func TestCall(t *testing.T) {
 				}),
 				"r2": property.New("s"),
 			}),
-			ReturnDependencies: map[string][]resource.URN{},
 		}, nil
 	}
 

--- a/tests/grpc/call_test.go
+++ b/tests/grpc/call_test.go
@@ -76,10 +76,11 @@ func TestCall(t *testing.T) {
           "r1":{
               "4dabf18193072939515e22adb298388d": "d0e6a833031e9bbcd3f4e8bde6ca49a4",
               "dependencies": ["urn1","urn2"]
-          }
+          },
+          "r2": "s"
        },
        "returnDependencies": {
-           "r1": {
+           "r2": {
               "urns": ["urn1", "urn2"]
            }
         }
@@ -115,7 +116,11 @@ func TestCall(t *testing.T) {
 				"r1": property.New(property.Computed).WithDependencies([]resource.URN{
 					"urn1", "urn2",
 				}),
+				"r2": property.New("s"),
 			}),
+			ReturnDependencies: map[string][]resource.URN{
+				"r2": {resource.URN("urn1"), resource.URN("urn2")},
+			},
 		}, nil
 	}
 

--- a/tests/grpc/construct_test.go
+++ b/tests/grpc/construct_test.go
@@ -98,11 +98,6 @@ func TestConstruct(t *testing.T) {
         "4dabf18193072939515e22adb298388d": "d0e6a833031e9bbcd3f4e8bde6ca49a4",
         "dependencies": ["urn7","urn8"]
       }
-    },
-    "stateDependencies": {
-      "r1": {
-        "urns": ["urn7", "urn8"]
-      }
     }
   },
   "metadata": {
@@ -148,9 +143,6 @@ func TestConstruct(t *testing.T) {
 					"urn7", "urn8",
 				}),
 			}),
-			StateDependencies: map[string][]resource.URN{
-				"r1": {resource.URN("urn7"), resource.URN("urn8")},
-			},
 		}, nil
 	}
 	replay.Replay(t, constructProvider(t, construct), jsonLog)

--- a/tests/grpc/construct_test.go
+++ b/tests/grpc/construct_test.go
@@ -140,9 +140,6 @@ func TestConstruct(t *testing.T) {
 		assert.Equal(t, property.NewMap(map[string]property.Value{
 			"k1": property.New("s").WithDependencies([]resource.URN{"urn4", "urn5"}),
 		}), req.Inputs)
-		assert.Equal(t, map[string][]resource.URN{
-			"k1": {resource.URN("urn4"), resource.URN("urn5")},
-		}, req.InputDependencies)
 
 		return p.ConstructResponse{
 			Urn: resource.URN("urn:pulumi:test::test::test:index:Parent$test:index:Component::test-component"),

--- a/tests/grpc/construct_test.go
+++ b/tests/grpc/construct_test.go
@@ -130,19 +130,15 @@ func TestConstruct(t *testing.T) {
 				ID:  "09e6d266-58b0-4452-8395-7bbe03011fad",
 			},
 		}, req.Providers)
-		assert.Equal(t, map[string][]resource.URN{
-			"k1": {resource.URN("urn4"), resource.URN("urn5")},
-		}, req.InputDependencies)
 		assert.Equal(t, []string{"r1"}, req.AdditionalSecretOutputs)
 		assert.Equal(t, &resource.CustomTimeouts{Create: 60, Update: 120, Delete: 180}, req.CustomTimeouts)
 		assert.Equal(t, resource.URN("urn6"), req.DeletedWith)
 		assert.Equal(t, &_true, req.DeleteBeforeReplace)
 		assert.Equal(t, []string{"k1"}, req.IgnoreChanges)
 		assert.Equal(t, []string{"k2"}, req.ReplaceOnChanges)
-		assert.Equal(t, true, req.AcceptsOutputValues)
 
 		assert.Equal(t, property.NewMap(map[string]property.Value{
-			"k1": property.New("s"),
+			"k1": property.New("s").WithDependencies([]resource.URN{"urn4", "urn5"}),
 		}), req.Inputs)
 		assert.Equal(t, map[string][]resource.URN{
 			"k1": {resource.URN("urn4"), resource.URN("urn5")},

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -743,11 +743,12 @@ func TestRPCCall(t *testing.T) {
 		})
 		require.NoError(t, s.Configure(p.ConfigureRequest{}))
 		resp, err := s.Call(p.CallRequest{
-			Tok:             tokens.ModuleMember("some-token"),
-			Project:         "some-project",
-			Stack:           "some-stack",
-			Args:            args,
-			ArgDependencies: argDeps,
+			Tok:                 tokens.ModuleMember("some-token"),
+			Project:             "some-project",
+			Stack:               "some-stack",
+			Args:                args,
+			ArgDependencies:     argDeps,
+			AcceptsOutputValues: true,
 		})
 
 		assert.NoError(t, err)
@@ -780,11 +781,12 @@ func TestRPCCall(t *testing.T) {
 				})
 				require.NoError(t, s.Configure(p.ConfigureRequest{}))
 				_, err := s.Call(p.CallRequest{
-					Tok:             tokens.ModuleMember("some-token"),
-					Project:         "some-project",
-					Stack:           "some-stack",
-					Args:            args,
-					ArgDependencies: argDeps,
+					Tok:                 tokens.ModuleMember("some-token"),
+					Project:             "some-project",
+					Stack:               "some-stack",
+					Args:                args,
+					ArgDependencies:     argDeps,
+					AcceptsOutputValues: true,
 				})
 
 				assert.NoError(t, err)
@@ -812,9 +814,10 @@ func TestRPCCall(t *testing.T) {
 		})
 		require.NoError(t, s.Configure(p.ConfigureRequest{}))
 		resp, err := s.Call(p.CallRequest{
-			Tok:     tokens.ModuleMember("some-token"),
-			Project: "some-project",
-			Stack:   "some-stack",
+			Tok:                 tokens.ModuleMember("some-token"),
+			Project:             "some-project",
+			Stack:               "some-stack",
+			AcceptsOutputValues: true,
 		})
 
 		assert.NoError(t, err)

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -642,12 +642,11 @@ func exampleConstructInputs(acceptOutputs bool) (property.Map, map[string]any) {
 	}
 }
 
-func exampleConstructInputDependencies(acceptOutputs bool) (map[string][]resource.URN, map[string]*rpc.ConstructRequest_PropertyDependencies) {
-	r := map[string][]resource.URN{}
+func exampleConstructInputDependencies(acceptOutputs bool) map[string]*rpc.ConstructRequest_PropertyDependencies {
 	if acceptOutputs {
-		return r, map[string]*rpc.ConstructRequest_PropertyDependencies{}
+		return map[string]*rpc.ConstructRequest_PropertyDependencies{}
 	} else {
-		return r, map[string]*rpc.ConstructRequest_PropertyDependencies{
+		return map[string]*rpc.ConstructRequest_PropertyDependencies{
 			"k2": {Urns: []string{"urn1", "urn2"}},
 		}
 	}
@@ -722,7 +721,7 @@ func TestRPCConstruct(t *testing.T) {
 		t.Parallel()
 		for _, acceptOutputs := range []bool{true, false} {
 			inputs, expectedInputs := exampleConstructInputs(acceptOutputs)
-			inputDeps, expectedInputDeps := exampleConstructInputDependencies(acceptOutputs)
+			expectedInputDeps := exampleConstructInputDependencies(acceptOutputs)
 			state, _ := exampleConstuctState()
 			stateDeps, _ := exampleConstructStateDependencies()
 
@@ -745,10 +744,9 @@ func TestRPCConstruct(t *testing.T) {
 			})
 			require.NoError(t, s.Configure(p.ConfigureRequest{}))
 			_, err := s.Construct(p.ConstructRequest{
-				Urn:               "urn:pulumi:test::test::test:index:Component::component",
-				Parent:            "urn:pulumi:test::test::test:index:Parent::parent",
-				Inputs:            inputs,
-				InputDependencies: inputDeps,
+				Urn:    "urn:pulumi:test::test::test:index:Component::component",
+				Parent: "urn:pulumi:test::test::test:index:Parent::parent",
+				Inputs: inputs,
 			})
 
 			assert.NoError(t, err)
@@ -761,7 +759,6 @@ func TestRPCConstruct(t *testing.T) {
 		t.Parallel()
 
 		inputs, _ := exampleConstructInputs(true)
-		inputDeps, _ := exampleConstructInputDependencies(true)
 		state, expectedState := exampleConstuctState()
 		stateDeps, expectedStateDeps := exampleConstructStateDependencies()
 
@@ -779,10 +776,9 @@ func TestRPCConstruct(t *testing.T) {
 		})
 		require.NoError(t, s.Configure(p.ConfigureRequest{}))
 		resp, err := s.Construct(p.ConstructRequest{
-			Urn:               "urn:pulumi:test::test::test:index:Component::component",
-			Parent:            "urn:pulumi:test::test::test:index:Parent::parent",
-			Inputs:            inputs,
-			InputDependencies: inputDeps,
+			Urn:    "urn:pulumi:test::test::test:index:Component::component",
+			Parent: "urn:pulumi:test::test::test:index:Parent::parent",
+			Inputs: inputs,
 		})
 
 		assert.NoError(t, err)

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -255,7 +255,6 @@ func TestRPCConfigure(t *testing.T) {
 									resource.NewProperty(""),
 								),
 							}, m)
-							// TODO assert the dependencies are present in deps.
 						}
 
 						return &rpc.CreateResponse{Id: "some-id"}, nil
@@ -1293,15 +1292,6 @@ func (r rpcTestServer) Call(ctx context.Context, req *rpc.CallRequest) (*rpc.Cal
 }
 
 func rpcServer(server rpcTestServer) integration.Server {
-	// if server.onConfigure == nil {
-	// 	server.onConfigure = func(context.Context, *rpc.ConfigureRequest) (*rpc.ConfigureResponse, error) {
-	// 		return &rpc.ConfigureResponse{
-	// 			AcceptOutputs:   true,
-	// 			AcceptResources: true,
-	// 			AcceptSecrets:   true,
-	// 		}, nil
-	// 	}
-	// }
 	return integration.NewServer("test",
 		semver.Version{Major: 1},
 		wraprpc.Provider(server))

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -865,7 +865,7 @@ func TestRPCCall(t *testing.T) {
 		args, expectedArgs := exampleCallArgs(true)
 		expectedArgDeps := exampleCallArgDependencies(true)
 		returns, expectedReturns := exampleCallReturns()
-		returnDeps, expectedReturnDeps := exampleCallReturnDependencies()
+		returnDeps, _ := exampleCallReturnDependencies()
 		wasCalled := false
 
 		s := rpcServer(rpcTestServer{
@@ -900,7 +900,6 @@ func TestRPCCall(t *testing.T) {
 		assert.Equal(t,
 			expectedReturns,
 			resp.Return, "return values should be the same")
-		assert.Equal(t, expectedReturnDeps, resp.ReturnDependencies, "return dependencies should be the same")
 	})
 
 	// Check that we downgrade args when outputs are not supported.
@@ -971,7 +970,6 @@ func TestRPCCall(t *testing.T) {
 			}
 			assert.Equal(t, deps, v.Dependencies(), "return dependencies for %q should be the same", name)
 		}
-		assert.Equal(t, expectedReturnDeps, resp.ReturnDependencies, "return dependencies should be the same")
 	})
 }
 

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -708,10 +708,9 @@ func TestRPCConstruct(t *testing.T) {
 		})
 		require.NoError(t, s.Configure(p.ConfigureRequest{}))
 		_, err := s.Construct(p.ConstructRequest{
-			Urn:                 "urn:pulumi:test::test::test:index:Component::component",
-			Parent:              "urn:pulumi:test::test::test:index:Parent::parent",
-			Inputs:              inputs,
-			AcceptsOutputValues: true,
+			Urn:    "urn:pulumi:test::test::test:index:Component::component",
+			Parent: "urn:pulumi:test::test::test:index:Parent::parent",
+			Inputs: inputs,
 		})
 
 		assert.NoError(t, err)
@@ -746,11 +745,10 @@ func TestRPCConstruct(t *testing.T) {
 			})
 			require.NoError(t, s.Configure(p.ConfigureRequest{}))
 			_, err := s.Construct(p.ConstructRequest{
-				Urn:                 "urn:pulumi:test::test::test:index:Component::component",
-				Parent:              "urn:pulumi:test::test::test:index:Parent::parent",
-				Inputs:              inputs,
-				InputDependencies:   inputDeps,
-				AcceptsOutputValues: true,
+				Urn:               "urn:pulumi:test::test::test:index:Component::component",
+				Parent:            "urn:pulumi:test::test::test:index:Parent::parent",
+				Inputs:            inputs,
+				InputDependencies: inputDeps,
 			})
 
 			assert.NoError(t, err)
@@ -781,11 +779,10 @@ func TestRPCConstruct(t *testing.T) {
 		})
 		require.NoError(t, s.Configure(p.ConfigureRequest{}))
 		resp, err := s.Construct(p.ConstructRequest{
-			Urn:                 "urn:pulumi:test::test::test:index:Component::component",
-			Parent:              "urn:pulumi:test::test::test:index:Parent::parent",
-			Inputs:              inputs,
-			InputDependencies:   inputDeps,
-			AcceptsOutputValues: true,
+			Urn:               "urn:pulumi:test::test::test:index:Component::component",
+			Parent:            "urn:pulumi:test::test::test:index:Parent::parent",
+			Inputs:            inputs,
+			InputDependencies: inputDeps,
 		})
 
 		assert.NoError(t, err)

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -890,12 +890,11 @@ func TestRPCCall(t *testing.T) {
 		})
 		require.NoError(t, s.Configure(p.ConfigureRequest{}))
 		resp, err := s.Call(p.CallRequest{
-			Tok:                 tokens.ModuleMember("some-token"),
-			Project:             "some-project",
-			Stack:               "some-stack",
-			Args:                args,
-			ArgDependencies:     argDeps,
-			AcceptsOutputValues: true,
+			Tok:             tokens.ModuleMember("some-token"),
+			Project:         "some-project",
+			Stack:           "some-stack",
+			Args:            args,
+			ArgDependencies: argDeps,
 		})
 
 		assert.NoError(t, err)
@@ -928,12 +927,11 @@ func TestRPCCall(t *testing.T) {
 				})
 				require.NoError(t, s.Configure(p.ConfigureRequest{}))
 				_, err := s.Call(p.CallRequest{
-					Tok:                 tokens.ModuleMember("some-token"),
-					Project:             "some-project",
-					Stack:               "some-stack",
-					Args:                args,
-					ArgDependencies:     argDeps,
-					AcceptsOutputValues: true,
+					Tok:             tokens.ModuleMember("some-token"),
+					Project:         "some-project",
+					Stack:           "some-stack",
+					Args:            args,
+					ArgDependencies: argDeps,
 				})
 
 				assert.NoError(t, err)
@@ -961,10 +959,9 @@ func TestRPCCall(t *testing.T) {
 		})
 		require.NoError(t, s.Configure(p.ConfigureRequest{}))
 		resp, err := s.Call(p.CallRequest{
-			Tok:                 tokens.ModuleMember("some-token"),
-			Project:             "some-project",
-			Stack:               "some-stack",
-			AcceptsOutputValues: true,
+			Tok:     tokens.ModuleMember("some-token"),
+			Project: "some-project",
+			Stack:   "some-stack",
 		})
 
 		assert.NoError(t, err)

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -791,7 +791,6 @@ func TestRPCConstruct(t *testing.T) {
 			}
 			assert.Equal(t, deps, v.Dependencies(), "state dependencies for %q should be the same", name)
 		}
-		assert.Equal(t, expectedStateDeps, resp.StateDependencies, "state dependencies should be the same")
 	})
 }
 

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -823,12 +823,11 @@ func exampleCallArgs(acceptOutputs bool) (property.Map, map[string]any) {
 	}
 }
 
-func exampleCallArgDependencies(acceptOutputs bool) (map[string][]resource.URN, map[string]*rpc.CallRequest_ArgumentDependencies) {
-	r := map[string][]resource.URN{}
+func exampleCallArgDependencies(acceptOutputs bool) map[string]*rpc.CallRequest_ArgumentDependencies {
 	if acceptOutputs {
-		return r, map[string]*rpc.CallRequest_ArgumentDependencies{}
+		return map[string]*rpc.CallRequest_ArgumentDependencies{}
 	} else {
-		return r, map[string]*rpc.CallRequest_ArgumentDependencies{
+		return map[string]*rpc.CallRequest_ArgumentDependencies{
 			"k2": {Urns: []string{"urn1", "urn2"}},
 		}
 	}
@@ -864,7 +863,7 @@ func TestRPCCall(t *testing.T) {
 	t.Run("no-error", func(t *testing.T) {
 		t.Parallel()
 		args, expectedArgs := exampleCallArgs(true)
-		argDeps, expectedArgDeps := exampleCallArgDependencies(true)
+		expectedArgDeps := exampleCallArgDependencies(true)
 		returns, expectedReturns := exampleCallReturns()
 		returnDeps, expectedReturnDeps := exampleCallReturnDependencies()
 		wasCalled := false
@@ -890,11 +889,10 @@ func TestRPCCall(t *testing.T) {
 		})
 		require.NoError(t, s.Configure(p.ConfigureRequest{}))
 		resp, err := s.Call(p.CallRequest{
-			Tok:             tokens.ModuleMember("some-token"),
-			Project:         "some-project",
-			Stack:           "some-stack",
-			Args:            args,
-			ArgDependencies: argDeps,
+			Tok:     tokens.ModuleMember("some-token"),
+			Project: "some-project",
+			Stack:   "some-stack",
+			Args:    args,
 		})
 
 		assert.NoError(t, err)
@@ -911,7 +909,7 @@ func TestRPCCall(t *testing.T) {
 		for _, acceptOutputs := range []bool{true, false} {
 			t.Run(fmt.Sprintf("%v", acceptOutputs), func(t *testing.T) {
 				args, expectedArgs := exampleCallArgs(acceptOutputs)
-				argDeps, expectedArgDeps := exampleCallArgDependencies(acceptOutputs)
+				expectedArgDeps := exampleCallArgDependencies(acceptOutputs)
 
 				var wasCalled bool
 				s := rpcServer(rpcTestServer{
@@ -927,11 +925,10 @@ func TestRPCCall(t *testing.T) {
 				})
 				require.NoError(t, s.Configure(p.ConfigureRequest{}))
 				_, err := s.Call(p.CallRequest{
-					Tok:             tokens.ModuleMember("some-token"),
-					Project:         "some-project",
-					Stack:           "some-stack",
-					Args:            args,
-					ArgDependencies: argDeps,
+					Tok:     tokens.ModuleMember("some-token"),
+					Project: "some-project",
+					Stack:   "some-stack",
+					Args:    args,
 				})
 
 				assert.NoError(t, err)


### PR DESCRIPTION
This PR removes the formal "dependencies" map that often accompanies property maps on Provider requests and responses. Any dependences on an incoming RPC request are simply folded into their respective properties. The resultant RPC response never contains a dependencies map, and the provider asserts that the caller MUST accept output values.

The request/response structs are changing like this:
![image](https://github.com/user-attachments/assets/852db98f-c6c3-4aa6-b97f-42bce63f632b)


The middleware.rpc package takes pains to downgrade input dependencies based on the wrapped provider's capabilities (Call and Construct ONLY). The wrapped provider MAY return a dependencies map in all modes.

**To discuss**: we know that dependency maps are often generated by walking an output value (recursively). When we use upgrade logic to re-attach the dependencies to the property values, does that cause some "garbage" to build up on those values?  Should the caller provide a dependency map only in a downgrade situation?  When may it be ignored? Should we filter out the deps that are present on the children?

Here, for example, we re-attach the dependencies map to the property values.  If those deps were extracted from deep children, now they're attached directly to the top-level value. Very concerning to me.
https://github.com/pulumi/pulumi-go-provider/pull/350/files#diff-1bb2cdf24b7aa1b1986f79d4ea823ec921a95ba94f6436119cb2a74c21ebff82R876-R883

on-wire:
```plain
v
├── k1 (urn1)
└── k2
    └── k3 (urn2)
```

after upgrade:
```plain
v (urn1, urn2)
├── k1 (urn1)
└── k2
    └── k3 (urn2)
```

My best idea here is to re-attach ONLY the deps that aren't present on the children. WDYT?

Update: It is assumed that, for a given value, the dependencies are either within the value itself OR in the dependency map. So, if the value has any dependencies, you needn't incorporate the map, and doing so would have the erroneous effect of folding the child dependencies into the parent.

Closes #346 

