### PR TITLE
Split up BuildAndRun

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,16 @@ import (
 func main() {
 	// We tell the provider what resources it needs to support.
 	// In this case, a single custom resource called HelloWorld.
-	err := infer.NewProviderBuilder().
-		WithName("greetings").
-		WithVersion("0.1.0").
+	p, err := infer.NewProviderBuilder().
 		WithResources(
 			infer.Resource[HelloWorld](),
 		).
-		BuildAndRun()
+		Build()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+    p.Run(context.Background(), "greetings", "0.1.0")
 }
 
 // Each resource has a controlling struct.
@@ -112,17 +111,16 @@ import (
 )
 
 func main() {
-	err := infer.NewProviderBuilder().
-		WithName("greetings").
-		WithVersion("0.1.0").
+	p, err := infer.NewProviderBuilder().
 		WithComponents(
 			infer.Component(NewRandomLogin),
 		).
-		BuildAndRun()
+		Build()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+    p.Run(context.Background(), "greetings", "0.1.0")
 }
 
 type RandomLoginArgs struct {
@@ -190,20 +188,19 @@ import (
 )
 
 func main() {
-	err := infer.NewProviderBuilder().
-		WithName("greetings").
-		WithVersion("0.1.0").
+	p, err := infer.NewProviderBuilder().
 		WithResources(
 			infer.Resource[HelloWorld](),
 		).
 		WithConfig(
 			infer.Config[*Config](),
 		).
-		BuildAndRun()
+		Build()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+    p.Run(context.Background(), "greetings", "0.1.0")
 }
 
 type Config struct {
@@ -245,17 +242,16 @@ import (
 )
 
 func main() {
-	err := infer.NewProviderBuilder().
-		WithName("greetings").
-		WithVersion("0.1.0").
+	p, err := infer.NewProviderBuilder().
 		WithFunctions(
 			infer.Function[*Replace](),
 		).
-		BuildAndRun()
+		Build()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+    p.Run(context.Background(), "greetings", "0.1.0")
 }
 
 type Replace struct{}

--- a/examples/component-provider/main.go
+++ b/examples/component-provider/main.go
@@ -25,8 +25,6 @@ import (
 
 func main() {
 	p, err := infer.NewProviderBuilder().
-		WithName("go-components").
-		WithVersion("v0.0.1").
 		WithNamespace("example-namespace").
 		WithComponents(
 			infer.Component(NewMyComponent),
@@ -38,5 +36,5 @@ func main() {
 		panic(err)
 	}
 
-	p.Run(context.Background())
+	p.Run(context.Background(), "go-components", "v0.0.1")
 }

--- a/examples/component-provider/main.go
+++ b/examples/component-provider/main.go
@@ -17,12 +17,14 @@
 package main
 
 import (
+	"context"
+
 	"github.com/pulumi/pulumi-go-provider/examples/component-provider/nested"
 	"github.com/pulumi/pulumi-go-provider/infer"
 )
 
 func main() {
-	err := infer.NewProviderBuilder().
+	p, err := infer.NewProviderBuilder().
 		WithName("go-components").
 		WithVersion("v0.0.1").
 		WithNamespace("example-namespace").
@@ -30,9 +32,11 @@ func main() {
 			infer.Component(NewMyComponent),
 			infer.Component(nested.NewNestedRandomComponent),
 		).
-		BuildAndRun()
+		Build()
 
 	if err != nil {
 		panic(err)
 	}
+
+	p.Run(context.Background())
 }

--- a/infer/README.md
+++ b/infer/README.md
@@ -93,17 +93,17 @@ telling it that it should serve the `Login` component.
 
 ```go
 func main() {
-	err := infer.NewProviderBuilder().
-		WithName("example").
-		WithVersion("0.1.0").
+	p, err := infer.NewProviderBuilder().
 		WithComponents(
 			infer.Component(NewLogin),
 		).
-		BuildAndRun()
+		Build()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s", err.Error())
 		os.Exit(1)
 	}
+
+    p.Run(context.Background(), "example", "0.1.0")
 }
 ```
 
@@ -348,17 +348,17 @@ telling it that it should serve the `File` resource.
 
 ```go
 func main() {
-	err := infer.NewProviderBuilder().
-		WithName("example").
-		WithVersion("0.1.0").
+	p, err := infer.NewProviderBuilder().
 		WithResources(
 			infer.Resource[File](),
 		).
-		BuildAndRun()
+		Build()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s", err.Error())
 		os.Exit(1)
 	}
+
+    p.Run(context.Background(), "example", "0.1.0")
 }
 ```
 

--- a/infer/provider.go
+++ b/infer/provider.go
@@ -79,6 +79,10 @@ type Options struct {
 	// will instead result in exposing the same resources at `pkg:bar:Foo`, `pkg:bar:Bar` and
 	// `pkg:fizz:Buzz`.
 	ModuleMap map[tokens.ModuleName]tokens.ModuleName
+
+	Name string
+
+	Version string
 }
 
 func (o Options) dispatch() dispatch.Options {
@@ -169,6 +173,9 @@ func Wrap(provider p.Provider, opts Options) p.Provider {
 			return context.WithValue(ctx, configKey, opts.Config)
 		})
 	}
+
+	provider.Name = opts.Name
+	provider.Version = opts.Version
 
 	provider = complexconfig.Wrap(provider)
 	return cancel.Wrap(provider)

--- a/infer/provider.go
+++ b/infer/provider.go
@@ -79,10 +79,6 @@ type Options struct {
 	// will instead result in exposing the same resources at `pkg:bar:Foo`, `pkg:bar:Bar` and
 	// `pkg:fizz:Buzz`.
 	ModuleMap map[tokens.ModuleName]tokens.ModuleName
-
-	Name string
-
-	Version string
 }
 
 func (o Options) dispatch() dispatch.Options {
@@ -173,9 +169,6 @@ func Wrap(provider p.Provider, opts Options) p.Provider {
 			return context.WithValue(ctx, configKey, opts.Config)
 		})
 	}
-
-	provider.Name = opts.Name
-	provider.Version = opts.Version
 
 	provider = complexconfig.Wrap(provider)
 	return cancel.Wrap(provider)

--- a/infer/provider_builder.go
+++ b/infer/provider_builder.go
@@ -38,29 +38,30 @@ type ProviderBuilder struct {
 //
 // This is an example of how to create a simple provider with a single component resource:
 //
-//		type RandomComponent struct {
-//			pulumi.ResourceState
-//			RandomComponentArgs
-//		 	Password        pulumi.StringOutput `pulumi:"password"`
-//		}
+//	type RandomComponent struct {
+//	    pulumi.ResourceState
+//	    RandomComponentArgs
 //
-//		type RandomComponentArgs struct {
-//			Length pulumi.IntInput `pulumi:"length"`
-//		}
+//	    Password pulumi.StringOutput `pulumi:"password"`
+//	}
 //
-//		func NewMyComponent(ctx *pulumi.Context, name string,
-//				compArgs RandomComponentArgs, opts ...pulumi.ResourceOption) (*RandomComponent, error) {
-//			// Define your component constructor logic here.
-//		}
+//	type RandomComponentArgs struct {
+//	    Length pulumi.IntInput `pulumi:"length"`
+//	}
 //
-//		func main() {
-//			p, _ := infer.NewProviderBuilder().
-//				WithComponents(
-//					infer.Component(NewMyComponent),
-//				).
-//				Build()
-//	        p.Run(context.Background(), "go-components", "v0.0.1")
-//		}
+//	func NewMyComponent(ctx *pulumi.Context, name string,
+//	    compArgs RandomComponentArgs, opts ...pulumi.ResourceOption) (*RandomComponent, error) {
+//	    // Define your component constructor logic here.
+//	}
+//
+//	func main() {
+//	    p, _ := infer.NewProviderBuilder().
+//	        WithComponents(
+//	            infer.Component(NewMyComponent),
+//	        ).
+//	        Build()
+//	    p.Run(context.Background(), "go-components", "v0.0.1")
+//	}
 //
 // Please note that the initial defaults provided by this function may change with future releases of
 // this framework. Currently, we are setting the following defaults:

--- a/infer/provider_builder.go
+++ b/infer/provider_builder.go
@@ -23,13 +23,12 @@ import (
 )
 
 type ProviderBuilder struct {
-	name, version string
-	metadata      schema.Metadata
-	resources     []InferredResource
-	components    []InferredComponent
-	functions     []InferredFunction
-	config        InferredConfig
-	moduleMap     map[tokens.ModuleName]tokens.ModuleName
+	metadata   schema.Metadata
+	resources  []InferredResource
+	components []InferredComponent
+	functions  []InferredFunction
+	config     InferredConfig
+	moduleMap  map[tokens.ModuleName]tokens.ModuleName
 }
 
 // NewProviderBuilder creates an inferred provider which fills as many defaults as possible.
@@ -56,7 +55,6 @@ type ProviderBuilder struct {
 //
 //		func main() {
 //			err := infer.NewProviderBuilder().
-//				WithName("go-components").
 //				WithVersion("v0.0.1").
 //				WithComponents(
 //					infer.Component(NewMyComponent),
@@ -89,9 +87,6 @@ func NewProviderBuilder() *ProviderBuilder {
 	}
 
 	return &ProviderBuilder{
-		// Default the component provider schema version to "0.0.0" if not provided for now,
-		// otherwise SDK codegen gets confused without a version.
-		version:  "0.0.0",
 		metadata: defaultMetadata,
 	}
 }
@@ -189,18 +184,6 @@ func (pb *ProviderBuilder) WithPluginDownloadURL(pluginDownloadURL string) *Prov
 	return pb
 }
 
-// WithName sets the provider name.
-func (pb *ProviderBuilder) WithName(name string) *ProviderBuilder {
-	pb.name = name
-	return pb
-}
-
-// WithVersion sets the provider version.
-func (pb *ProviderBuilder) WithVersion(version string) *ProviderBuilder {
-	pb.version = version
-	return pb
-}
-
 // WithNamespace sets the provider namespace.
 func (pb *ProviderBuilder) WithNamespace(namespace string) *ProviderBuilder {
 	pb.metadata.Namespace = namespace
@@ -217,17 +200,12 @@ func (pb *ProviderBuilder) BuildOptions() Options {
 		Functions:  pb.functions,
 		Config:     pb.config,
 		ModuleMap:  pb.moduleMap,
-		Name:       pb.name,
-		Version:    pb.version,
 	}
 }
 
 // validate checks if the provider builder configuration is valid.
 func (pb *ProviderBuilder) validate() error {
-	switch {
-	case pb.name == "":
-		return fmt.Errorf("provider name is required")
-	case len(pb.components) == 0 && len(pb.resources) == 0 && len(pb.functions) == 0:
+	if len(pb.components) == 0 && len(pb.resources) == 0 && len(pb.functions) == 0 {
 		return fmt.Errorf("at least one resource, component, or function is required")
 	}
 

--- a/infer/provider_builder.go
+++ b/infer/provider_builder.go
@@ -15,7 +15,6 @@
 package infer
 
 import (
-	"context"
 	"fmt"
 
 	provider "github.com/pulumi/pulumi-go-provider"
@@ -40,30 +39,31 @@ type ProviderBuilder struct {
 //
 // This is an example of how to create a simple provider with a single component resource:
 //
-//	type RandomComponent struct {
-//		pulumi.ResourceState
-//		RandomComponentArgs
-//	 	Password        pulumi.StringOutput `pulumi:"password"`
-//	}
+//		type RandomComponent struct {
+//			pulumi.ResourceState
+//			RandomComponentArgs
+//		 	Password        pulumi.StringOutput `pulumi:"password"`
+//		}
 //
-//	type RandomComponentArgs struct {
-//		Length pulumi.IntInput `pulumi:"length"`
-//	}
+//		type RandomComponentArgs struct {
+//			Length pulumi.IntInput `pulumi:"length"`
+//		}
 //
-//	func NewMyComponent(ctx *pulumi.Context, name string,
-//			compArgs RandomComponentArgs, opts ...pulumi.ResourceOption) (*RandomComponent, error) {
-//		// Define your component constructor logic here.
-//	}
+//		func NewMyComponent(ctx *pulumi.Context, name string,
+//				compArgs RandomComponentArgs, opts ...pulumi.ResourceOption) (*RandomComponent, error) {
+//			// Define your component constructor logic here.
+//		}
 //
-//	func main() {
-//		err := infer.NewProviderBuilder().
-//			WithName("go-components").
-//			WithVersion("v0.0.1").
-//			WithComponents(
-//				infer.Component(NewMyComponent),
-//			).
-//			BuildAndRun()
-//	}
+//		func main() {
+//			err := infer.NewProviderBuilder().
+//				WithName("go-components").
+//				WithVersion("v0.0.1").
+//				WithComponents(
+//					infer.Component(NewMyComponent),
+//				).
+//				Build().
+//	         Run()
+//		}
 //
 // Please note that the initial defaults provided by this function may change with future releases of
 // this framework. Currently, we are setting the following defaults:
@@ -217,6 +217,8 @@ func (pb *ProviderBuilder) BuildOptions() Options {
 		Functions:  pb.functions,
 		Config:     pb.config,
 		ModuleMap:  pb.moduleMap,
+		Name:       pb.name,
+		Version:    pb.version,
 	}
 }
 
@@ -232,12 +234,12 @@ func (pb *ProviderBuilder) validate() error {
 	return nil
 }
 
-// BuildAndRun builds the provider options, validates them, and runs the provider.
-func (pb *ProviderBuilder) BuildAndRun() error {
+// Build builds the provider options and validates them., and runs the provider.
+func (pb *ProviderBuilder) Build() (provider.Provider, error) {
 	if err := pb.validate(); err != nil {
-		return err
+		return provider.Provider{}, err
 	}
 
 	opts := pb.BuildOptions()
-	return provider.RunProvider(context.Background(), pb.name, pb.version, Provider(opts))
+	return Provider(opts), nil
 }

--- a/infer/provider_builder.go
+++ b/infer/provider_builder.go
@@ -54,13 +54,12 @@ type ProviderBuilder struct {
 //		}
 //
 //		func main() {
-//			err := infer.NewProviderBuilder().
-//				WithVersion("v0.0.1").
+//			p, _ := infer.NewProviderBuilder().
 //				WithComponents(
 //					infer.Component(NewMyComponent),
 //				).
-//				Build().
-//	         Run()
+//				Build()
+//	        p.Run(context.Background(), "go-components", "v0.0.1")
 //		}
 //
 // Please note that the initial defaults provided by this function may change with future releases of

--- a/infer/provider_builder_test.go
+++ b/infer/provider_builder_test.go
@@ -103,7 +103,6 @@ func TestNewDefaultProvider(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, "0.0.0", dp.version)
 	assert.Equal(t, expectedLangMap, dp.metadata.LanguageMap)
 }
 
@@ -301,14 +300,8 @@ func TestValidate(t *testing.T) {
 	t.Parallel()
 	dp := NewProviderBuilder()
 
-	// Should fail with no name
+	// Should fail with no resources, components or functions
 	err := dp.validate()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "provider name is required")
-
-	// Set name, should fail with no resources, components or functions
-	dp.WithName("test-provider")
-	err = dp.validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one resource, component, or function is required")
 
@@ -319,14 +312,12 @@ func TestValidate(t *testing.T) {
 
 	// Reset and test with component
 	dp = NewProviderBuilder()
-	dp.WithName("test-provider").WithVersion("1.0.0")
 	dp.WithComponents(Component(NewMockComponentResource))
 	err = dp.validate()
 	assert.NoError(t, err)
 
 	// Reset and test with function
 	dp = NewProviderBuilder()
-	dp.WithName("test-provider").WithVersion("1.0.0")
 	dp.WithFunctions(Function[MockFunction]())
 	err = dp.validate()
 	assert.NoError(t, err)
@@ -341,15 +332,13 @@ func TestBuildAndRun(t *testing.T) {
 	// 2. Create a provider with a component and ensure that it starts and runs successfully.
 	p, err := NewProviderBuilder().
 		WithComponents(Component(NewMockComponentResource)).
-		WithName("test-provider").
-		WithVersion("1.0.0").
 		Build()
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	err = p.Run(ctx)
+	err = p.Run(ctx, "test-provider", "v0.0.1")
 
 	assert.NoError(t, err, "provider startup should not fail")
 }

--- a/provider.go
+++ b/provider.go
@@ -373,6 +373,9 @@ type Provider struct {
 
 	// Components Resources
 	Construct func(context.Context, ConstructRequest) (ConstructResponse, error)
+
+	Name    string
+	Version string
 }
 
 // WithDefaults returns a provider with sensible defaults. It does not mutate its
@@ -465,6 +468,10 @@ func (d Provider) WithDefaults() Provider {
 		}
 	}
 	return d
+}
+
+func (d Provider) Run(ctx context.Context) error {
+	return RunProvider(ctx, d.Name, d.Version, d)
 }
 
 // RunProvider runs a provider with the given name and version.

--- a/provider.go
+++ b/provider.go
@@ -480,7 +480,12 @@ func RunProvider(ctx context.Context, name, version string, provider Provider) e
 }
 
 // RunProviderF allows running a provider that has not yet been bound to a HostClient.
-func RunProviderF(ctx context.Context, name, version string, providerF func(*pprovider.HostClient) (Provider, error)) error {
+func RunProviderF(
+	ctx context.Context,
+	name string,
+	version string,
+	providerF func(*pprovider.HostClient) (Provider, error),
+) error {
 	return pprovider.MainContext(ctx, name, func(host *pprovider.HostClient) (rpc.ResourceProviderServer, error) {
 		provider, err := providerF(host)
 		if err != nil {


### PR DESCRIPTION
It's very common (especially in testing) to construct a provider and then pass it around before acting on it.

https://github.com/pulumi/pulumi-docker-build/blob/30a01b689388605b53cf10594ad593c9f270cf15/provider/internal/provider.go#L68

https://github.com/pulumi/pulumi-provider-boilerplate/blob/5c43e6c38e62b35b3352dc535f6e83c6cf4ab32f/provider/provider.go#L28

This means `BuildAndRun` is too restrictive, so this PR breaks out `Build` into a standalone method which returns an error if validation fails.

`Run` is added to go-provider's `Provider` struct to spare the user the unintuitive `provider.Main` call. Name and Version make this a little kludgy because we don't currently track those on the `Provider` itself.