### PR TITLE
Store provider version in state

### DIFF
--- a/tests/grpc/config_test.go
+++ b/tests/grpc/config_test.go
@@ -142,7 +142,8 @@ func TestBasicConfig(t *testing.T) {
           },
           "s": "foo"
         },
-        "s": "foo"
+        "s": "foo",
+        "version": "1.0.0"
       }
     },
     "metadata": {
@@ -368,7 +369,8 @@ func TestConfigWithSecrets(t *testing.T) {
           },
           "s": "foo"
         },
-        "s": "foo"
+        "s": "foo",
+        "version": "1.0.0"
       }
     },
     "metadata": {
@@ -598,7 +600,8 @@ func TestJSONEncodedConfig(t *testing.T) {
                 },
                 "s": "foo"
             },
-            "s": "foo"
+            "s": "foo",
+            "version": "1.0.0"
         }
     },
     "metadata": {


### PR DESCRIPTION
Our bridged and native providers currently store the provider's version as part of its configuration input. For example:

```
❯ cat index.ts
import * as aws from "@pulumi/aws";
import * as k8s from "@pulumi/kubernetes";
import * as docker from "@pulumi/docker-build";

new aws.Provider("aws");

new docker.Provider("docker-build");

new k8s.Provider("k8s");
```

The aws and k8s providers automatically include a version.

```json
        {
          "type": "pulumi:providers:aws",
          "inputs": {
            "__internal": {},
            "skipCredentialsValidation": "false",
            "skipRegionValidation": "true",
            "version": "7.3.1"
          },
          "outputs": {
            "skipCredentialsValidation": "false",
            "skipRegionValidation": "true",
            "version": "7.3.1"
          },
          ...
        },
        {
          "type": "pulumi:providers:kubernetes",
          "inputs": {
            "__internal": {},
            "version": "4.23.0"
          },
          "outputs": {
            "version": "4.23.0"
          },
          ...
        }
```

Docker (implemented with p-go-provider) doesn't track this version information:

```json
        {
          "type": "pulumi:providers:docker-build",
          "inputs": {
            "__internal": {},
            "host": ""
          },
          "outputs": {
            "host": ""
          },
          ...
        },
```

I thought this might be because we were missing a version from GetSchema, but it's there:

```
❯ pulumi package get-schema ~/.pulumi/plugins/resource-docker-build-v0.0.8/pulumi-resource-docker-build | jq .version
"0.0.8"
```

The SDK also has the version set:
```
❯ cat node_modules/@pulumi/docker-build/package.json | jq .version; cat node_modules/@pulumi/docker-build/package.json | jq .pulumi.version;
"0.0.8"
"0.0.8"
```

At this point I suspect the reason the version is getting omitted is because we're implementing some of our own GetConfig since we're inferring user-provided logic.

As a workaround this PR modifies the provider to persist its version by modifying CheckConfig directly. It has the intended effect but it feels very wrong. In particular it has replace semantics for Diff which is undesirable.

```
Do you want to perform this update? details
  pulumi:pulumi:Stack: (same)
    [urn=urn:pulumi:foo::go-provider-406::pulumi:pulumi:Stack::go-provider-406-foo]
    ++pulumi:providers:docker-build: (create-replacement)
        [id=495f6125-970b-4e1a-867e-72b4fdb558f3]
        [urn=urn:pulumi:foo::go-provider-406::pulumi:providers:docker-build::docker-build]
      + version: "0.2.0-alpha.0+dev"
    +-pulumi:providers:docker-build: (replace)
        [id=495f6125-970b-4e1a-867e-72b4fdb558f3]
        [urn=urn:pulumi:foo::go-provider-406::pulumi:providers:docker-build::docker-build]
      + version: "0.2.0-alpha.0+dev"
```

I would prefer to use some shared logic but I'm not sure where that logic lives or if it would be possible/reasonable.

Refs #406.