### PR TITLE
Keep internal metadata under __internal

### DIFF
--- a/infer/configuration.go
+++ b/infer/configuration.go
@@ -81,7 +81,15 @@ func (*config[T]) GetSchema(reg schema.RegisterDerivativeType) (pschema.Resource
 
 // markAsInferProvider adds a key to the provider state to indicate that [infer] is being used for this provider.
 func markAsInferProvider(pm resource.PropertyMap) {
-	pm[inferStateKeyName] = resource.NewBoolProperty(true)
+	internal := pm["__internal"]
+	if !internal.IsObject() {
+		newMap := resource.PropertyMap{}
+		internal = resource.NewObjectProperty(newMap)
+		pm["__internal"] = internal
+	}
+
+	m := internal.ObjectValue()
+	m[inferStateKeyName] = resource.NewBoolProperty(true)
 }
 
 func (c *config[T]) checkConfig(ctx context.Context, req p.CheckRequest) (p.CheckResponse, error) {

--- a/infer/provider.go
+++ b/infer/provider.go
@@ -31,7 +31,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const inferStateKeyName = "__pulumi-go-provider-infer"
+const inferStateKeyName = "pulumi-go-provider-infer"
 
 type configKeyType struct{}
 

--- a/infer/tests/check_config_test.go
+++ b/infer/tests/check_config_test.go
@@ -40,8 +40,10 @@ func TestCheckConfig(t *testing.T) {
 	// By default, check simply ensures that we can decode cleanly. It removes unknown
 	// fields so that diff doesn't trigger on changes to unwatched arguments.
 	assert.Equal(t, property.NewMap(map[string]property.Value{
-		"value":                      property.New("foo"),
-		"__pulumi-go-provider-infer": property.New(true),
+		"value": property.New("foo"),
+		"__internal": property.New(property.NewMap(map[string]property.Value{
+			"pulumi-go-provider-infer": property.New(true),
+		})),
 	}), resp.Inputs)
 }
 
@@ -61,23 +63,35 @@ func TestCheckConfigCustom(t *testing.T) {
 
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
-		test(t, property.Map{}, property.NewMap(map[string]property.Value{
-			"__pulumi-go-provider-infer": property.New(true),
-		}))
+		test(t, property.Map{},
+			property.NewMap(map[string]property.Value{
+				"__internal": property.New(property.NewMap(map[string]property.Value{
+					"pulumi-go-provider-infer": property.New(true),
+				})),
+			}),
+		)
 	})
 	t.Run("unknown", func(t *testing.T) {
 		t.Parallel()
 		test(t,
 			property.NewMap(map[string]property.Value{"unknownField": property.New("bar")}),
-			property.NewMap(map[string]property.Value{"__pulumi-go-provider-infer": property.New(true)}))
+			property.NewMap(map[string]property.Value{
+				"__internal": property.New(property.NewMap(map[string]property.Value{
+					"pulumi-go-provider-infer": property.New(true),
+				}))},
+			),
+		)
 	})
 	t.Run("number", func(t *testing.T) {
 		t.Parallel()
 		test(t,
 			property.NewMap(map[string]property.Value{"number": property.New(42.0)}),
 			property.NewMap(map[string]property.Value{
-				"number":                     property.New(42.5),
-				"__pulumi-go-provider-infer": property.New(true),
-			}))
+				"number": property.New(42.5),
+				"__internal": property.New(property.NewMap(map[string]property.Value{
+					"pulumi-go-provider-infer": property.New(true),
+				})),
+			}),
+		)
 	})
 }

--- a/provider.go
+++ b/provider.go
@@ -706,8 +706,15 @@ func (p *provider) CheckConfig(ctx context.Context, req *rpc.CheckRequest) (*rpc
 		return nil, err
 	}
 
+	internal, ok := r.Inputs.GetOk("__internal")
+	if !ok {
+		internal = property.New(property.NewMap(nil))
+	}
+	m := internal.AsMap()
+	m = m.Set(frameworkStateKeyName, property.New(frameworkVersion.String()))
+
 	// Inject the version of pulumi-go-provider into the news map to store in state.
-	r.Inputs = r.Inputs.Set(frameworkStateKeyName, property.New(frameworkVersion.String()))
+	r.Inputs = r.Inputs.Set("__internal", property.New(m))
 
 	inputs, err := p.asStruct(r.Inputs)
 	if err != nil {

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -142,8 +142,10 @@ func TestInferCheckConfigSecrets(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, resp.Failures)
 	assert.Equal(t, property.NewMap(map[string]property.Value{
-		"__pulumi-go-provider-infer": property.New(true),
-		"field":                      property.New("value").WithSecret(true),
+		"__internal": property.New(property.NewMap(map[string]property.Value{
+			"pulumi-go-provider-infer": property.New(true),
+		})),
+		"field": property.New("value").WithSecret(true),
 		"nested": property.New(map[string]property.Value{
 			"int":        property.New(1.0).WithSecret(true),
 			"not-nested": property.New("not-secret"),
@@ -225,10 +227,12 @@ func TestInferCustomCheckConfig(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, resp.Failures)
 			assert.Equal(t, property.NewMap(map[string]property.Value{
-				"__pulumi-go-provider-infer": property.New(true),
-				"field":                      property.New("value").WithSecret(true),
-				"not":                        property.New("not-secret"),
-				"applyDefaults":              property.New(applyDefaults),
+				"__internal": property.New(property.NewMap(map[string]property.Value{
+					"pulumi-go-provider-infer": property.New(true),
+				})),
+				"field":         property.New("value").WithSecret(true),
+				"not":           property.New("not-secret"),
+				"applyDefaults": property.New(applyDefaults),
 			}), resp.Inputs)
 		})
 	}

--- a/tests/grpc/config_test.go
+++ b/tests/grpc/config_test.go
@@ -114,8 +114,10 @@ func TestBasicConfig(t *testing.T) {
     },
     "response": {
       "inputs": {
-        "__pulumi-go-provider-infer": true,
-        "__pulumi-go-provider-version": "{{VERSION}}",
+        "__internal": {
+          "pulumi-go-provider-infer": true,
+          "pulumi-go-provider-version": "{{VERSION}}"
+        },
         "a": [
           "one",
           "two"
@@ -338,8 +340,10 @@ func TestConfigWithSecrets(t *testing.T) {
     },
     "response": {
       "inputs": {
-        "__pulumi-go-provider-infer": true,
-        "__pulumi-go-provider-version": "{{VERSION}}",
+        "__internal": {
+          "pulumi-go-provider-infer": true,
+          "pulumi-go-provider-version": "{{VERSION}}"
+        },
         "a": [
           "one",
           "two"
@@ -566,8 +570,10 @@ func TestJSONEncodedConfig(t *testing.T) {
     },
     "response": {
         "inputs": {
-            "__pulumi-go-provider-infer": true,
-            "__pulumi-go-provider-version": "{{VERSION}}",
+            "__internal": {
+              "pulumi-go-provider-infer": true,
+              "pulumi-go-provider-version": "{{VERSION}}"
+            },
             "a": [
                 "one",
                 "two"

--- a/version.go
+++ b/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	// frameworkStateKeyName is the key name used to store the framework version in
 	// a program's state.
-	frameworkStateKeyName = "__pulumi-go-provider-version"
+	frameworkStateKeyName = "pulumi-go-provider-version"
 )
 
 //go:embed .version


### PR DESCRIPTION
The __internal key is already automatically excluded from diffs by the engine.