### PR TITLE
Use `ProviderBuilder` in the examples

### DIFF
--- a/examples/assets/go.mod
+++ b/examples/assets/go.mod
@@ -6,7 +6,10 @@ go 1.24
 
 toolchain go1.24.0
 
-require github.com/pulumi/pulumi-go-provider v0.0.0-00010101000000-000000000000
+require (
+	github.com/pulumi/pulumi-go-provider v0.0.0-00010101000000-000000000000
+	github.com/pulumi/pulumi/sdk/v3 v3.168.1-0.20250507185715-bddbda9403ca
+)
 
 require (
 	dario.cat/mergo v1.0.0 // indirect

--- a/examples/assets/go.mod
+++ b/examples/assets/go.mod
@@ -8,7 +8,7 @@ toolchain go1.24.0
 
 require (
 	github.com/pulumi/pulumi-go-provider v0.0.0-00010101000000-000000000000
-	github.com/pulumi/pulumi/sdk/v3 v3.168.1-0.20250507185715-bddbda9403ca
+	github.com/pulumi/pulumi/sdk/v3 v3.169.0
 )
 
 require (
@@ -68,7 +68,6 @@ require (
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
 	github.com/pulumi/esc v0.13.0 // indirect
 	github.com/pulumi/pulumi/pkg/v3 v3.169.0 // indirect
-	github.com/pulumi/pulumi/sdk/v3 v3.169.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect

--- a/examples/assets/schema.json
+++ b/examples/assets/schema.json
@@ -1,8 +1,24 @@
 {
   "name": "assets",
   "version": "0.1.0",
+  "namespace": "examples",
   "meta": {
     "moduleFormat": "(.*)"
+  },
+  "language": {
+    "csharp": {
+      "respectSchemaVersion": true
+    },
+    "go": {
+      "generateResourceContainerTypes": true,
+      "respectSchemaVersion": true
+    },
+    "nodejs": {
+      "respectSchemaVersion": true
+    },
+    "python": {
+      "respectSchemaVersion": true
+    }
   },
   "config": {},
   "provider": {

--- a/examples/auto-naming/main.go
+++ b/examples/auto-naming/main.go
@@ -16,20 +16,28 @@ import (
 )
 
 func main() {
-	err := p.RunProvider(context.Background(), "auto-naming", "0.1.0", provider())
+	provider, err := provider()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s", err.Error())
+		os.Exit(1)
+	}
+	err = provider.Run(context.Background(), "auto-naming", "0.1.0")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s", err.Error())
 		os.Exit(1)
 	}
 }
 
-func provider() p.Provider {
-	return infer.Provider(infer.Options{
-		Resources: []infer.InferredResource{infer.Resource(&User{})},
-		ModuleMap: map[tokens.ModuleName]tokens.ModuleName{
+func provider() (p.Provider, error) {
+	return infer.NewProviderBuilder().
+		WithNamespace("examples").
+		WithResources(
+			infer.Resource(&User{}),
+		).
+		WithModuleMap(map[tokens.ModuleName]tokens.ModuleName{
 			"auto-naming": "index",
-		},
-	})
+		}).
+		Build()
 }
 
 type (

--- a/examples/auto-naming/main_test.go
+++ b/examples/auto-naming/main_test.go
@@ -15,11 +15,13 @@ import (
 
 func TestAutoName(t *testing.T) {
 	t.Parallel()
+	provider, err := provider()
+	require.NoError(t, err)
 
 	s, err := integration.NewServer(t.Context(),
 		"autoname",
 		semver.MustParse("0.1.0"),
-		integration.WithProvider(provider()),
+		integration.WithProvider(provider),
 	)
 	require.NoError(t, err)
 

--- a/examples/auto-naming/schema.json
+++ b/examples/auto-naming/schema.json
@@ -1,8 +1,24 @@
 {
   "name": "auto-naming",
   "version": "0.1.0",
+  "namespace": "examples",
   "meta": {
     "moduleFormat": "(.*)"
+  },
+  "language": {
+    "csharp": {
+      "respectSchemaVersion": true
+    },
+    "go": {
+      "generateResourceContainerTypes": true,
+      "respectSchemaVersion": true
+    },
+    "nodejs": {
+      "respectSchemaVersion": true
+    },
+    "python": {
+      "respectSchemaVersion": true
+    }
   },
   "config": {},
   "provider": {

--- a/examples/component-provider/main.go
+++ b/examples/component-provider/main.go
@@ -18,23 +18,34 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"os"
 
+	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/examples/component-provider/nested"
 	"github.com/pulumi/pulumi-go-provider/infer"
 )
 
 func main() {
-	p, err := infer.NewProviderBuilder().
-		WithNamespace("example-namespace").
+	provider, err := provider()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s", err.Error())
+		os.Exit(1)
+	}
+
+	err = provider.Run(context.Background(), "go-components", "0.1.0")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s", err.Error())
+		os.Exit(1)
+	}
+}
+
+func provider() (p.Provider, error) {
+	return infer.NewProviderBuilder().
+		WithNamespace("examples").
 		WithComponents(
 			infer.ComponentF(NewMyComponent),
 			infer.ComponentF(nested.NewNestedRandomComponent),
 		).
 		Build()
-
-	if err != nil {
-		panic(err)
-	}
-
-	p.Run(context.Background(), "go-components", "v0.0.1")
 }

--- a/examples/component-provider/schema.json
+++ b/examples/component-provider/schema.json
@@ -1,7 +1,7 @@
 {
   "name": "go-components",
-  "version": "0.0.1",
-  "namespace": "example-namespace",
+  "version": "0.1.0",
+  "namespace": "examples",
   "meta": {
     "moduleFormat": "(.*)"
   },

--- a/examples/credentials/schema.json
+++ b/examples/credentials/schema.json
@@ -1,8 +1,24 @@
 {
   "name": "credentials",
   "version": "0.1.0",
+  "namespace": "examples",
   "meta": {
     "moduleFormat": "(.*)"
+  },
+  "language": {
+    "csharp": {
+      "respectSchemaVersion": true
+    },
+    "go": {
+      "generateResourceContainerTypes": true,
+      "respectSchemaVersion": true
+    },
+    "nodejs": {
+      "respectSchemaVersion": true
+    },
+    "python": {
+      "respectSchemaVersion": true
+    }
   },
   "config": {
     "variables": {

--- a/examples/dna-store/go.mod
+++ b/examples/dna-store/go.mod
@@ -6,7 +6,10 @@ go 1.24
 
 toolchain go1.24.0
 
-require github.com/pulumi/pulumi-go-provider v0.0.0-00010101000000-000000000000
+require (
+	github.com/pulumi/pulumi-go-provider v0.0.0-00010101000000-000000000000
+	github.com/pulumi/pulumi/sdk/v3 v3.168.1-0.20250507185715-bddbda9403ca
+)
 
 require (
 	dario.cat/mergo v1.0.0 // indirect

--- a/examples/dna-store/go.mod
+++ b/examples/dna-store/go.mod
@@ -8,7 +8,7 @@ toolchain go1.24.0
 
 require (
 	github.com/pulumi/pulumi-go-provider v0.0.0-00010101000000-000000000000
-	github.com/pulumi/pulumi/sdk/v3 v3.168.1-0.20250507185715-bddbda9403ca
+	github.com/pulumi/pulumi/sdk/v3 v3.169.0
 )
 
 require (
@@ -68,7 +68,6 @@ require (
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
 	github.com/pulumi/esc v0.13.0 // indirect
 	github.com/pulumi/pulumi/pkg/v3 v3.169.0 // indirect
-	github.com/pulumi/pulumi/sdk/v3 v3.169.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect

--- a/examples/dna-store/main.go
+++ b/examples/dna-store/main.go
@@ -12,6 +12,7 @@ import (
 
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
 type Molecule int
@@ -204,12 +205,26 @@ func (d *DNAStoreArgs) Annotate(a infer.Annotator) {
 }
 
 func main() {
-	err := p.RunProvider(context.Background(), "dna-store", "0.1.0",
-		infer.Provider(infer.Options{
-			Resources: []infer.InferredResource{infer.Resource(&DNAStore{})},
-		}))
+	provider, err := provider()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s", err.Error())
+		os.Exit(1)
+	}
+	err = provider.Run(context.Background(), "dna-store", "0.1.0")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
 		os.Exit(1)
 	}
+}
+
+func provider() (p.Provider, error) {
+	return infer.NewProviderBuilder().
+		WithNamespace("examples").
+		WithResources(
+			infer.Resource(&DNAStore{}),
+		).
+		WithModuleMap(map[tokens.ModuleName]tokens.ModuleName{
+			"dna-store": "index",
+		}).
+		Build()
 }

--- a/examples/dna-store/schema.json
+++ b/examples/dna-store/schema.json
@@ -1,8 +1,24 @@
 {
   "name": "dna-store",
   "version": "0.1.0",
+  "namespace": "examples",
   "meta": {
     "moduleFormat": "(.*)"
+  },
+  "language": {
+    "csharp": {
+      "respectSchemaVersion": true
+    },
+    "go": {
+      "generateResourceContainerTypes": true,
+      "respectSchemaVersion": true
+    },
+    "nodejs": {
+      "respectSchemaVersion": true
+    },
+    "python": {
+      "respectSchemaVersion": true
+    }
   },
   "config": {},
   "types": {

--- a/examples/file/main.go
+++ b/examples/file/main.go
@@ -14,20 +14,28 @@ import (
 )
 
 func main() {
-	err := p.RunProvider(context.Background(), "file", "0.1.0", provider())
+	provider, err := provider()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s", err.Error())
+		os.Exit(1)
+	}
+	err = provider.Run(context.Background(), "file", "0.1.0")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s", err.Error())
 		os.Exit(1)
 	}
 }
 
-func provider() p.Provider {
-	return infer.Provider(infer.Options{
-		Resources: []infer.InferredResource{infer.Resource(&File{})},
-		ModuleMap: map[tokens.ModuleName]tokens.ModuleName{
+func provider() (p.Provider, error) {
+	return infer.NewProviderBuilder().
+		WithNamespace("examples").
+		WithResources(
+			infer.Resource(&File{}),
+		).
+		WithModuleMap(map[tokens.ModuleName]tokens.ModuleName{
 			"file": "index",
-		},
-	})
+		}).
+		Build()
 }
 
 type File struct{}

--- a/examples/file/schema.json
+++ b/examples/file/schema.json
@@ -1,8 +1,24 @@
 {
   "name": "file",
   "version": "0.1.0",
+  "namespace": "examples",
   "meta": {
     "moduleFormat": "(.*)"
+  },
+  "language": {
+    "csharp": {
+      "respectSchemaVersion": true
+    },
+    "go": {
+      "generateResourceContainerTypes": true,
+      "respectSchemaVersion": true
+    },
+    "nodejs": {
+      "respectSchemaVersion": true
+    },
+    "python": {
+      "respectSchemaVersion": true
+    }
   },
   "config": {},
   "provider": {

--- a/examples/random-login/main_test.go
+++ b/examples/random-login/main_test.go
@@ -18,6 +18,7 @@ import (
 const schema = `{
   "name": "random-login",
   "version": "0.1.0",
+  "namespace": "examples",
   "language": {
     "go": {
       "importBasePath": "github.com/pulumi/pulumi-go-provider/examples/random-login/sdk/go/randomlogin"
@@ -143,10 +144,12 @@ const schema = `{
 }`
 
 func TestSchema(t *testing.T) {
+	provider, err := provider()
+	require.NoError(t, err)
 	server, err := integration.NewServer(t.Context(),
 		"random-login",
 		semver.Version{Minor: 1},
-		integration.WithProvider(provider()),
+		integration.WithProvider(provider),
 	)
 	require.NoError(t, err)
 
@@ -159,10 +162,12 @@ func TestSchema(t *testing.T) {
 }
 
 func TestRandomSalt(t *testing.T) {
+	provider, err := provider()
+	require.NoError(t, err)
 	server, err := integration.NewServer(t.Context(),
 		"random-login",
 		semver.Version{Minor: 1},
-		integration.WithProvider(provider()),
+		integration.WithProvider(provider),
 	)
 	require.NoError(t, err)
 
@@ -197,10 +202,12 @@ func TestRandomSalt(t *testing.T) {
 }
 
 func TestRandomLogin(t *testing.T) {
+	provider, err := provider()
+	require.NoError(t, err)
 	server, err := integration.NewServer(t.Context(),
 		"random-login",
 		semver.Version{Minor: 1},
-		integration.WithProvider(provider()),
+		integration.WithProvider(provider),
 		integration.WithMocks(&integration.MockResourceMonitor{
 			NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
 				// mock the registration of the component's resources

--- a/examples/random-login/schema.json
+++ b/examples/random-login/schema.json
@@ -1,6 +1,7 @@
 {
   "name": "random-login",
   "version": "0.1.0",
+  "namespace": "examples",
   "meta": {
     "moduleFormat": "(.*)"
   },

--- a/examples/str/main.go
+++ b/examples/str/main.go
@@ -16,25 +16,31 @@ import (
 )
 
 func main() {
-	err := p.RunProvider(context.Background(), "str", "0.1.0", provider())
+	provider, err := provider()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s", err.Error())
+		os.Exit(1)
+	}
+	err = provider.Run(context.Background(), "str", "0.1.0")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %s\n", err)
 		os.Exit(1)
 	}
 }
 
-func provider() p.Provider {
-	return infer.Provider(infer.Options{
-		Functions: []infer.InferredFunction{
+func provider() (p.Provider, error) {
+	return infer.NewProviderBuilder().
+		WithNamespace("examples").
+		WithFunctions(
 			infer.Function(&Replace{}),
 			infer.Function(&Print{}),
 			infer.Function(&GiveMeAString{}),
 			infer.Function(&regex.Replace{}),
-		},
-		ModuleMap: map[tokens.ModuleName]tokens.ModuleName{
+		).
+		WithModuleMap(map[tokens.ModuleName]tokens.ModuleName{
 			"str": "index",
-		},
-	})
+		}).
+		Build()
 }
 
 type Replace struct{}

--- a/examples/str/main_test.go
+++ b/examples/str/main_test.go
@@ -15,6 +15,22 @@ import (
 const schema = `{
   "name": "str",
   "version": "0.1.0",
+  "namespace": "examples",
+  "language": {
+    "csharp": {
+      "respectSchemaVersion": true
+    },
+    "go": {
+      "generateResourceContainerTypes": true,
+      "respectSchemaVersion": true
+    },
+    "nodejs": {
+      "respectSchemaVersion": true
+    },
+    "python": {
+      "respectSchemaVersion": true
+    }
+  },
   "config": {},
   "provider": {},
   "functions": {
@@ -125,10 +141,12 @@ const schema = `{
 }`
 
 func TestSchema(t *testing.T) {
+	provider, err := provider()
+	require.NoError(t, err)
 	server, err := integration.NewServer(t.Context(),
 		"str",
 		semver.Version{Minor: 1},
-		integration.WithProvider(provider()),
+		integration.WithProvider(provider),
 	)
 	require.NoError(t, err)
 
@@ -143,10 +161,12 @@ func TestSchema(t *testing.T) {
 }
 
 func TestInvokes(t *testing.T) {
+	provider, err := provider()
+	require.NoError(t, err)
 	server, err := integration.NewServer(t.Context(),
 		"str",
 		semver.Version{Minor: 1},
-		integration.WithProvider(provider()),
+		integration.WithProvider(provider),
 	)
 	require.NoError(t, err)
 

--- a/examples/str/schema.json
+++ b/examples/str/schema.json
@@ -1,8 +1,24 @@
 {
   "name": "str",
   "version": "0.1.0",
+  "namespace": "examples",
   "meta": {
     "moduleFormat": "(.*)"
+  },
+  "language": {
+    "csharp": {
+      "respectSchemaVersion": true
+    },
+    "go": {
+      "generateResourceContainerTypes": true,
+      "respectSchemaVersion": true
+    },
+    "nodejs": {
+      "respectSchemaVersion": true
+    },
+    "python": {
+      "respectSchemaVersion": true
+    }
   },
   "config": {},
   "provider": {


### PR DESCRIPTION
This PR updates the examples to uniformly use the `ProviderBuilder` and the `provider.Run` function.