### PR TITLE
Don't replace providers on version changes

### DIFF
--- a/infer/configuration.go
+++ b/infer/configuration.go
@@ -148,7 +148,10 @@ func (c *config[T]) checkConfig(ctx context.Context, req p.CheckRequest) (p.Chec
 }
 
 func (c *config[T]) diffConfig(ctx context.Context, req p.DiffRequest) (p.DiffResponse, error) {
-	return diff[T, T, T](ctx, req, c.receiver, func(string) bool { return true })
+	// We currently replace the provider on any changes
+	// (https://github.com/pulumi/pulumi-go-provider/issues/409) except for
+	// version.
+	return diff[T, T, T](ctx, req, c.receiver, func(field string) bool { return field != "version" })
 }
 
 func (c *config[T]) configure(ctx context.Context, req p.ConfigureRequest) error {


### PR DESCRIPTION
Followup to https://github.com/pulumi/pulumi-go-provider/pull/407 and https://github.com/pulumi/pulumi/pull/20401.

If a provider doesn't define `DiffConfig` we currently replace it on any changes (https://github.com/pulumi/pulumi-go-provider/issues/409).

Changing the default behavior to instead update is a breaking change in behavior, so we can't do that.

However, the version field in particular is currently broken -- changing the version and nothing else should _not_ trigger a replacement. Special-casing this field to only cause updates is an appropriate bug fix.