### PR TITLE
Add WithProvider and WithProviderF server options

### DIFF
--- a/examples/auto-naming/main_test.go
+++ b/examples/auto-naming/main_test.go
@@ -16,7 +16,12 @@ import (
 func TestAutoName(t *testing.T) {
 	t.Parallel()
 
-	s := integration.NewServer("autoname", semver.MustParse("0.1.0"), provider())
+	s, err := integration.NewServer(t.Context(),
+		"autoname",
+		semver.MustParse("0.1.0"),
+		integration.WithProvider(provider()),
+	)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name     string

--- a/examples/random-login/main_test.go
+++ b/examples/random-login/main_test.go
@@ -131,7 +131,13 @@ const schema = `{
 }`
 
 func TestSchema(t *testing.T) {
-	server := integration.NewServer("random-login", semver.Version{Minor: 1}, provider())
+	server, err := integration.NewServer(t.Context(),
+		"random-login",
+		semver.Version{Minor: 1},
+		integration.WithProvider(provider()),
+	)
+	require.NoError(t, err)
+
 	s, err := server.GetSchema(p.GetSchemaRequest{})
 	require.NoError(t, err)
 	blob := json.RawMessage{}
@@ -143,7 +149,13 @@ func TestSchema(t *testing.T) {
 }
 
 func TestRandomSalt(t *testing.T) {
-	server := integration.NewServer("random-login", semver.Version{Minor: 1}, provider())
+	server, err := integration.NewServer(t.Context(),
+		"random-login",
+		semver.Version{Minor: 1},
+		integration.WithProvider(provider()),
+	)
+	require.NoError(t, err)
+
 	integration.LifeCycleTest{
 		Resource: "random-login:index:RandomSalt",
 		Create: integration.Operation{

--- a/examples/str/main_test.go
+++ b/examples/str/main_test.go
@@ -9,6 +9,7 @@ import (
 	integration "github.com/pulumi/pulumi-go-provider/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const schema = `{
@@ -124,7 +125,13 @@ const schema = `{
 }`
 
 func TestSchema(t *testing.T) {
-	server := integration.NewServer("str", semver.Version{Minor: 1}, provider())
+	server, err := integration.NewServer(t.Context(),
+		"str",
+		semver.Version{Minor: 1},
+		integration.WithProvider(provider()),
+	)
+	require.NoError(t, err)
+
 	s, err := server.GetSchema(p.GetSchemaRequest{})
 	assert.NoError(t, err)
 	blob := json.RawMessage{}
@@ -136,7 +143,12 @@ func TestSchema(t *testing.T) {
 }
 
 func TestInvokes(t *testing.T) {
-	server := integration.NewServer("str", semver.Version{Minor: 1}, provider())
+	server, err := integration.NewServer(t.Context(),
+		"str",
+		semver.Version{Minor: 1},
+		integration.WithProvider(provider()),
+	)
+	require.NoError(t, err)
 
 	r, err := server.Invoke(p.InvokeRequest{
 		Token: "str:index:replace",

--- a/infer/tests/migrate_test.go
+++ b/infer/tests/migrate_test.go
@@ -102,15 +102,23 @@ type MigrateStateV2 struct {
 
 type MigrateStateInput struct{}
 
-func migrationServer() integration.Server {
-	return integration.NewServer("test",
+func migrationServer(t *testing.T) integration.Server {
+	t.Helper()
+
+	s, err := integration.NewServer(t.Context(),
+		"test",
 		semver.MustParse("1.0.0"),
-		infer.Provider(infer.Options{
-			Resources: []infer.InferredResource{
-				infer.Resource[*MigrateR](),
-			},
-			ModuleMap: map[tokens.ModuleName]tokens.ModuleName{"tests": "index"},
-		}))
+		integration.WithProvider(
+			infer.Provider(infer.Options{
+				Resources: []infer.InferredResource{
+					infer.Resource[*MigrateR](),
+				},
+				ModuleMap: map[tokens.ModuleName]tokens.ModuleName{"tests": "index"},
+			})),
+	)
+	require.NoError(t, err)
+
+	return s
 }
 
 // Test f on some old states that should be equivalent after upgrades.
@@ -182,7 +190,7 @@ func TestMigrateUpdate(t *testing.T) {
 	t.Parallel()
 
 	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State property.Map) {
-		resp, err := migrationServer().Update(p.UpdateRequest{
+		resp, err := migrationServer(t).Update(p.UpdateRequest{
 			ID:    "some-id",
 			Urn:   urn("MigrateR", "update"),
 			State: state,
@@ -196,7 +204,7 @@ func TestMigrateDiff(t *testing.T) {
 	t.Parallel()
 
 	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State property.Map) {
-		_, err := migrationServer().Diff(p.DiffRequest{
+		_, err := migrationServer(t).Diff(p.DiffRequest{
 			ID:    "some-id",
 			Urn:   urn("MigrateR", "diff"),
 			State: state,
@@ -214,7 +222,7 @@ func TestMigrateDelete(t *testing.T) {
 	t.Parallel()
 
 	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State property.Map) {
-		err := migrationServer().Delete(p.DeleteRequest{
+		err := migrationServer(t).Delete(p.DeleteRequest{
 			ID:         "some-id",
 			Urn:        urn("MigrateR", "delete"),
 			Properties: state,
@@ -232,7 +240,7 @@ func TestMigrateRead(t *testing.T) {
 	t.Parallel()
 
 	testMigrationEquivalentStates(t, func(t *testing.T, state, v2State property.Map) {
-		resp, err := migrationServer().Read(p.ReadRequest{
+		resp, err := migrationServer(t).Read(p.ReadRequest{
 			ID:         "some-id",
 			Urn:        urn("MigrateR", "read"),
 			Properties: state,

--- a/infer/tests/provider_test.go
+++ b/infer/tests/provider_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/require"
 
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
@@ -604,16 +605,32 @@ func providerOpts(config infer.InferredConfig) infer.Options {
 
 func provider(t testing.TB) integration.Server {
 	p := infer.Provider(providerOpts(nil))
-	return integration.NewServer("test", semver.MustParse("1.0.0"), p)
+	s, err := integration.NewServer(t.Context(),
+		"test",
+		semver.MustParse("1.0.0"),
+		integration.WithProvider(p),
+	)
+	require.NoError(t, err)
+
+	return s
 }
 
 func providerWithConfig[T any](t testing.TB) integration.Server {
 	p := infer.Provider(providerOpts(infer.Config[T]()))
-	return integration.NewServer("test", semver.MustParse("1.0.0"), p)
+	s, err := integration.NewServer(t.Context(), "test", semver.MustParse("1.0.0"), integration.WithProvider(p))
+	require.NoError(t, err)
+	return s
 }
 
 func providerWithMocks[T any](t testing.TB, mocks pulumi.MockResourceMonitor) integration.Server {
 	p := infer.Provider(providerOpts(infer.Config[T]()))
-	return integration.NewServerWithOptions(t.Context(), "test", semver.MustParse("1.0.0"), p,
-		integration.WithMocks(mocks))
+	s, err := integration.NewServer(
+		t.Context(),
+		"test",
+		semver.MustParse("1.0.0"),
+		integration.WithProvider(p),
+		integration.WithMocks(mocks),
+	)
+	require.NoError(t, err)
+	return s
 }

--- a/infer/tests/token_test.go
+++ b/infer/tests/token_test.go
@@ -90,7 +90,11 @@ func TestTokens(t *testing.T) {
 		},
 		ModuleMap: map[tokens.ModuleName]tokens.ModuleName{"overwritten": "index"},
 	})
-	server := integration.NewServer("test", semver.MustParse("1.0.0"), provider)
+	server, err := integration.NewServer(t.Context(),
+		"test",
+		semver.MustParse("1.0.0"), integration.WithProvider(provider),
+	)
+	require.NoError(t, err)
 
 	schema, err := server.GetSchema(p.GetSchemaRequest{})
 	require.NoError(t, err)

--- a/infer/tests/types_test.go
+++ b/infer/tests/types_test.go
@@ -67,9 +67,12 @@ func TestOmittingAssetTypes(t *testing.T) {
 	}
 
 	p := infer.Provider(providerOpts)
-	server := integration.NewServer("test", semver.MustParse("1.0.0"), p)
+	server, err := integration.NewServer(t.Context(),
+		"test",
+		semver.MustParse("1.0.0"), integration.WithProvider(p))
+	require.NoError(t, err)
 
-	_, err := server.GetSchema(pgp.GetSchemaRequest{Version: 1})
+	_, err = server.GetSchema(pgp.GetSchemaRequest{Version: 1})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "is not a valid input type, please use types.AssetOrArchive instead")
 }

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -120,7 +120,7 @@ func NewServer(ctx context.Context, pkg string, version semver.Version,
 		opt.applyServerOption(o)
 	}
 	if o.mocks == nil {
-		o.mocks = &MockMonitor{} // Why?
+		o.mocks = &MockMonitor{} // MockResourceMonitor requires a non-nil monitor.
 	}
 	if o.provider == nil && o.providerF == nil {
 		return nil, fmt.Errorf("WithProvider or WithProviderF is required")

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	provider "github.com/pulumi/pulumi-go-provider"
+	pprovider "github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	presource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
@@ -61,49 +63,91 @@ type ServerOption interface {
 	applyServerOption(*serverOptions)
 }
 
+// TODO: What does this do?
+func WithMocks(mocks pulumi.MockResourceMonitor) ServerOption {
+	return mocksOption{mocks: mocks}
+}
+
+// WithProvider backs the server with the given concrete provider.
+func WithProvider(p provider.Provider) ServerOption {
+	return providerOption{provider: p}
+}
+
+// WithProviderF backes the server with a lazily initialized provider.
+func WithProviderF(p func(*pprovider.HostClient) p.Provider) ServerOption {
+	return providerFOption{providerF: p}
+}
+
 // serverOptions is the internal representation of the effect of
 // [ServerOption]s.
 type serverOptions struct {
+	mocks     pulumi.MockResourceMonitor
+	provider  *p.Provider
+	providerF func(*pprovider.HostClient) p.Provider
+}
+
+type mocksOption struct {
 	mocks pulumi.MockResourceMonitor
 }
 
-type serverOption func(*serverOptions)
-
-func (o serverOption) applyServerOption(opts *serverOptions) {
-	o(opts)
+func (mo mocksOption) applyServerOption(opts *serverOptions) {
+	opts.mocks = mo.mocks
 }
 
-func WithMocks(mocks pulumi.MockResourceMonitor) ServerOption {
-	return serverOption(func(ro *serverOptions) {
-		ro.mocks = mocks
-	})
+type providerOption struct {
+	provider p.Provider
 }
 
-func NewServer(pkg string, version semver.Version, provider p.Provider) Server {
-	return NewServerWithContext(context.Background(), pkg, version, provider)
+func (po providerOption) applyServerOption(opts *serverOptions) {
+	opts.provider = &po.provider
 }
 
-func NewServerWithContext(ctx context.Context, pkg string, version semver.Version, provider p.Provider) Server {
-	return NewServerWithOptions(ctx, pkg, version, provider)
+type providerFOption struct {
+	providerF func(*pprovider.HostClient) p.Provider
 }
 
-func NewServerWithOptions(ctx context.Context, pkg string, version semver.Version, provider p.Provider,
+func (po providerFOption) applyServerOption(opts *serverOptions) {
+	opts.providerF = po.providerF
+}
+
+// NewServer constructs a gRPC server for testing the given provider.
+//
+// Must be called with WithProvider or WithProviderF.
+func NewServer(ctx context.Context, pkg string, version semver.Version,
 	opts ...ServerOption,
-) Server {
+) (Server, error) {
 	o := &serverOptions{}
 	for _, opt := range opts {
 		opt.applyServerOption(o)
 	}
 	if o.mocks == nil {
-		o.mocks = &MockMonitor{}
+		o.mocks = &MockMonitor{} // Why?
+	}
+	if o.provider == nil && o.providerF == nil {
+		return nil, fmt.Errorf("WithProvider or WithProviderF is required")
 	}
 
 	host := newHost(ctx, o.mocks)
 
-	return &server{p.RunInfo{
+	var prov p.Provider
+	if o.provider != nil {
+		prov = *o.provider
+	}
+	if o.providerF != nil {
+		host.lazyInit()
+		hc, err := pprovider.NewHostClient(host.engineAddr)
+		if err != nil {
+			return nil, fmt.Errorf("constructing HostClient: %w", err)
+		}
+		prov = o.providerF(hc)
+	}
+
+	s := &server{p.RunInfo{
 		PackageName: pkg,
 		Version:     version.String(),
-	}, host, provider.WithDefaults(), ctx}
+	}, host, prov.WithDefaults(), ctx}
+
+	return s, nil
 }
 
 // Server hosts a [Provider] for integration test purposes.

--- a/tests/component_test.go
+++ b/tests/component_test.go
@@ -60,11 +60,15 @@ type Bundle struct {
 }
 
 func provider(t *testing.T) integration.Server {
-	return integration.NewServerWithContext(t.Context(), "foo", semver.Version{Major: 1},
-		infer.Provider(infer.Options{
+	s, err := integration.NewServer(t.Context(),
+		"foo",
+		semver.Version{Major: 1},
+		integration.WithProvider(infer.Provider(infer.Options{
 			Components: []infer.InferredComponent{infer.Component(NewFoo)},
-		}),
+		})),
 	)
+	require.NoError(t, err)
+	return s
 }
 
 func TestConstruct(t *testing.T) {

--- a/tests/invoke_test.go
+++ b/tests/invoke_test.go
@@ -53,11 +53,18 @@ func (c inv) Annotate(a infer.Annotator) { a.SetToken("index", "inv") }
 func TestInferInvokeSecrets(t *testing.T) {
 	t.Parallel()
 
-	resp, err := integration.NewServer("test", semver.MustParse("0.0.0"), infer.Provider(infer.Options{
-		Functions: []infer.InferredFunction{
-			infer.Function[inv](),
-		},
-	})).Invoke(p.InvokeRequest{
+	s, err := integration.NewServer(t.Context(),
+		"test",
+		semver.MustParse("0.0.0"),
+		integration.WithProvider(infer.Provider(infer.Options{
+			Functions: []infer.InferredFunction{
+				infer.Function[inv](),
+			},
+		})),
+	)
+	require.NoError(t, err)
+
+	resp, err := s.Invoke(p.InvokeRequest{
 		Token: "test:index:inv",
 		Args: property.NewMap(map[string]property.Value{
 			"field": property.New("value"),

--- a/tests/resource_test.go
+++ b/tests/resource_test.go
@@ -48,11 +48,17 @@ func (c res) Annotate(a infer.Annotator) { a.SetToken("index", "res") }
 func TestInferCheckSecrets(t *testing.T) {
 	t.Parallel()
 
-	resp, err := integration.NewServer("test", semver.MustParse("0.0.0"), infer.Provider(infer.Options{
-		Resources: []infer.InferredResource{
-			infer.Resource[res](),
-		},
-	})).Check(p.CheckRequest{
+	s, err := integration.NewServer(t.Context(),
+		"test",
+		semver.MustParse("0.0.0"),
+		integration.WithProvider(infer.Provider(infer.Options{
+			Resources: []infer.InferredResource{
+				infer.Resource[res](),
+			},
+		})))
+	require.NoError(t, err)
+
+	resp, err := s.Check(p.CheckRequest{
 		Urn: resource.CreateURN("name", "test:index:res", "", "proj", "stack"),
 		Inputs: property.NewMap(map[string]property.Value{
 			"field": property.New("value"),

--- a/tests/schema_test.go
+++ b/tests/schema_test.go
@@ -66,7 +66,13 @@ func TestMergeSchema(t *testing.T) {
 			&givenResource{"foo:index:foo", "from s2"},
 		},
 	})
-	server := integration.NewServer("pkg", semver.Version{Major: 2}, s2)
+	server, err := integration.NewServer(t.Context(),
+		"pkg",
+		semver.Version{Major: 2},
+		integration.WithProvider(s2),
+	)
+	require.NoError(t, err)
+
 	schema, err := server.GetSchema(p.GetSchemaRequest{})
 	require.NoError(t, err)
 


### PR DESCRIPTION
This consolidates all of the NewServer methods, and adds WithProvider and
WithProviderF options. This way servers can continue to be created with
concrete or lazy providers.

A `WithVersion` would make sense IMO, but we can do that later.

(It's odd that we use an option pattern here and a builder pattern for the provider.)