### PR TITLE
Rename Olds/News -> State/Inputs

### DIFF
--- a/examples/auto-naming/main_test.go
+++ b/examples/auto-naming/main_test.go
@@ -20,13 +20,13 @@ func TestAutoName(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		olds     property.Map
-		news     property.Map
+		state    property.Map
+		inputs   property.Map
 		validate func(*testing.T, property.Map)
 	}{
 		{
-			name: "create new auto-named resource",
-			news: property.Map{},
+			name:   "create new auto-named resource",
+			inputs: property.Map{},
 			validate: func(t *testing.T, result property.Map) {
 				name, ok := result.GetOk("name")
 				require.True(t, ok, "could not find name in %q", result)
@@ -37,7 +37,7 @@ func TestAutoName(t *testing.T) {
 		},
 		{
 			name: "create new manually named resource",
-			news: property.NewMap(map[string]property.Value{
+			inputs: property.NewMap(map[string]property.Value{
 				"name": property.New("custom-name"),
 			}),
 			validate: func(t *testing.T, result property.Map) {
@@ -47,9 +47,9 @@ func TestAutoName(t *testing.T) {
 			},
 		},
 		{
-			name: "update an auto-named resource (same name)",
-			news: property.Map{},
-			olds: property.NewMap(map[string]property.Value{
+			name:   "update an auto-named resource (same name)",
+			inputs: property.Map{},
+			state: property.NewMap(map[string]property.Value{
 				"name": property.New("name-123456"),
 			}),
 			validate: func(t *testing.T, result property.Map) {
@@ -60,10 +60,10 @@ func TestAutoName(t *testing.T) {
 		},
 		{
 			name: "update an auto-named resource (new name)",
-			news: property.NewMap(map[string]property.Value{
+			inputs: property.NewMap(map[string]property.Value{
 				"name": property.New("custom-name"),
 			}),
-			olds: property.NewMap(map[string]property.Value{
+			state: property.NewMap(map[string]property.Value{
 				"name": property.New("name-123456"),
 			}),
 			validate: func(t *testing.T, result property.Map) {
@@ -74,10 +74,10 @@ func TestAutoName(t *testing.T) {
 		},
 		{
 			name: "update a manually named resource (same name)",
-			news: property.NewMap(map[string]property.Value{
+			inputs: property.NewMap(map[string]property.Value{
 				"name": property.New("custom-name"),
 			}),
-			olds: property.NewMap(map[string]property.Value{
+			state: property.NewMap(map[string]property.Value{
 				"name": property.New("custom-name"),
 			}),
 			validate: func(t *testing.T, result property.Map) {
@@ -88,10 +88,10 @@ func TestAutoName(t *testing.T) {
 		},
 		{
 			name: "update a manually named resource (different name)",
-			news: property.NewMap(map[string]property.Value{
+			inputs: property.NewMap(map[string]property.Value{
 				"name": property.New("custom-name1"),
 			}),
-			olds: property.NewMap(map[string]property.Value{
+			state: property.NewMap(map[string]property.Value{
 				"name": property.New("custom-name2"),
 			}),
 			validate: func(t *testing.T, result property.Map) {
@@ -101,9 +101,9 @@ func TestAutoName(t *testing.T) {
 			},
 		},
 		{
-			name: "convert from a named to an auto-named resource",
-			news: property.Map{},
-			olds: property.NewMap(map[string]property.Value{
+			name:   "convert from a named to an auto-named resource",
+			inputs: property.Map{},
+			state: property.NewMap(map[string]property.Value{
 				"name": property.New("custom-name"),
 			}),
 			validate: func(t *testing.T, result property.Map) {
@@ -124,9 +124,9 @@ func TestAutoName(t *testing.T) {
 			t.Parallel()
 			t.Helper()
 			resp, err := s.Check(p.CheckRequest{
-				Urn:  resource.NewURN("dev", "test", "", "autoname:index:User", "name"),
-				News: tt.news,
-				Olds: tt.olds,
+				Urn:    resource.NewURN("dev", "test", "", "autoname:index:User", "name"),
+				Inputs: tt.inputs,
+				State:  tt.state,
 			})
 			require.NoError(t, err)
 			require.Empty(t, resp.Failures)

--- a/examples/credentials/main.go
+++ b/examples/credentials/main.go
@@ -105,7 +105,7 @@ var _ = (infer.CustomDiff[UserArgs, UserState])((*User)(nil))
 
 func (*User) Diff(ctx context.Context, req infer.DiffRequest[UserArgs, UserState]) (infer.DiffResponse, error) {
 	config := infer.GetConfig[Config](ctx)
-	if config.User != req.Olds.Name {
+	if config.User != req.State.Name {
 		return infer.DiffResponse{
 			HasChanges: true,
 			DetailedDiff: map[string]p.PropertyDiff{

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -58,7 +58,7 @@ func main() {
 		},
 		CheckConfig: func(_ context.Context, req p.CheckRequest) (p.CheckResponse, error) {
 			// Assume inputs are valid
-			return p.CheckResponse{Inputs: req.News}, nil
+			return p.CheckResponse{Inputs: req.Inputs}, nil
 		},
 		Configure: func(context.Context, p.ConfigureRequest) error {
 			return nil
@@ -70,7 +70,7 @@ func main() {
 			return p.CheckResponse{
 				// Only take "value" and ignore everything else.
 				Inputs: property.NewMap(map[string]property.Value{
-					"value": req.News.Get("value"),
+					"value": req.Inputs.Get("value"),
 				}),
 			}, nil
 		},
@@ -78,7 +78,7 @@ func main() {
 			if req.Urn.Type() != echoType {
 				return p.DiffResponse{}, fmt.Errorf("unknown resource %q", req.Urn.Type())
 			}
-			if req.News.Get("value").Equals(req.Olds.Get("value")) {
+			if req.Inputs.Get("value").Equals(req.State.Get("value")) {
 				return p.DiffResponse{
 					HasChanges: false,
 				}, nil
@@ -121,7 +121,7 @@ func main() {
 				return p.UpdateResponse{}, fmt.Errorf("unknown resource %q", req.Urn.Type())
 			}
 			// The provider assumes that all fields are valid, and just updates
-			return p.UpdateResponse{Properties: req.News}, nil
+			return p.UpdateResponse{Properties: req.Inputs}, nil
 		},
 		Delete: func(_ context.Context, req p.DeleteRequest) error {
 			if req.Urn.Type() != echoType {

--- a/examples/file/main.go
+++ b/examples/file/main.go
@@ -124,26 +124,26 @@ func (*File) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckResp
 }
 
 func (*File) Update(ctx context.Context, req infer.UpdateRequest[FileArgs, FileState]) (infer.UpdateResponse[FileState], error) {
-	if !req.Preview && req.Olds.Content != req.News.Content {
-		f, err := os.Create(req.Olds.Path)
+	if !req.Preview && req.State.Content != req.Inputs.Content {
+		f, err := os.Create(req.State.Path)
 		if err != nil {
 			return infer.UpdateResponse[FileState]{}, err
 		}
 		defer f.Close()
-		n, err := f.WriteString(req.News.Content)
+		n, err := f.WriteString(req.Inputs.Content)
 		if err != nil {
 			return infer.UpdateResponse[FileState]{}, err
 		}
-		if n != len(req.News.Content) {
-			return infer.UpdateResponse[FileState]{}, fmt.Errorf("only wrote %d/%d bytes", n, len(req.News.Content))
+		if n != len(req.Inputs.Content) {
+			return infer.UpdateResponse[FileState]{}, fmt.Errorf("only wrote %d/%d bytes", n, len(req.Inputs.Content))
 		}
 	}
 
 	return infer.UpdateResponse[FileState]{
 		Output: FileState{
-			Path:    req.News.Path,
-			Force:   req.News.Force,
-			Content: req.News.Content,
+			Path:    req.Inputs.Path,
+			Force:   req.Inputs.Force,
+			Content: req.Inputs.Content,
 		},
 	}, nil
 
@@ -151,13 +151,13 @@ func (*File) Update(ctx context.Context, req infer.UpdateRequest[FileArgs, FileS
 
 func (*File) Diff(ctx context.Context, req infer.DiffRequest[FileArgs, FileState]) (infer.DiffResponse, error) {
 	diff := map[string]p.PropertyDiff{}
-	if req.News.Content != req.Olds.Content {
+	if req.Inputs.Content != req.Inputs.Content {
 		diff["content"] = p.PropertyDiff{Kind: p.Update}
 	}
-	if req.News.Force != req.Olds.Force {
+	if req.Inputs.Force != req.State.Force {
 		diff["force"] = p.PropertyDiff{Kind: p.Update}
 	}
-	if req.News.Path != req.Olds.Path {
+	if req.Inputs.Path != req.State.Path {
 		diff["path"] = p.PropertyDiff{Kind: p.UpdateReplace}
 	}
 	return infer.DiffResponse{

--- a/examples/random-login/main.go
+++ b/examples/random-login/main.go
@@ -191,20 +191,20 @@ var _ = (infer.CustomUpdate[RandomSaltArgs, RandomSaltState])((*RandomSalt)(nil)
 
 func (r *RandomSalt) Update(ctx context.Context, req infer.UpdateRequest[RandomSaltArgs, RandomSaltState]) (infer.UpdateResponse[RandomSaltState], error) {
 	var redoSalt bool
-	if req.Olds.SaltLength != nil && req.News.SaltLength != nil {
-		redoSalt = *req.Olds.SaltLength != *req.News.SaltLength
-	} else if req.Olds.SaltLength != nil || req.News.SaltLength != nil {
+	if req.State.SaltLength != nil && req.Inputs.SaltLength != nil {
+		redoSalt = *req.State.SaltLength != *req.Inputs.SaltLength
+	} else if req.State.SaltLength != nil || req.Inputs.SaltLength != nil {
 		redoSalt = true
 	}
 
-	salt := req.Olds.Salt
+	salt := req.State.Salt
 	if redoSalt {
 		if req.Preview {
 			return infer.UpdateResponse[RandomSaltState]{}, nil
 		}
 		l := 4
-		if req.News.SaltLength != nil {
-			l = *req.News.SaltLength
+		if req.Inputs.SaltLength != nil {
+			l = *req.Inputs.SaltLength
 		}
 		salt = makeSalt(l)
 	}
@@ -212,9 +212,9 @@ func (r *RandomSalt) Update(ctx context.Context, req infer.UpdateRequest[RandomS
 	return infer.UpdateResponse[RandomSaltState]{
 		Output: RandomSaltState{
 			Salt:           salt,
-			SaltedPassword: fmt.Sprintf("%s%s", salt, req.News.Password),
-			Password:       req.News.Password,
-			SaltLength:     req.News.SaltLength,
+			SaltedPassword: fmt.Sprintf("%s%s", salt, req.Inputs.Password),
+			Password:       req.Inputs.Password,
+			SaltLength:     req.Inputs.SaltLength,
 		},
 	}, nil
 }

--- a/infer/README.md
+++ b/infer/README.md
@@ -258,26 +258,26 @@ allow updates, we need to implement the `Update` method:
 
 ```go
 func (*File) Update(ctx context.Context, req infer.UpdateRequest[FileArgs, FileState]) (infer.UpdateResponse[FileState], error) {
-	if !req.Preview && req.Olds.Content != req.News.Content {
-		f, err := os.Create(req.Olds.Path)
+	if !req.Preview && req.State.Content != req.Inputs.Content {
+		f, err := os.Create(req.State.Path)
 		if err != nil {
 			return infer.UpdateResponse[FileState]{}, err
 		}
 		defer f.Close()
-		n, err := f.WriteString(req.News.Content)
+		n, err := f.WriteString(req.Inputs.Content)
 		if err != nil {
 			return infer.UpdateResponse[FileState]{}, err
 		}
-		if n != len(req.News.Content) {
-			return infer.UpdateResponse[FileState]{}, fmt.Errorf("only wrote %d/%d bytes", n, len(req.News.Content))
+		if n != len(req.Inputs.Content) {
+			return infer.UpdateResponse[FileState]{}, fmt.Errorf("only wrote %d/%d bytes", n, len(req.Inputs.Content))
 		}
 	}
 
 	return infer.UpdateResponse[FileState]{
 		Output: FileState{
-			Path:    req.News.Path,
-			Force:   req.News.Force,
-			Content: req.News.Content,
+			Path:    req.Inputs.Path,
+			Force:   req.Inputs.Force,
+			Content: req.Inputs.Content,
 		},
 	}, nil
 
@@ -293,13 +293,13 @@ to override how diff works:
 ```go
 func (*File) Diff(ctx context.Context, req infer.DiffRequest[FileArgs, FileState]) (infer.DiffResponse, error) {
 	diff := map[string]p.PropertyDiff{}
-	if req.News.Content != req.Olds.Content {
+	if req.Inputs.Content != req.State.Content {
 		diff["content"] = p.PropertyDiff{Kind: p.Update}
 	}
-	if req.News.Force != req.Olds.Force {
+	if req.Inputs.Force != req.State.Force {
 		diff["force"] = p.PropertyDiff{Kind: p.Update}
 	}
-	if req.News.Path != req.Olds.Path {
+	if req.Inputs.Path != req.State.Path {
 		diff["path"] = p.PropertyDiff{Kind: p.UpdateReplace}
 	}
 	return infer.DiffResponse{
@@ -310,8 +310,8 @@ func (*File) Diff(ctx context.Context, req infer.DiffRequest[FileArgs, FileState
 }
 ```
 
-We check for each field, and if there is a change, we record it. Changes in `news.Content`
-and `news.Force` result in an `Update`, but changes in `news.Path` result in an
+We check for each field, and if there is a change, we record it. Changes in `Inputs.Content`
+and `Inputs.Force` result in an `Update`, but changes in `Inputs.Path` result in an
 `UpdateReplace`. Since the `id` (file path) is globally unique, we also tell Pulumi that it
 needs to perform deletes before the associated create.
 

--- a/infer/configuration.go
+++ b/infer/configuration.go
@@ -90,7 +90,7 @@ func (c *config[T]) checkConfig(ctx context.Context, req p.CheckRequest) (p.Chec
 		t = reflect.New(v.Type().Elem()).Interface().(T)
 	}
 
-	encoder, decodeError := ende.DecodeConfig(req.News, &t)
+	encoder, decodeError := ende.DecodeConfig(req.Inputs, &t)
 	if t, ok := ((interface{})(t)).(CustomCheck[T]); ok {
 		// The user implemented check manually, so call that.
 		//
@@ -99,7 +99,7 @@ func (c *config[T]) checkConfig(ctx context.Context, req p.CheckRequest) (p.Chec
 		if req.Urn != "" {
 			name = req.Urn.Name()
 		}
-		defCheckEnc, i, failures, err := callCustomCheck(ctx, t, name, req.Olds, req.News)
+		defCheckEnc, i, failures, err := callCustomCheck(ctx, t, name, req.State, req.Inputs)
 		if err != nil {
 			return p.CheckResponse{}, err
 		}

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -989,7 +989,7 @@ func (rc *derivedResourceController[R, I, O]) Check(ctx context.Context, req p.C
 		//
 		// We do not apply defaults if the user has implemented Check
 		// themselves. Defaults are applied by [DefaultCheck].
-		encoder, i, failures, err := callCustomCheck(ctx, r, req.Urn.Name(), req.Olds, req.News)
+		encoder, i, failures, err := callCustomCheck(ctx, r, req.Urn.Name(), req.State, req.Inputs)
 		if err != nil {
 			return p.CheckResponse{}, err
 		}
@@ -1005,7 +1005,7 @@ func (rc *derivedResourceController[R, I, O]) Check(ctx context.Context, req p.C
 		// and `I`, so we are not guaranteed that `decodeCheckingMapErrors` won't
 		// produce errors.
 		if encoder == nil {
-			backupEncoder, _, _, _ := decodeCheckingMapErrors[I](req.News)
+			backupEncoder, _, _, _ := decodeCheckingMapErrors[I](req.Inputs)
 			encoder = &backupEncoder
 		}
 
@@ -1016,7 +1016,7 @@ func (rc *derivedResourceController[R, I, O]) Check(ctx context.Context, req p.C
 		}, err
 	}
 
-	encoder, i, failures, err := decodeCheckingMapErrors[I](req.News)
+	encoder, i, failures, err := decodeCheckingMapErrors[I](req.Inputs)
 	if err != nil {
 		return p.CheckResponse{}, err
 	}
@@ -1024,7 +1024,7 @@ func (rc *derivedResourceController[R, I, O]) Check(ctx context.Context, req p.C
 		return p.CheckResponse{
 			// If we failed to decode, we apply secrets pro-actively to ensure
 			// that they don't leak into previews.
-			Inputs:   applySecrets[I](resource.ToResourcePropertyValue(property.New(req.News)).ObjectValue()),
+			Inputs:   applySecrets[I](resource.ToResourcePropertyValue(property.New(req.Inputs)).ObjectValue()),
 			Failures: failures,
 		}, nil
 	}
@@ -1148,18 +1148,18 @@ func diff[R, I, O any](
 	ctx context.Context, req p.DiffRequest, r *R, forceReplace func(string) bool,
 ) (p.DiffResponse, error) {
 	for _, ignoredChange := range req.IgnoreChanges {
-		v, ok := req.Olds.GetOk(ignoredChange)
+		v, ok := req.State.GetOk(ignoredChange)
 		if ok {
-			req.News = req.News.Set(ignoredChange, v)
+			req.Inputs = req.Inputs.Set(ignoredChange, v)
 		}
 	}
 
 	if r, ok := ((interface{})(*r)).(CustomDiff[I, O]); ok {
-		_, olds, err := hydrateFromState[R, I, O](ctx, req.Olds) // TODO
+		_, olds, err := hydrateFromState[R, I, O](ctx, req.State) // TODO
 		if err != nil {
 			return p.DiffResponse{}, err
 		}
-		_, news, err := ende.Decode[I](req.News)
+		_, news, err := ende.Decode[I](req.Inputs)
 		if err != nil {
 			return p.DiffResponse{}, err
 		}
@@ -1182,10 +1182,10 @@ func diff[R, I, O any](
 	// so we need to filter out fields that are in Output but not Input.
 	oldInputs := map[string]property.Value{}
 	for k := range inputProps {
-		oldInputs[k] = req.Olds.Get(k)
+		oldInputs[k] = req.State.Get(k)
 	}
 	objDiff := resource.ToResourcePropertyValue(property.New(oldInputs)).ObjectValue().Diff(
-		resource.ToResourcePropertyValue(property.New(req.News)).ObjectValue(),
+		resource.ToResourcePropertyValue(property.New(req.Inputs)).ObjectValue(),
 	)
 	pluginDiff := plugin.NewDetailedDiffFromObjectDiff(objDiff, false)
 	diff := map[string]p.PropertyDiff{}
@@ -1389,17 +1389,17 @@ func (rc *derivedResourceController[R, I, O]) Update(
 			"Update is not implemented for resource %s", req.Urn)
 	}
 	for _, ignoredChange := range req.IgnoreChanges {
-		v, ok := req.Olds.GetOk(ignoredChange)
+		v, ok := req.State.GetOk(ignoredChange)
 		if ok {
-			req.News = req.News.Set(ignoredChange, v)
+			req.Inputs = req.Inputs.Set(ignoredChange, v)
 		}
 	}
 
-	_, olds, err := hydrateFromState[R, I, O](ctx, req.Olds)
+	_, olds, err := hydrateFromState[R, I, O](ctx, req.State)
 	if err != nil {
 		return p.UpdateResponse{}, err
 	}
-	encoder, news, err := ende.Decode[I](req.News)
+	encoder, news, err := ende.Decode[I](req.Inputs)
 	if err != nil {
 		return p.UpdateResponse{}, err
 	}
@@ -1443,8 +1443,8 @@ func (rc *derivedResourceController[R, I, O]) Update(
 		return p.UpdateResponse{}, err
 	}
 	setDeps(
-		resource.ToResourcePropertyValue(property.New(req.Olds)).ObjectValue(),
-		resource.ToResourcePropertyValue(property.New(req.News)).ObjectValue(),
+		resource.ToResourcePropertyValue(property.New(req.State)).ObjectValue(),
+		resource.ToResourcePropertyValue(property.New(req.Inputs)).ObjectValue(),
 		m,
 	)
 

--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -213,7 +213,6 @@ func TestFieldGenerator(t *testing.T) {
 			tt.assert(t, *fm)
 		})
 	}
-
 }
 
 type Context struct {
@@ -292,10 +291,10 @@ func TestDiff(t *testing.T) {
 
 	for _, test := range tests {
 		diffRequest := p.DiffRequest{
-			ID:   "foo",
-			Urn:  r.CreateURN("foo", "a:b:c", "", "proj", "stack"),
-			Olds: test.olds,
-			News: test.news,
+			ID:     "foo",
+			Urn:    r.CreateURN("foo", "a:b:c", "", "proj", "stack"),
+			State:  test.olds,
+			Inputs: test.news,
 		}
 		resp, err := diff[struct{}, I, any](
 			Context{context.Background()},
@@ -519,9 +518,9 @@ func TestCheck(t *testing.T) {
 			t.Parallel()
 			res := Resource[checkResource]()
 			checkResp, err := res.Check(context.Background(), p.CheckRequest{
-				Urn:  "a:b:c",
-				Olds: property.Map{},
-				News: tc.input,
+				Urn:    "a:b:c",
+				State:  property.Map{},
+				Inputs: tc.input,
 			})
 			require.NoError(t, err)
 			assert.Empty(t, checkResp.Failures)

--- a/infer/tests/check_config_test.go
+++ b/infer/tests/check_config_test.go
@@ -29,7 +29,7 @@ func TestCheckConfig(t *testing.T) {
 
 	prov := providerWithConfig[Config](t)
 	resp, err := prov.CheckConfig(p.CheckRequest{
-		News: property.NewMap(map[string]property.Value{
+		Inputs: property.NewMap(map[string]property.Value{
 			"value":        property.New("foo"),
 			"unknownField": property.New("bar"),
 		}),
@@ -51,8 +51,8 @@ func TestCheckConfigCustom(t *testing.T) {
 	test := func(t *testing.T, inputs, expected property.Map) {
 		prov := providerWithConfig[*ConfigCustom](t)
 		resp, err := prov.CheckConfig(p.CheckRequest{
-			Urn:  urn("provider", "provider"),
-			News: inputs,
+			Urn:    urn("provider", "provider"),
+			Inputs: inputs,
 		})
 		require.NoError(t, err)
 
@@ -62,7 +62,8 @@ func TestCheckConfigCustom(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
 		test(t, property.Map{}, property.NewMap(map[string]property.Value{
-			"__pulumi-go-provider-infer": property.New(true)}))
+			"__pulumi-go-provider-infer": property.New(true),
+		}))
 	})
 	t.Run("unknown", func(t *testing.T) {
 		t.Parallel()
@@ -76,6 +77,7 @@ func TestCheckConfigCustom(t *testing.T) {
 			property.NewMap(map[string]property.Value{"number": property.New(42.0)}),
 			property.NewMap(map[string]property.Value{
 				"number":                     property.New(42.5),
-				"__pulumi-go-provider-infer": property.New(true)}))
+				"__pulumi-go-provider-infer": property.New(true),
+			}))
 	})
 }

--- a/infer/tests/check_test.go
+++ b/infer/tests/check_test.go
@@ -60,8 +60,8 @@ func TestCheckDefaults(t *testing.T) {
 
 			prov := provider(t)
 			resp, err := prov.Check(p.CheckRequest{
-				Urn:  urn("WithDefaults", "check-defaults"),
-				News: inputs,
+				Urn:    urn("WithDefaults", "check-defaults"),
+				Inputs: inputs,
 			})
 			require.NoError(t, err)
 			require.Len(t, resp.Failures, 0)
@@ -146,8 +146,8 @@ func TestCheckDefaultsEnv(t *testing.T) {
 
 	prov := provider(t)
 	resp, err := prov.Check(p.CheckRequest{
-		Urn:  urn("ReadEnv", "check-env"),
-		News: property.Map{},
+		Urn:    urn("ReadEnv", "check-env"),
+		Inputs: property.Map{},
 	})
 	require.NoError(t, err)
 
@@ -166,8 +166,8 @@ func TestCheckDefaultsRecursive(t *testing.T) {
 
 	// If we just have a type without the recursive field nil, we don't recurse.
 	resp, err := prov.Check(p.CheckRequest{
-		Urn:  urn("Recursive", "check-env"),
-		News: property.Map{},
+		Urn:    urn("Recursive", "check-env"),
+		Inputs: property.Map{},
 	})
 	require.NoError(t, err)
 
@@ -179,7 +179,7 @@ func TestCheckDefaultsRecursive(t *testing.T) {
 	// values.
 	resp, err = prov.Check(p.CheckRequest{
 		Urn: urn("Recursive", "check-env"),
-		News: property.NewMap(map[string]property.Value{
+		Inputs: property.NewMap(map[string]property.Value{
 			"other": property.New(map[string]property.Value{
 				"other": property.New(map[string]property.Value{
 					"value": property.New("custom"),
@@ -214,7 +214,7 @@ func TestCheckAlwaysAppliesSecrets(t *testing.T) {
 	prov := provider(t)
 	resp, err := prov.Check(p.CheckRequest{
 		Urn: urn("CustomCheckNoDefaults", "check-env"),
-		News: property.NewMap(map[string]property.Value{
+		Inputs: property.NewMap(map[string]property.Value{
 			"input": property.New("value"),
 		}),
 	})

--- a/infer/tests/migrate_test.go
+++ b/infer/tests/migrate_test.go
@@ -116,7 +116,6 @@ func migrationServer() integration.Server {
 // Test f on some old states that should be equivalent after upgrades.
 func testMigrationEquivalentStates(t *testing.T, f func(t *testing.T, state, v2State property.Map)) {
 	t.Run("defaults", func(t *testing.T) {
-
 		v2 := property.NewMap(map[string]property.Value{
 			"aString": property.New("default-string"),
 			"aInt":    property.New(-7.0),
@@ -244,7 +243,8 @@ func TestMigrateRead(t *testing.T) {
 }
 
 func (*MigrateR) Create(_ context.Context,
-	req infer.CreateRequest[MigrateStateInput]) (infer.CreateResponse[MigrateStateV2], error) {
+	req infer.CreateRequest[MigrateStateInput],
+) (infer.CreateResponse[MigrateStateV2], error) {
 	panic("CANNOT CREATE; ONLY MIGRATE")
 }
 
@@ -252,7 +252,7 @@ func (*MigrateR) Create(_ context.Context,
 func (*MigrateR) Update(
 	_ context.Context, req infer.UpdateRequest[MigrateStateInput, MigrateStateV2],
 ) (infer.UpdateResponse[MigrateStateV2], error) {
-	return infer.UpdateResponse[MigrateStateV2]{Output: req.Olds}, nil
+	return infer.UpdateResponse[MigrateStateV2]{Output: req.State}, nil
 }
 
 func (*MigrateR) Read(
@@ -266,8 +266,9 @@ func (*MigrateR) Delete(_ context.Context, req infer.DeleteRequest[MigrateStateV
 }
 
 func (*MigrateR) Diff(_ context.Context,
-	req infer.DiffRequest[MigrateStateInput, MigrateStateV2]) (infer.DiffResponse, error) {
-	return infer.DiffResponse{}, viaError[MigrateStateV2]{req.Olds}
+	req infer.DiffRequest[MigrateStateInput, MigrateStateV2],
+) (infer.DiffResponse, error) {
+	return infer.DiffResponse{}, viaError[MigrateStateV2]{req.State}
 }
 
 type viaError[T any] struct{ t T }

--- a/infer/tests/migrate_test.go
+++ b/infer/tests/migrate_test.go
@@ -183,9 +183,9 @@ func TestMigrateUpdate(t *testing.T) {
 
 	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State property.Map) {
 		resp, err := migrationServer().Update(p.UpdateRequest{
-			ID:   "some-id",
-			Urn:  urn("MigrateR", "update"),
-			Olds: state,
+			ID:    "some-id",
+			Urn:   urn("MigrateR", "update"),
+			State: state,
 		})
 		require.NoError(t, err)
 		assert.Equal(t, v2State, resp.Properties)
@@ -197,9 +197,9 @@ func TestMigrateDiff(t *testing.T) {
 
 	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State property.Map) {
 		_, err := migrationServer().Diff(p.DiffRequest{
-			ID:   "some-id",
-			Urn:  urn("MigrateR", "diff"),
-			Olds: state,
+			ID:    "some-id",
+			Urn:   urn("MigrateR", "diff"),
+			State: state,
 		})
 		var via viaError[MigrateStateV2]
 		require.ErrorAs(t, err, &via)

--- a/infer/tests/update_test.go
+++ b/infer/tests/update_test.go
@@ -39,8 +39,8 @@ func TestUpdateManualDeps(t *testing.T) {
 				resp, err := prov.Update(p.UpdateRequest{
 					ID:      "some-id",
 					Urn:     urn(resource, "test"),
-					Olds:    olds,
-					News:    newsPreview,
+					State:   olds,
+					Inputs:  newsPreview,
 					Preview: true,
 				})
 				assert.NoError(t, err)
@@ -52,9 +52,9 @@ func TestUpdateManualDeps(t *testing.T) {
 				t.Parallel()
 				prov := provider(t)
 				resp, err := prov.Update(p.UpdateRequest{
-					ID:   "some-id",
-					Urn:  urn(resource, "test"),
-					Olds: olds, News: newsUpdate,
+					ID:    "some-id",
+					Urn:   urn(resource, "test"),
+					State: olds, Inputs: newsUpdate,
 				})
 				assert.NoError(t, err)
 				assert.Equal(t, p.UpdateResponse{
@@ -124,21 +124,22 @@ func TestUpdateDefaultDeps(t *testing.T) {
 	t.Parallel()
 
 	test := func(t *testing.T, newString property.Value,
-		expectedPreview, expectedUp property.Map) {
+		expectedPreview, expectedUp property.Map,
+	) {
 		t.Run("preview", func(t *testing.T) {
 			t.Parallel()
 			prov := provider(t)
 			resp, err := prov.Update(p.UpdateRequest{
 				ID:  "some-id",
 				Urn: urn("Echo", "preview"),
-				Olds: property.NewMap(map[string]property.Value{
+				State: property.NewMap(map[string]property.Value{
 					"string":    property.New("old-string"),
 					"int":       property.New(1.0),
 					"intOut":    property.New(1.0),
 					"nameOut":   property.New("old-name"),
 					"stringOut": property.New("old-string"),
 				}),
-				News: property.NewMap(map[string]property.Value{
+				Inputs: property.NewMap(map[string]property.Value{
 					// Became computed
 					"string": newString,
 					"int":    property.New(1.0),
@@ -162,14 +163,14 @@ func TestUpdateDefaultDeps(t *testing.T) {
 			resp, err := prov.Update(p.UpdateRequest{
 				ID:  "some-id",
 				Urn: urn("Echo", "update"),
-				Olds: property.NewMap(map[string]property.Value{
+				State: property.NewMap(map[string]property.Value{
 					"string":    property.New("old-string"),
 					"int":       property.New(1.0),
 					"intOut":    property.New(1.0),
 					"nameOut":   property.New("old-name"),
 					"stringOut": property.New("old-string"),
 				}),
-				News: property.NewMap(map[string]property.Value{
+				Inputs: property.NewMap(map[string]property.Value{
 					"string": newString,
 					"int":    property.New(1.0),
 				}),

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -88,7 +88,8 @@ func NewServerWithContext(ctx context.Context, pkg string, version semver.Versio
 }
 
 func NewServerWithOptions(ctx context.Context, pkg string, version semver.Version, provider p.Provider,
-	opts ...ServerOption) Server {
+	opts ...ServerOption,
+) Server {
 	o := &serverOptions{}
 	for _, opt := range opts {
 		opt.applyServerOption(o)
@@ -231,7 +232,6 @@ var _ = (p.Host)(&host{})
 // Construct implements the host interface to allow the provider to construct resources.
 func (h *host) Construct(ctx context.Context, req p.ConstructRequest, construct comProvider.ConstructFunc,
 ) (p.ConstructResponse, error) {
-
 	// Use the fake engine to create a pulumi context,
 	// and then call the user's construct function with the context.
 	// the function is expected to register resources, which will be
@@ -260,7 +260,6 @@ func (s *server) Call(req p.CallRequest) (p.CallResponse, error) {
 
 func (h *host) Call(ctx context.Context, req p.CallRequest, call comProvider.CallFunc,
 ) (p.CallResponse, error) {
-
 	// Use the fake engine to create a pulumi context,
 	// and then call the user's call function with the context.
 	// the function is expected to register resources, which will be
@@ -333,9 +332,9 @@ func (l LifeCycleTest) Run(t *testing.T, server Server) {
 	runCreate := func(op Operation) (p.CreateResponse, bool) {
 		// Here we do the create and the initial setup
 		checkResponse, err := server.Check(p.CheckRequest{
-			Urn:  urn,
-			Olds: property.Map{},
-			News: op.Inputs,
+			Urn:    urn,
+			State:  property.Map{},
+			Inputs: op.Inputs,
 		})
 		assert.NoError(t, err, "resource check errored")
 		if len(op.CheckFailures) > 0 || len(checkResponse.Failures) > 0 {
@@ -384,9 +383,9 @@ func (l LifeCycleTest) Run(t *testing.T, server Server) {
 	for i, update := range l.Updates {
 		// Perform the check
 		check, err := server.Check(p.CheckRequest{
-			Urn:  urn,
-			Olds: olds,
-			News: update.Inputs,
+			Urn:    urn,
+			State:  olds,
+			Inputs: update.Inputs,
 		})
 
 		assert.NoErrorf(t, err, "check returned an error on update %d", i)
@@ -400,10 +399,10 @@ func (l LifeCycleTest) Run(t *testing.T, server Server) {
 		}
 
 		diff, err := server.Diff(p.DiffRequest{
-			ID:   id,
-			Urn:  urn,
-			Olds: olds,
-			News: check.Inputs,
+			ID:     id,
+			Urn:    urn,
+			State:  olds,
+			Inputs: check.Inputs,
 		})
 		assert.NoErrorf(t, err, "diff failed on update %d", i)
 		if err != nil {
@@ -458,8 +457,8 @@ func (l LifeCycleTest) Run(t *testing.T, server Server) {
 			_, err = server.Update(p.UpdateRequest{
 				ID:      id,
 				Urn:     urn,
-				Olds:    olds,
-				News:    check.Inputs,
+				State:   olds,
+				Inputs:  check.Inputs,
 				Preview: true,
 			})
 
@@ -468,10 +467,10 @@ func (l LifeCycleTest) Run(t *testing.T, server Server) {
 			}
 
 			result, err := server.Update(p.UpdateRequest{
-				ID:   id,
-				Urn:  urn,
-				Olds: olds,
-				News: check.Inputs,
+				ID:     id,
+				Urn:    urn,
+				State:  olds,
+				Inputs: check.Inputs,
 			})
 			if !update.ExpectFailure && err != nil {
 				assert.NoError(t, err, "failed to update the resource")
@@ -496,5 +495,4 @@ func (l LifeCycleTest) Run(t *testing.T, server Server) {
 		Properties: olds,
 	})
 	assert.NoError(t, err, "failed to delete the resource")
-
 }

--- a/middleware/complexconfig/provider.go
+++ b/middleware/complexconfig/provider.go
@@ -51,7 +51,7 @@ type (
 func encodeCheckConfig(check checkConfig, getSchema getSchema) checkConfig {
 	if check == nil {
 		check = func(_ context.Context, req p.CheckRequest) (p.CheckResponse, error) {
-			return p.CheckResponse{Inputs: req.News}, nil
+			return p.CheckResponse{Inputs: req.Inputs}, nil
 		}
 	}
 	return func(ctx context.Context, req p.CheckRequest) (p.CheckResponse, error) {
@@ -59,7 +59,7 @@ func encodeCheckConfig(check checkConfig, getSchema getSchema) checkConfig {
 		// and thus went through a previous normalizing pass of CheckConfig.
 
 		// If there are no inputs, then we can just return.
-		if req.News.Len() == 0 {
+		if req.Inputs.Len() == 0 {
 			return check(ctx, req)
 		}
 
@@ -74,7 +74,7 @@ func encodeCheckConfig(check checkConfig, getSchema getSchema) checkConfig {
 				p.InternalErrorf("unable to decode config: invalid schema: %w", err)
 		}
 
-		news := resource.ToResourcePropertyValue(property.New(req.News)).ObjectValue()
+		news := resource.ToResourcePropertyValue(property.New(req.Inputs)).ObjectValue()
 
 		for k, spec := range spec.Config.Variables {
 			v, ok := news[resource.PropertyKey(k)]
@@ -93,7 +93,7 @@ func encodeCheckConfig(check checkConfig, getSchema getSchema) checkConfig {
 			news[k] = fixEncoding(v, schema.PropertySpec{})
 		}
 
-		req.News = resource.FromResourcePropertyValue(resource.NewProperty(news)).AsMap()
+		req.Inputs = resource.FromResourcePropertyValue(resource.NewProperty(news)).AsMap()
 		return check(ctx, req)
 	}
 }

--- a/middleware/complexconfig/provider_test.go
+++ b/middleware/complexconfig/provider_test.go
@@ -73,7 +73,6 @@ func TestComplexConfigEncoding(t *testing.T) {
 				}
 
 				return p, nil
-
 			},
 			expected: property.NewMap(map[string]property.Value{
 				"$": property.New("42"),
@@ -99,8 +98,8 @@ func TestComplexConfigEncoding(t *testing.T) {
 					}, err
 				},
 				CheckConfig: func(_ context.Context, req p.CheckRequest) (p.CheckResponse, error) {
-					if !property.New(req.News).Equals(property.New(tt.expected)) {
-						assert.Equal(t, tt.expected, req.News)
+					if !property.New(req.Inputs).Equals(property.New(tt.expected)) {
+						assert.Equal(t, tt.expected, req.Inputs)
 					}
 
 					return p.CheckResponse{}, nil
@@ -108,7 +107,7 @@ func TestComplexConfigEncoding(t *testing.T) {
 			})
 
 			_, err := provider.CheckConfig(context.Background(), p.CheckRequest{
-				News: generateJSONEncoding(t, resource.ToResourcePropertyValue(property.New(tt.input)).ObjectValue()),
+				Inputs: generateJSONEncoding(t, resource.ToResourcePropertyValue(property.New(tt.input)).ObjectValue()),
 			})
 			require.NoError(t, err)
 		})
@@ -141,14 +140,14 @@ func TestRapidComplexConfigEncoding(t *testing.T) {
 				}, err
 			},
 			CheckConfig: func(_ context.Context, req p.CheckRequest) (p.CheckResponse, error) {
-				assert.Equal(t, resource.FromResourcePropertyValue(resource.NewProperty(m)).AsMap(), req.News)
+				assert.Equal(t, resource.FromResourcePropertyValue(resource.NewProperty(m)).AsMap(), req.Inputs)
 
 				return p.CheckResponse{}, nil
 			},
 		})
 
 		_, err := provider.CheckConfig(context.Background(), p.CheckRequest{
-			News: generateJSONEncoding(t, m.Copy()),
+			Inputs: generateJSONEncoding(t, m.Copy()),
 		})
 		require.NoError(t, err)
 	})

--- a/middleware/rpc/provider.go
+++ b/middleware/rpc/provider.go
@@ -63,12 +63,12 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 			return err
 		},
 		CheckConfig: func(ctx context.Context, req p.CheckRequest) (p.CheckResponse, error) {
-			olds, err := runtime.propertyToRPC(req.Olds)
+			olds, err := runtime.propertyToRPC(req.State)
 			if err != nil {
 				return p.CheckResponse{}, err
 			}
 
-			news, err := runtime.propertyToRPC(req.News)
+			news, err := runtime.propertyToRPC(req.Inputs)
 			if err != nil {
 				return p.CheckResponse{}, err
 			}
@@ -81,11 +81,11 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 			}))
 		},
 		DiffConfig: func(ctx context.Context, req p.DiffRequest) (p.DiffResponse, error) {
-			olds, err := runtime.propertyToRPC(req.Olds)
+			olds, err := runtime.propertyToRPC(req.State)
 			if err != nil {
 				return p.DiffResponse{}, err
 			}
-			news, err := runtime.propertyToRPC(req.News)
+			news, err := runtime.propertyToRPC(req.Inputs)
 			if err != nil {
 				return p.DiffResponse{}, err
 			}
@@ -113,7 +113,6 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 			return err
 		},
 		Invoke: func(ctx context.Context, req p.InvokeRequest) (p.InvokeResponse, error) {
-
 			args, err := runtime.propertyToRPC(req.Args)
 			if err != nil {
 				return p.InvokeResponse{}, err
@@ -130,12 +129,12 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 			}, err
 		},
 		Check: func(ctx context.Context, req p.CheckRequest) (p.CheckResponse, error) {
-			olds, err := runtime.propertyToRPC(req.Olds)
+			olds, err := runtime.propertyToRPC(req.State)
 			if err != nil {
 				return p.CheckResponse{}, err
 			}
 
-			news, err := runtime.propertyToRPC(req.News)
+			news, err := runtime.propertyToRPC(req.Inputs)
 			if err != nil {
 				return p.CheckResponse{}, err
 			}
@@ -148,12 +147,12 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 			}))
 		},
 		Diff: func(ctx context.Context, req p.DiffRequest) (p.DiffResponse, error) {
-			olds, err := runtime.propertyToRPC(req.Olds)
+			olds, err := runtime.propertyToRPC(req.State)
 			if err != nil {
 				return p.DiffResponse{}, err
 			}
 
-			news, err := runtime.propertyToRPC(req.News)
+			news, err := runtime.propertyToRPC(req.Inputs)
 			if err != nil {
 				return p.DiffResponse{}, err
 			}
@@ -217,12 +216,12 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 				return p.UpdateResponse{}, nil
 			}
 
-			inOlds, err := runtime.propertyToRPC(req.Olds)
+			inOlds, err := runtime.propertyToRPC(req.State)
 			if err != nil {
 				return p.UpdateResponse{}, err
 			}
 
-			inNews, err := runtime.propertyToRPC(req.News)
+			inNews, err := runtime.propertyToRPC(req.Inputs)
 			if err != nil {
 				return p.UpdateResponse{}, err
 			}

--- a/provider.go
+++ b/provider.go
@@ -63,8 +63,8 @@ type GetSchemaResponse struct {
 
 type CheckRequest struct {
 	Urn        presource.URN
-	Olds       property.Map
-	News       property.Map
+	State      property.Map
+	Inputs     property.Map
 	RandomSeed []byte
 }
 
@@ -81,8 +81,8 @@ type CheckResponse struct {
 type DiffRequest struct {
 	ID            string
 	Urn           presource.URN
-	Olds          property.Map
-	News          property.Map
+	State         property.Map
+	Inputs        property.Map
 	IgnoreChanges []string
 }
 
@@ -168,7 +168,6 @@ func (c diffChanges) rpc() rpc.DiffResponse_DiffChanges {
 }
 
 func (d DiffResponse) rpc() *rpc.DiffResponse {
-
 	hasDetailedDiff := true
 	if _, ok := d.DetailedDiff[key.ForceNoDetailedDiff]; ok {
 		hasDetailedDiff = false
@@ -262,8 +261,8 @@ type ReadResponse struct {
 type UpdateRequest struct {
 	ID            string        // the ID of the resource to update.
 	Urn           presource.URN // the Pulumi URN for this resource.
-	Olds          property.Map  // the old values of provider inputs for the resource to update.
-	News          property.Map  // the new values of provider inputs for the resource to update.
+	State         property.Map  // the old values of provider inputs for the resource to update.
+	Inputs        property.Map  // the new values of provider inputs for the resource to update.
 	Timeout       float64       // the update request timeout represented in seconds.
 	IgnoreChanges []string      // a set of property paths that should be treated as unchanged.
 	Preview       bool          // true if the provider should not actually create the resource.
@@ -676,11 +675,10 @@ func (p *provider) CheckConfig(ctx context.Context, req *rpc.CheckRequest) (*rpc
 
 	r, err := p.client.CheckConfig(ctx, CheckRequest{
 		Urn:        presource.URN(req.GetUrn()),
-		Olds:       olds,
-		News:       news,
+		State:      olds,
+		Inputs:     news,
 		RandomSeed: req.RandomSeed,
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -712,8 +710,8 @@ func (p *provider) DiffConfig(ctx context.Context, req *rpc.DiffRequest) (*rpc.D
 	r, err := p.client.DiffConfig(ctx, DiffRequest{
 		ID:            req.GetId(),
 		Urn:           presource.URN(req.GetUrn()),
-		Olds:          olds,
-		News:          news,
+		State:         olds,
+		Inputs:        news,
 		IgnoreChanges: req.GetIgnoreChanges(),
 	})
 	if err != nil {
@@ -853,8 +851,8 @@ type CallRequest struct {
 }
 
 func newCallRequest(req *rpc.CallRequest,
-	unmarshal func(s *structpb.Struct) (property.Map, error)) (CallRequest, error) {
-
+	unmarshal func(s *structpb.Struct) (property.Map, error),
+) (CallRequest, error) {
 	var errs multierror.Error
 
 	r := CallRequest{
@@ -913,7 +911,6 @@ func newCallRequest(req *rpc.CallRequest,
 }
 
 func (c CallRequest) rpc(marshal propertyToRPC) *rpc.CallRequest {
-
 	fromUrns := func(urns []presource.URN) []string {
 		r := make([]string, len(urns))
 		for i, urn := range urns {
@@ -979,7 +976,6 @@ type CallResponse struct {
 }
 
 func newCallResponse(req *rpc.CallResponse) (CallResponse, error) {
-
 	// Umarshal the return properties.
 	ret, err := internalrpc.UnmarshalProperties(req.Return)
 	if err != nil {
@@ -1024,9 +1020,9 @@ func (p *provider) Check(ctx context.Context, req *rpc.CheckRequest) (*rpc.Check
 	}
 
 	r, err := p.client.Check(ctx, CheckRequest{
-		Urn:  presource.URN(req.GetUrn()),
-		Olds: olds,
-		News: news,
+		Urn:    presource.URN(req.GetUrn()),
+		State:  olds,
+		Inputs: news,
 	})
 	if err != nil {
 		return nil, err
@@ -1040,7 +1036,6 @@ func (p *provider) Check(ctx context.Context, req *rpc.CheckRequest) (*rpc.Check
 		Inputs:   inputs,
 		Failures: checkFailureList(r.Failures).rpc(),
 	}, nil
-
 }
 
 func (p *provider) Diff(ctx context.Context, req *rpc.DiffRequest) (*rpc.DiffResponse, error) {
@@ -1056,8 +1051,8 @@ func (p *provider) Diff(ctx context.Context, req *rpc.DiffRequest) (*rpc.DiffRes
 	r, err := p.client.Diff(ctx, DiffRequest{
 		ID:            req.GetId(),
 		Urn:           presource.URN(req.GetUrn()),
-		Olds:          olds,
-		News:          news,
+		State:         olds,
+		Inputs:        news,
 		IgnoreChanges: req.GetIgnoreChanges(),
 	})
 	if err != nil {
@@ -1163,8 +1158,8 @@ func (p *provider) Update(ctx context.Context, req *rpc.UpdateRequest) (*rpc.Upd
 	r, err := p.client.Update(ctx, UpdateRequest{
 		ID:            req.GetId(),
 		Urn:           presource.URN(req.GetUrn()),
-		Olds:          oldsMap,
-		News:          newsMap,
+		State:         oldsMap,
+		Inputs:        newsMap,
 		Timeout:       req.GetTimeout(),
 		IgnoreChanges: req.GetIgnoreChanges(),
 		Preview:       req.GetPreview(),
@@ -1189,7 +1184,6 @@ func (p *provider) Update(ctx context.Context, req *rpc.UpdateRequest) (*rpc.Upd
 	return &rpc.UpdateResponse{
 		Properties: props,
 	}, nil
-
 }
 
 func (p *provider) Delete(ctx context.Context, req *rpc.DeleteRequest) (*emptypb.Empty, error) {
@@ -1208,7 +1202,6 @@ func (p *provider) Delete(ctx context.Context, req *rpc.DeleteRequest) (*emptypb
 		return nil, err
 	}
 	return &emptypb.Empty{}, nil
-
 }
 
 // ConstructRequest captures enough data to be able to register nested components against the caller's resource
@@ -1294,8 +1287,8 @@ type ProviderReference struct {
 }
 
 func newConstructRequest(req *rpc.ConstructRequest,
-	unmarshal func(s *structpb.Struct) (property.Map, error)) (ConstructRequest, error) {
-
+	unmarshal func(s *structpb.Struct) (property.Map, error),
+) (ConstructRequest, error) {
 	var errs multierror.Error
 
 	toTimeout := func(name, s string) float64 {
@@ -1429,7 +1422,6 @@ func newConstructRequest(req *rpc.ConstructRequest,
 type propertyToRPC func(m property.Map) (*structpb.Struct, error)
 
 func (c ConstructRequest) rpc(marshal propertyToRPC) *rpc.ConstructRequest {
-
 	// https://github.com/pulumi/pulumi/blob/v3.162.0/sdk/go/common/resource/plugin/provider_plugin.go#L1735-L1812
 
 	fromUrns := func(urns []presource.URN) []string {
@@ -1604,7 +1596,6 @@ func (p *provider) Cancel(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty
 		return nil, err
 	}
 	return &emptypb.Empty{}, nil
-
 }
 
 type (

--- a/provider.go
+++ b/provider.go
@@ -261,7 +261,7 @@ type ReadResponse struct {
 type UpdateRequest struct {
 	ID            string        // the ID of the resource to update.
 	Urn           presource.URN // the Pulumi URN for this resource.
-	State         property.Map  // the old values of provider inputs for the resource to update.
+	State         property.Map  // the old state of the resource to update.
 	Inputs        property.Map  // the new values of provider inputs for the resource to update.
 	Timeout       float64       // the update request timeout represented in seconds.
 	IgnoreChanges []string      // a set of property paths that should be treated as unchanged.

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -112,7 +112,7 @@ func TestInferCheckConfigSecrets(t *testing.T) {
 	resp, err := integration.NewServer("test", semver.MustParse("0.0.0"), infer.Provider(infer.Options{
 		Config: infer.Config[config](),
 	})).CheckConfig(p.CheckRequest{
-		News: property.NewMap(map[string]property.Value{
+		Inputs: property.NewMap(map[string]property.Value{
 			"field": property.New("value"),
 			"nested": property.New(map[string]property.Value{
 				"int":        property.New(1.0),
@@ -203,7 +203,7 @@ func TestInferCustomCheckConfig(t *testing.T) {
 			t.Parallel()
 			resp, err := s.CheckConfig(p.CheckRequest{
 				Urn: resource.CreateURN("p", "pulumi:providers:test", "", "test", "dev"),
-				News: property.NewMap(map[string]property.Value{
+				Inputs: property.NewMap(map[string]property.Value{
 					"field":         property.New("value"),
 					"not":           property.New("not-secret"),
 					"applyDefaults": property.New(applyDefaults),

--- a/tests/grpc/partial/provider.go
+++ b/tests/grpc/partial/provider.go
@@ -69,9 +69,9 @@ func (*Partial) Update(ctx context.Context, req infer.UpdateRequest[Args, State]
 	if req.Preview {
 		return infer.UpdateResponse[State]{}, nil
 	}
-	contract.Assertf(req.News.S == "for-update", `expected news.S to be "for-update"`)
-	contract.Assertf(req.Olds.S == "+for-create", `expected olds.Out to be "partial-create"`)
-	contract.Assertf(req.Olds.Out == "partial-init", `expected olds.Out to be "partial-create"`)
+	contract.Assertf(req.Inputs.S == "for-update", `expected news.S to be "for-update"`)
+	contract.Assertf(req.State.S == "+for-create", `expected olds.Out to be "partial-create"`)
+	contract.Assertf(req.State.Out == "partial-init", `expected olds.Out to be "partial-create"`)
 
 	return infer.UpdateResponse[State]{
 			Output: State{

--- a/tests/resource_test.go
+++ b/tests/resource_test.go
@@ -54,7 +54,7 @@ func TestInferCheckSecrets(t *testing.T) {
 		},
 	})).Check(p.CheckRequest{
 		Urn: resource.CreateURN("name", "test:index:res", "", "proj", "stack"),
-		News: property.NewMap(map[string]property.Value{
+		Inputs: property.NewMap(map[string]property.Value{
 			"field": property.New("value"),
 		}),
 	})

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -538,8 +538,8 @@ func TestRPCUpdate(t *testing.T) {
 		}).Update(p.UpdateRequest{
 			ID:            "some-id",
 			Urn:           "some-urn",
-			Olds:          resource.FromResourcePropertyValue(resource.NewProperty(olds)).AsMap(),
-			News:          resource.FromResourcePropertyValue(resource.NewProperty(news)).AsMap(),
+			State:         resource.FromResourcePropertyValue(resource.NewProperty(olds)).AsMap(),
+			Inputs:        resource.FromResourcePropertyValue(resource.NewProperty(news)).AsMap(),
 			Timeout:       1.23,
 			IgnoreChanges: []string{"f1"},
 			Preview:       true,
@@ -815,8 +815,8 @@ func testRPCCheck(
 			}, nil
 		})(p.CheckRequest{
 			Urn:        "some-urn",
-			Olds:       resource.FromResourcePropertyValue(resource.NewProperty(olds)).AsMap(),
-			News:       resource.FromResourcePropertyValue(resource.NewProperty(news)).AsMap(),
+			State:      resource.FromResourcePropertyValue(resource.NewProperty(olds)).AsMap(),
+			Inputs:     resource.FromResourcePropertyValue(resource.NewProperty(news)).AsMap(),
 			RandomSeed: []byte("12345"),
 		})
 		require.NoError(t, err)
@@ -895,8 +895,8 @@ func testRPCDiff(
 		})(p.DiffRequest{
 			ID:            "some-id",
 			Urn:           "my-urn",
-			Olds:          resource.FromResourcePropertyValue(resource.NewProperty(olds)).AsMap(),
-			News:          resource.FromResourcePropertyValue(resource.NewProperty(news)).AsMap(),
+			State:         resource.FromResourcePropertyValue(resource.NewProperty(olds)).AsMap(),
+			Inputs:        resource.FromResourcePropertyValue(resource.NewProperty(news)).AsMap(),
 			IgnoreChanges: []string{"field1", "field2"},
 		})
 


### PR DESCRIPTION
Olds/News is a Pulumi naming convention that isn't immediately obvious to newcomers.

We're already using State/Inputs terminology, which is much more obvious. Let's rename these for consistency.

Edit: We could also go the other way and rename State/Inputs to → Olds/News if we want to keep things as close as possible to the protocol.