### PR TITLE
Use property.Map with mock monitor

### DIFF
--- a/examples/component-provider/consumer/Pulumi.yaml
+++ b/examples/component-provider/consumer/Pulumi.yaml
@@ -16,7 +16,7 @@ resources:
     properties:
       length: 2
 outputs:
-  password: ${myrandom.password}
+  password: ${myrandom.password.result}
   hardcoded: ${myrandom.hardcodedOutput}
-  nestedPassword: ${myrandom-2.password}
+  nestedPassword: ${myrandom-2.password.result}
   nestedHardcoded: ${myrandom-2.hardcodedOutput}

--- a/examples/component-provider/nested/nestedRandomComponent.go
+++ b/examples/component-provider/nested/nestedRandomComponent.go
@@ -23,8 +23,8 @@ import (
 type NestedRandomComponent struct {
 	pulumi.ResourceState
 	NestedRandomComponentArgs
-	Password        pulumi.StringOutput `pulumi:"password"`
-	HardcodedOutput pulumi.StringOutput `pulumi:"hardcodedOutput"`
+	Password        *random.RandomPassword `pulumi:"password" provider:"type=random@v4.8.1:index/randomPassword:RandomPassword"`
+	HardcodedOutput pulumi.StringOutput    `pulumi:"hardcodedOutput"`
 }
 
 type NestedRandomComponentArgs struct {
@@ -49,7 +49,7 @@ func NewNestedRandomComponent(ctx *pulumi.Context, name string, compArgs *Nested
 		return nil, err
 	}
 
-	comp.Password = password.Result
+	comp.Password = password
 	comp.HardcodedOutput = pulumi.String("This is a hardcoded output string from a nested module.").ToStringOutput()
 
 	return comp, nil

--- a/examples/component-provider/randomComponent.go
+++ b/examples/component-provider/randomComponent.go
@@ -23,8 +23,8 @@ import (
 type RandomComponent struct {
 	pulumi.ResourceState
 	RandomComponentArgs
-	Password        pulumi.StringOutput `pulumi:"password"`
-	HardcodedOutput pulumi.StringOutput `pulumi:"hardcodedOutput"`
+	Password        *random.RandomPassword `pulumi:"password" provider:"type=random@v4.8.1:index/randomPassword:RandomPassword"`
+	HardcodedOutput pulumi.StringOutput    `pulumi:"hardcodedOutput"`
 }
 
 type RandomComponentArgs struct {
@@ -47,7 +47,7 @@ func NewMyComponent(ctx *pulumi.Context, name string, compArgs RandomComponentAr
 		return nil, err
 	}
 
-	comp.Password = password.Result
+	comp.Password = password
 	comp.HardcodedOutput = pulumi.String("This is a hardcoded output string").ToStringOutput()
 
 	return comp, nil

--- a/examples/component-provider/schema.json
+++ b/examples/component-provider/schema.json
@@ -34,7 +34,7 @@
           "type": "integer"
         },
         "password": {
-          "type": "string"
+          "$ref": "/random/v4.8.1/schema.json#/resources/random:index%2FrandomPassword:RandomPassword"
         }
       },
       "type": "object",
@@ -62,7 +62,7 @@
           "type": "integer"
         },
         "password": {
-          "type": "string"
+          "$ref": "/random/v4.8.1/schema.json#/resources/random:index%2FrandomPassword:RandomPassword"
         }
       },
       "type": "object",

--- a/examples/random-login/Makefile
+++ b/examples/random-login/Makefile
@@ -1,0 +1,5 @@
+
+.PHONY: generate
+generate:
+	pulumi package get-schema . > schema.json
+	pulumi package gen-sdk ./schema.json --language go

--- a/examples/random-login/PulumiPlugin.yaml
+++ b/examples/random-login/PulumiPlugin.yaml
@@ -1,0 +1,1 @@
+runtime: go

--- a/examples/random-login/consumer/Pulumi.yaml
+++ b/examples/random-login/consumer/Pulumi.yaml
@@ -24,7 +24,7 @@ resources:
   badPassword:
     type: random-login:MoreRandomPassword
     properties:
-      length: ${badPasswordLength}
+      length: ${badPasswordLength.result}
 
 outputs:
   username:

--- a/examples/random-login/schema.json
+++ b/examples/random-login/schema.json
@@ -28,10 +28,10 @@
     "random-login:index:MoreRandomPassword": {
       "properties": {
         "length": {
-          "$ref": "/random/v4.8.1/schema.json#/resources/random:index%2FrandomInteger:RandomInteger"
+          "type": "integer"
         },
         "password": {
-          "$ref": "/random/v4.8.1/schema.json#/resources/random:index%2FrandomPassword:RandomPassword"
+          "type": "string"
         }
       },
       "type": "object",
@@ -41,7 +41,7 @@
       ],
       "inputProperties": {
         "length": {
-          "$ref": "/random/v4.8.1/schema.json#/resources/random:index%2FrandomInteger:RandomInteger"
+          "type": "integer"
         }
       },
       "requiredInputs": [

--- a/examples/random-login/sdk/go/randomlogin/moreRandomPassword.go
+++ b/examples/random-login/sdk/go/randomlogin/moreRandomPassword.go
@@ -9,15 +9,14 @@ import (
 
 	"errors"
 	"github.com/pulumi/pulumi-go-provider/examples/random-login/sdk/go/randomlogin/internal"
-	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 type MoreRandomPassword struct {
 	pulumi.ResourceState
 
-	Length   random.RandomIntegerOutput  `pulumi:"length"`
-	Password random.RandomPasswordOutput `pulumi:"password"`
+	Length   pulumi.IntOutput    `pulumi:"length"`
+	Password pulumi.StringOutput `pulumi:"password"`
 }
 
 // NewMoreRandomPassword registers a new resource with the given unique name, arguments, and options.
@@ -40,12 +39,12 @@ func NewMoreRandomPassword(ctx *pulumi.Context,
 }
 
 type moreRandomPasswordArgs struct {
-	Length *random.RandomInteger `pulumi:"length"`
+	Length int `pulumi:"length"`
 }
 
 // The set of arguments for constructing a MoreRandomPassword resource.
 type MoreRandomPasswordArgs struct {
-	Length random.RandomIntegerInput
+	Length pulumi.IntInput
 }
 
 func (MoreRandomPasswordArgs) ElementType() reflect.Type {
@@ -85,12 +84,12 @@ func (o MoreRandomPasswordOutput) ToMoreRandomPasswordOutputWithContext(ctx cont
 	return o
 }
 
-func (o MoreRandomPasswordOutput) Length() random.RandomIntegerOutput {
-	return o.ApplyT(func(v *MoreRandomPassword) random.RandomIntegerOutput { return v.Length }).(random.RandomIntegerOutput)
+func (o MoreRandomPasswordOutput) Length() pulumi.IntOutput {
+	return o.ApplyT(func(v *MoreRandomPassword) pulumi.IntOutput { return v.Length }).(pulumi.IntOutput)
 }
 
-func (o MoreRandomPasswordOutput) Password() random.RandomPasswordOutput {
-	return o.ApplyT(func(v *MoreRandomPassword) random.RandomPasswordOutput { return v.Password }).(random.RandomPasswordOutput)
+func (o MoreRandomPasswordOutput) Password() pulumi.StringOutput {
+	return o.ApplyT(func(v *MoreRandomPassword) pulumi.StringOutput { return v.Password }).(pulumi.StringOutput)
 }
 
 func init() {

--- a/infer/tests/construct_test.go
+++ b/infer/tests/construct_test.go
@@ -23,17 +23,14 @@ import (
 	"github.com/pulumi/pulumi-go-provider/integration"
 	r "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func TestConstruct(t *testing.T) {
 	t.Parallel()
 
-	prov := providerWithMocks[Config](t, &integration.MockMonitor{
-		NewResourceF: func(args pulumi.MockResourceArgs) (string, r.PropertyMap, error) {
-			assert.Equal(t, "test:index:RandomComponent", args.TypeToken)
-			assert.Equal(t, "test-component", args.Name)
-			return args.ID, r.PropertyMap{}, nil
+	prov := providerWithMocks[Config](t, &integration.MockResourceMonitor{
+		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
+			return args.ID, property.Map{}, nil
 		},
 	})
 

--- a/integration/README.md
+++ b/integration/README.md
@@ -25,7 +25,7 @@ is never called.
 
 To configure mocking, use the `integration.WithMocks` server option and pass an implementation of `pulumi.MockResourceMonitor`.
 The mock monitor receives a callback for the component resource and for each child resource as it is registered,
-giving you an opportunity to return a simulated state for each child. See `integation.MockMonitor` for a simple implementation.
+giving you an opportunity to return a simulated state for each child. See `integation.MockResourceMonitor` for a simple implementation.
 
 To test a component resource, call the `Construct` method on the integration server.
 
@@ -56,23 +56,23 @@ func TestConstruct(t *testing.T) {
 		"example",
 		semver.MustParse("1.0.0"),
 		integration.WithProvider(myProvider),
-		integration.WithMocks(&integration.MockMonitor{
-			NewResourceF: func(args pulumi.MockResourceArgs) (string, r.PropertyMap, error) {
+        integration.WithMocks(&integration.MockResourceMonitor{
+			NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
 				// NewResourceF is called as the each resource is registered
 				switch {
 				case args.TypeToken == "my:module:MyComponent" && args.Name == "my-component":
-					// make assertions about the component resource
-				default:
-					// make assertions about the component's children
+                default:
+                    // make assertions about the component's children and return
+                    // a fake id and some resource properties
 				}
-				return args.ID, r.PropertyMap{}, nil
+				return "", property.Map{}, nil
 			},
 		}),
 	)
 	require.NoError(t, err)
 
 	// test the "my:module:MyComponent" component
-	resp, err := prov.Construct(p.ConstructRequest{
+	resp, err := server.Construct(p.ConstructRequest{
 		Urn:    "urn:pulumi:stack::project::my:module:MyComponent::my-component",
 		Inputs: property.NewMap(map[string]property.Value{
 			"pi": property.New(3.14),

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -120,7 +120,7 @@ func NewServer(ctx context.Context, pkg string, version semver.Version,
 		opt.applyServerOption(o)
 	}
 	if o.mocks == nil {
-		o.mocks = &MockResourceMonitor{} // fake.MockResourceMonitor requires a non-nil monitor.
+		o.mocks = &MockResourceMonitor{} // newHost requires a non-nil monitor.
 	}
 	if o.provider == nil && o.providerF == nil {
 		return nil, fmt.Errorf("WithProvider or WithProviderF is required")

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -120,7 +120,7 @@ func NewServer(ctx context.Context, pkg string, version semver.Version,
 		opt.applyServerOption(o)
 	}
 	if o.mocks == nil {
-		o.mocks = &MockMonitor{} // MockResourceMonitor requires a non-nil monitor.
+		o.mocks = &MockResourceMonitor{} // fake.MockResourceMonitor requires a non-nil monitor.
 	}
 	if o.provider == nil && o.providerF == nil {
 		return nil, fmt.Errorf("WithProvider or WithProviderF is required")
@@ -317,25 +317,6 @@ func (h *host) Call(ctx context.Context, req p.CallRequest, call comProvider.Cal
 	}
 
 	return linkedCallResponseFromRPC(comResp)
-}
-
-type MockMonitor struct {
-	CallF        func(args pulumi.MockCallArgs) (presource.PropertyMap, error)
-	NewResourceF func(args pulumi.MockResourceArgs) (string, presource.PropertyMap, error)
-}
-
-func (m *MockMonitor) Call(args pulumi.MockCallArgs) (presource.PropertyMap, error) {
-	if m.CallF == nil {
-		return presource.PropertyMap{}, nil
-	}
-	return m.CallF(args)
-}
-
-func (m *MockMonitor) NewResource(args pulumi.MockResourceArgs) (string, presource.PropertyMap, error) {
-	if m.NewResourceF == nil {
-		return args.Name, args.Inputs, nil
-	}
-	return m.NewResourceF(args)
 }
 
 // Operation describes a step in a [LifeCycleTest].

--- a/integration/monitor.go
+++ b/integration/monitor.go
@@ -1,0 +1,108 @@
+// Copyright 2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/internal/putil"
+
+	presource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+// MockCallArgs is used to construct a call Mock
+type MockCallArgs struct {
+	// Token indicates which function is being called. This token is of the form "package:module:function".
+	Token string
+	// Args are the arguments provided to the function call.
+	Args property.Map
+	// Provider is the identifier of the provider instance being used to make the call.
+	Provider string // ProviderReference
+}
+
+// MockResourceArgs is a used to construct a newResource Mock
+type MockResourceArgs struct {
+	// TypeToken is the token that indicates which resource type is being constructed. This token
+	// is of the form "package:module:type".
+	TypeToken tokens.Type
+	// Name is the logical name of the resource instance.
+	Name string
+	// Inputs are the inputs for the resource.
+	Inputs property.Map
+	// Provider is the identifier of the provider instance being used to manage this resource.
+	Provider p.ProviderReference
+	// ID is the physical identifier of an existing resource to read or import.
+	ID string
+	// Custom specifies whether or not the resource is Custom (i.e. managed by a resource provider).
+	Custom bool
+	// Full register RPC call, if available.
+	RegisterRPC *pulumirpc.RegisterResourceRequest
+	// Full read RPC call, if available
+	ReadRPC *pulumirpc.ReadResourceRequest
+}
+
+// MockResourceMonitor mocks resource registration and function calls.
+type MockResourceMonitor struct {
+	CallF        func(args MockCallArgs) (property.Map, error)
+	NewResourceF func(args MockResourceArgs) (string, property.Map, error)
+}
+
+var _ pulumi.MockResourceMonitor = (*MockResourceMonitor)(nil)
+
+func (m *MockResourceMonitor) Call(args pulumi.MockCallArgs) (presource.PropertyMap, error) {
+	if m.CallF == nil {
+		return presource.PropertyMap{}, nil
+	}
+	_args := MockCallArgs{
+		Token:    args.Token,
+		Args:     presource.FromResourcePropertyMap(args.Args),
+		Provider: args.Provider,
+	}
+
+	result, err := m.CallF(_args)
+	if err != nil {
+		return presource.PropertyMap{}, err
+	}
+	return presource.ToResourcePropertyMap(result), nil
+}
+
+func (m *MockResourceMonitor) NewResource(args pulumi.MockResourceArgs) (string, presource.PropertyMap, error) {
+	if m.NewResourceF == nil {
+		return args.Name, args.Inputs, nil
+	}
+
+	_args := MockResourceArgs{
+		TypeToken: tokens.Type(args.TypeToken),
+		Name:      args.Name,
+		Inputs:    presource.FromResourcePropertyMap(args.Inputs),
+		Provider: func() p.ProviderReference {
+			urn, id, _ := putil.ParseProviderReference(args.Provider)
+			return p.ProviderReference{
+				Urn: urn,
+				ID:  id,
+			}
+		}(),
+		ID:          args.ID,
+		Custom:      args.Custom,
+		RegisterRPC: args.RegisterRPC,
+		ReadRPC:     args.ReadRPC,
+	}
+
+	id, state, err := m.NewResourceF(_args)
+	return id, presource.ToResourcePropertyMap(state), err
+}

--- a/integration/monitor.go
+++ b/integration/monitor.go
@@ -28,11 +28,11 @@ import (
 // MockCallArgs is used to construct a call Mock
 type MockCallArgs struct {
 	// Token indicates which function is being called. This token is of the form "package:module:function".
-	Token string
+	Token tokens.ModuleMember
 	// Args are the arguments provided to the function call.
 	Args property.Map
 	// Provider is the identifier of the provider instance being used to make the call.
-	Provider string // ProviderReference
+	Provider p.ProviderReference
 }
 
 // MockResourceArgs is a used to construct a newResource Mock
@@ -68,10 +68,17 @@ func (m *MockResourceMonitor) Call(args pulumi.MockCallArgs) (presource.Property
 	if m.CallF == nil {
 		return presource.PropertyMap{}, nil
 	}
+
 	_args := MockCallArgs{
-		Token:    args.Token,
-		Args:     presource.FromResourcePropertyMap(args.Args),
-		Provider: args.Provider,
+		Token: tokens.ModuleMember(args.Token),
+		Args:  presource.FromResourcePropertyMap(args.Args),
+		Provider: func() p.ProviderReference {
+			urn, id, _ := putil.ParseProviderReference(args.Provider)
+			return p.ProviderReference{
+				Urn: urn,
+				ID:  id,
+			}
+		}(),
 	}
 
 	result, err := m.CallF(_args)


### PR DESCRIPTION
This PR is an ergonomic enhancement to the mock facility provided by the `integration` package, to use `property.Map` rather than `resource.PropertyMap`.  This makes it easier to make assertions about resource registration.

For example, a test case for the RandomLogin component can easily synthesize a random:RandomInteger resource.

```go
    NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
        // validate the child resource inputs and synthesize their outputs
        case args.TypeToken == "random:index/randomInteger:RandomInteger" && args.Name == "login-length":
            assert.Equal(t, 8.0, args.Inputs.Get("min").AsNumber())
            assert.Equal(t, 24.0, args.Inputs.Get("max").AsNumber())
            return args.Name, property.NewMap(map[string]property.Value{
                "result": property.New(12.0),
            }), nil
```

This PR also adds a [new test case](https://github.com/pulumi/pulumi-go-provider/pull/373/files#diff-68c0e6c0cea0397afe13ee4565d0d89b27e55856228f9898ea24f71ea8b48844R189) to `examples/random-login/main_test.go`, demonstrating how to use mocks to test the `NewRandomLogin` function ([ref](https://github.com/pulumi/pulumi-go-provider/pull/373/files#diff-d83334518762585b7cfe144bd510474999dc319aaa71cdbfb553716a4b1ff988R100)).

I chose to simplify the RandomLogin and MoreRandomPassword components, with respect to the input and output property types. Resource references were being used, which I was unable to mock and I believe to be confusing to understand (as an example).