### PR TITLE
rewrite aliases to use correct package name

### DIFF
--- a/middleware/schema/schema.go
+++ b/middleware/schema/schema.go
@@ -423,6 +423,16 @@ func renamePackage[T any](typ T, pkg string, modMap map[tokens.ModuleName]tokens
 				rewritten := fixReference(field.String(), pkg, modMap)
 				field.SetString(rewritten)
 			}
+			if v.Type() == reflect.TypeOf(schema.AliasSpec{}) {
+				field := v.FieldByName("Type")
+				tk, err := tokens.ParseTypeToken(field.String())
+				if err != nil {
+					// Not a valid token, so again we just leave it
+				} else {
+					rewritten := assignTo(tk, pkg, modMap)
+					field.SetString(rewritten.String())
+				}
+			}
 			for _, f := range reflect.VisibleFields(v.Type()) {
 				f := v.FieldByIndex(f.Index)
 				rename(f)

--- a/middleware/schema/schema_test.go
+++ b/middleware/schema/schema_test.go
@@ -34,10 +34,16 @@ func TestRenamePackage(t *testing.T) {
 				},
 			},
 		},
+		Aliases: []schema.AliasSpec{
+			{
+				Type: "pkg:other:Buzz",
+			},
+		},
 	}
 
 	p = renamePackage(p, "fizz", map[tokens.ModuleName]tokens.ModuleName{})
 	assert.Equal(t, "#/types/fizz:bar:Buzz", p.ObjectTypeSpec.Properties["foo"].Ref)
+	assert.Equal(t, "fizz:other:Buzz", p.Aliases[0].Type)
 
 	arr := []schema.PropertySpec{
 		{


### PR DESCRIPTION
Fixes a bug with schema generation: the aliases must be rewritten to have the final package name.  Internally the middleware uses a placeholder `"pkg"` and rewrites the type tokens later.  Seems this wasn't happening for aliases.