### PR TITLE
Update golangci-lint to v2

### DIFF
--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   lint:
-    container: golangci/golangci-lint:v1.64.8
+    container: golangci/golangci-lint:v2.1.6
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,40 +1,39 @@
-run:
-  timeout: 10m
-issues:
-  # Enable checking the by default skipped "examples" dirs
-  exclude-dirs-use-default: false
-  exclude-use-default: false
-  exclude-dirs:
-    - vendor$
-    - third_party$
-    - testdata$
-    - Godeps$
-    - builtin$
+version: "2"
 linters:
-  enable-all: false
   enable:
-    - errcheck
     - goconst
-    - gofmt
-    - revive
     - gosec
-    - gosimple
-    - govet
-    - ineffassign
     - lll
     - misspell
     - nakedret
-    - unconvert
     - paralleltest
+    - revive
     - staticcheck
-    - stylecheck
-    - unused
+    - unconvert
   disable:
     - godot
-linters-settings:
-  revive:
-    rules:
-      # Require that exported types and functions have comments.
-      - name: package-comments
-        # We do not require this for internal types.
-        exclude: ["**/internal/**"]
+  settings:
+    revive:
+      rules:
+        - name: package-comments
+          exclude:
+            - '**/internal/**'
+  exclusions:
+    generated: lax
+    paths:
+      - vendor$
+      - third_party$
+      - testdata$
+      - Godeps$
+      - builtin$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - vendor$
+      - third_party$
+      - testdata$
+      - Godeps$
+      - builtin$

--- a/infer/provider_builder_test.go
+++ b/infer/provider_builder_test.go
@@ -273,7 +273,7 @@ func TestWithNamespace(t *testing.T) {
 	assert.Equal(t, finalNamespace, dp.metadata.Namespace)
 
 	opts := dp.BuildOptions()
-	assert.Equal(t, finalNamespace, opts.Metadata.Namespace)
+	assert.Equal(t, finalNamespace, opts.Namespace)
 }
 
 func TestWithWrapped(t *testing.T) {

--- a/internal/putil/putil_test.go
+++ b/internal/putil/putil_test.go
@@ -242,7 +242,7 @@ func TestWalk(t *testing.T) {
 			t.Run(tc.v.GoString(), func(t *testing.T) {
 				t.Parallel()
 				continueWalking := putil.Walk(tc.v, func(v property.Value) (continueWalking bool) {
-					return !(v.IsString() && v.AsString() == "stop")
+					return !v.IsString() || v.AsString() != "stop"
 				})
 				assert.False(t, continueWalking)
 			})


### PR DESCRIPTION
The changes to `.golangci.yaml` are from running `golangci-lint migrate`. The code fixes are both automated: `golangci-lint run -c .golangci.yaml --timeout 5m --fix`.