### PR TITLE
Add WithWrapped to wrap an existing provider

### DIFF
--- a/infer/provider.go
+++ b/infer/provider.go
@@ -79,6 +79,9 @@ type Options struct {
 	// will instead result in exposing the same resources at `pkg:bar:Foo`, `pkg:bar:Bar` and
 	// `pkg:fizz:Buzz`.
 	ModuleMap map[tokens.ModuleName]tokens.ModuleName
+
+	// wrapped is an optional provider which this new provider wraps.
+	wrapped p.Provider
 }
 
 func (o Options) dispatch() dispatch.Options {
@@ -135,7 +138,7 @@ func (o Options) schema() schema.Options {
 // To customize the resulting provider, including setting resources, functions, config options and other
 // schema metadata, look at the [Options] struct.
 func Provider(opts Options) p.Provider {
-	return Wrap(p.Provider{}, opts)
+	return Wrap(opts.wrapped, opts)
 }
 
 // Wrap wraps a compatible underlying provider in an inferred provider (as described by options).

--- a/infer/provider_builder.go
+++ b/infer/provider_builder.go
@@ -29,6 +29,7 @@ type ProviderBuilder struct {
 	functions  []InferredFunction
 	config     InferredConfig
 	moduleMap  map[tokens.ModuleName]tokens.ModuleName
+	wrapped    provider.Provider
 }
 
 // NewProviderBuilder creates an inferred provider which fills as many defaults as possible.
@@ -141,6 +142,12 @@ func (pb *ProviderBuilder) WithDisplayName(displayName string) *ProviderBuilder 
 	return pb
 }
 
+// WithWrapped wraps another provider.
+func (pb *ProviderBuilder) WithWrapped(provider provider.Provider) *ProviderBuilder {
+	pb.wrapped = provider
+	return pb
+}
+
 // WithKeywords adds the specified keywords to the provider's metadata.
 // These keywords can be used to improve discoverability of the provider.
 func (pb *ProviderBuilder) WithKeywords(keywords ...string) *ProviderBuilder {
@@ -200,6 +207,7 @@ func (pb *ProviderBuilder) BuildOptions() Options {
 		Functions:  pb.functions,
 		Config:     pb.config,
 		ModuleMap:  pb.moduleMap,
+		wrapped:    pb.wrapped,
 	}
 }
 


### PR DESCRIPTION
This allows the builder to wrap an existing Provider.