### PR TITLE
[examples/file] fix identical expressions of the '!=' operator

### DIFF
--- a/examples/file/main.go
+++ b/examples/file/main.go
@@ -151,7 +151,7 @@ func (*File) Update(ctx context.Context, req infer.UpdateRequest[FileArgs, FileS
 
 func (*File) Diff(ctx context.Context, req infer.DiffRequest[FileArgs, FileState]) (infer.DiffResponse, error) {
 	diff := map[string]p.PropertyDiff{}
-	if req.Inputs.Content != req.Inputs.Content {
+	if req.Inputs.Content != req.State.Content {
 		diff["content"] = p.PropertyDiff{Kind: p.Update}
 	}
 	if req.Inputs.Force != req.State.Force {


### PR DESCRIPTION
This fixes the identical expressions on the left and right side of the '!=' operator in _examples/file_.

## Demo

To demonstrate, I added some additional logging lines:

<details>
<summary>📄examples/file/main.go diff</summary>

```diff

diff --git a/examples/file/main.go b/examples/file/main.go
index 2c39f23..2216470 100644
--- a/examples/file/main.go
+++ b/examples/file/main.go
@@ -30,15 +30,17 @@ func provider() p.Provider {
 
 type File struct{}
 
-var _ = (infer.CustomDelete[FileState])((*File)(nil))
-var _ = (infer.CustomCheck[FileArgs])((*File)(nil))
-var _ = (infer.CustomUpdate[FileArgs, FileState])((*File)(nil))
-var _ = (infer.CustomDiff[FileArgs, FileState])((*File)(nil))
-var _ = (infer.CustomRead[FileArgs, FileState])((*File)(nil))
-var _ = (infer.ExplicitDependencies[FileArgs, FileState])((*File)(nil))
-var _ = (infer.Annotated)((*File)(nil))
-var _ = (infer.Annotated)((*FileArgs)(nil))
-var _ = (infer.Annotated)((*FileState)(nil))
+var (
+	_ = (infer.CustomDelete[FileState])((*File)(nil))
+	_ = (infer.CustomCheck[FileArgs])((*File)(nil))
+	_ = (infer.CustomUpdate[FileArgs, FileState])((*File)(nil))
+	_ = (infer.CustomDiff[FileArgs, FileState])((*File)(nil))
+	_ = (infer.CustomRead[FileArgs, FileState])((*File)(nil))
+	_ = (infer.ExplicitDependencies[FileArgs, FileState])((*File)(nil))
+	_ = (infer.Annotated)((*File)(nil))
+	_ = (infer.Annotated)((*FileArgs)(nil))
+	_ = (infer.Annotated)((*FileState)(nil))
+)
 
 func (f *File) Annotate(a infer.Annotator) {
 	a.Describe(&f, "A file projected into a pulumi resource")
@@ -69,6 +71,8 @@ func (f *FileState) Annotate(a infer.Annotator) {
 }
 
 func (*File) Create(ctx context.Context, req infer.CreateRequest[FileArgs]) (resp infer.CreateResponse[FileState], err error) {
+	p.GetLogger(ctx).Debugf("Create:File path=%s, content=%s", req.Inputs.Path, req.Inputs.Content)
+
 	if !req.Inputs.Force {
 		_, err := os.Stat(req.Inputs.Path)
 		if !os.IsNotExist(err) {
@@ -103,6 +107,7 @@ func (*File) Create(ctx context.Context, req infer.CreateRequest[FileArgs]) (res
 }
 
 func (*File) Delete(ctx context.Context, req infer.DeleteRequest[FileState]) (infer.DeleteResponse, error) {
+	p.GetLogger(ctx).Debugf("Delete:File path=%s, content=%s", req.State.Path, req.State.Content)
 	err := os.Remove(req.State.Path)
 	if os.IsNotExist(err) {
 		p.GetLogger(ctx).Warningf("file %q already deleted", req.State.Path)
@@ -112,6 +117,7 @@ func (*File) Delete(ctx context.Context, req infer.DeleteRequest[FileState]) (in
 }
 
 func (*File) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckResponse[FileArgs], error) {
+	p.GetLogger(ctx).Debugf("Check:File old=%s, new=%s", req.OldInputs.GoString(), req.NewInputs.GoString())
 	if _, ok := req.NewInputs.GetOk("path"); !ok {
 		req.NewInputs = req.NewInputs.Set("path", property.New(req.Name))
 	}
@@ -124,6 +130,8 @@ func (*File) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckResp
 }
 
 func (*File) Update(ctx context.Context, req infer.UpdateRequest[FileArgs, FileState]) (infer.UpdateResponse[FileState], error) {
+	p.GetLogger(ctx).Debugf("Update:FileArgs path=%s, content=%s", req.Inputs.Path, req.Inputs.Content)
+	p.GetLogger(ctx).Debugf("Update:FileState path=%s, content=%s", req.State.Path, req.State.Content)
 	if !req.DryRun && req.State.Content != req.Inputs.Content {
 		f, err := os.Create(req.State.Path)
 		if err != nil {
@@ -146,12 +154,14 @@ func (*File) Update(ctx context.Context, req infer.UpdateRequest[FileArgs, FileS
 			Content: req.Inputs.Content,
 		},
 	}, nil
-
 }
 
 func (*File) Diff(ctx context.Context, req infer.DiffRequest[FileArgs, FileState]) (infer.DiffResponse, error) {
+	p.GetLogger(ctx).Debugf("Diff:FileArgs path=%s, content=%s", req.Inputs.Path, req.Inputs.Content)
+	p.GetLogger(ctx).Debugf("Diff:FileState path=%s, content=%s", req.State.Path, req.State.Content)
 	diff := map[string]p.PropertyDiff{}
-	if req.Inputs.Content != req.Inputs.Content {
+
+	if req.Inputs.Content != req.State.Content {
 		diff["content"] = p.PropertyDiff{Kind: p.Update}
 	}
 	if req.Inputs.Force != req.State.Force {
@@ -168,6 +178,8 @@ func (*File) Diff(ctx context.Context, req infer.DiffRequest[FileArgs, FileState
 }
 
 func (*File) Read(ctx context.Context, req infer.ReadRequest[FileArgs, FileState]) (infer.ReadResponse[FileArgs, FileState], error) {
+	p.GetLogger(ctx).Debugf("Read:FileArgs path=%s, content=%s", req.Inputs.Path, req.Inputs.Content)
+	p.GetLogger(ctx).Debugf("Read:FileState path=%s, content=%s", req.State.Path, req.State.Content)
 	path := req.ID
 	byteContent, err := os.ReadFile(path)
 	if err != nil {
```

</details>

## Pulumi Up Before

Here is the `pulumi up -d -v 3` output before these changes:

<details>
<summary>📄pulumi up output</summary>

```
Previewing update (file-dev):
     Type                 Name                   Plan     Info
     pulumi:pulumi:Stack  consume-file-file-dev           1 debug
     └─ file:index:File   managedFile                     3 debugs

Diagnostics:
  pulumi:pulumi:Stack (consume-file-file-dev):
    debug: Registering resource [managedFile]

  file:index:File (managedFile):
    debug: Check:File old=property.NewMap(map[string]property.Value{"content":property.New("An important piece of information\n"), "force":property.New(true), "path":property.New("/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt")}), new=property.NewMap(map[string]property.Value{"content":property.New("An important piece of information\n"), "force":property.New(true), "path":property.New("/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt")})
    debug: Diff:FileArgs path=/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt, content=An important piece of information
    debug: Diff:FileState path=/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt, content=An important piece of information 3

Resources:
    2 unchanged

Updating (file-dev):
     Type                 Name                   Status     Info
     pulumi:pulumi:Stack  consume-file-file-dev             1 debug
     └─ file:index:File   managedFile                       3 debugs

Diagnostics:
  pulumi:pulumi:Stack (consume-file-file-dev):
    debug: Registering resource [managedFile]

  file:index:File (managedFile):
    debug: Check:File old=property.NewMap(map[string]property.Value{"content":property.New("An important piece of information\n"), "force":property.New(true), "path":property.New("/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt")}), new=property.NewMap(map[string]property.Value{"content":property.New("An important piece of information\n"), "force":property.New(true), "path":property.New("/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt")})
    debug: Diff:FileArgs path=/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt, content=An important piece of information
    debug: Diff:FileState path=/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt, content=An important piece of information 3

Resources:
    2 unchanged

Duration: 1s
```

</details>

As you can tell by the logs `Diff:FileArgs` and `Diff:FileState` diverge but do not cause an update.

## Pulumi Up After

Here is the `pulumi up -d -v 3` output after these changes:


<details>
<summary>📄pulumi up output</summary>

```
Previewing update (file-dev):
     Type                 Name                   Plan       Info
     pulumi:pulumi:Stack  consume-file-file-dev             1 debug
 ~   └─ file:index:File   managedFile            update     [diff: ~content]; 5 debugs

Diagnostics:
  pulumi:pulumi:Stack (consume-file-file-dev):
    debug: Registering resource [managedFile]

  file:index:File (managedFile):
    debug: Check:File old=property.NewMap(map[string]property.Value{"content":property.New("An important piece of information\n"), "force":property.New(true), "path":property.New("/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt")}), new=property.NewMap(map[string]property.Value{"content":property.New("An important piece of information\n"), "force":property.New(true), "path":property.New("/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt")})
    debug: Diff:FileArgs path=/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt, content=An important piece of information
    debug: Diff:FileState path=/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt, content=An important piece of information 3
    debug: Update:FileArgs path=/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt, content=An important piece of information
    debug: Update:FileState path=/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt, content=An important piece of information 3

Resources:
    ~ 1 to update
    1 unchanged

Updating (file-dev):
     Type                 Name                   Status              Info
     pulumi:pulumi:Stack  consume-file-file-dev                      1 debug
 ~   └─ file:index:File   managedFile            updated (0.00s)     [diff: ~content]; 5 debugs

Diagnostics:
  pulumi:pulumi:Stack (consume-file-file-dev):
    debug: Registering resource [managedFile]

  file:index:File (managedFile):
    debug: Check:File old=property.NewMap(map[string]property.Value{"content":property.New("An important piece of information\n"), "force":property.New(true), "path":property.New("/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt")}), new=property.NewMap(map[string]property.Value{"content":property.New("An important piece of information\n"), "force":property.New(true), "path":property.New("/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt")})
    debug: Diff:FileArgs path=/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt, content=An important piece of information
    debug: Diff:FileState path=/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt, content=An important piece of information 3
    debug: Update:FileArgs path=/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt, content=An important piece of information
    debug: Update:FileState path=/Users/100375710929136833253/dev/Personal/pulumi-netbird/examples/yaml/managed.txt, content=An important piece of information 3

Resources:
    ~ 1 updated
    1 unchanged

Duration: 1s
```

</details>

Here `Diff:FileArgs` and `Diff:FileState` diverge and correctly cause an update.

