### PR TITLE
Add WillReplaceOnChanges

### DIFF
--- a/infer/resource.go
+++ b/infer/resource.go
@@ -410,6 +410,15 @@ type Annotator interface {
 	//		a.Deprecate(&s, "Struct is deprecated")
 	//	}
 	Deprecate(i any, message string)
+
+	// WillReplaceOnChanges sets the willReplaceOnChanges flag on a field.
+	//
+	// For example:
+	//
+	//	func (*s Struct) Annotated(a Annotator) {
+	//		a.WillReplaceOnChanges(&s.Field, true)
+	//
+	WillReplaceOnChanges(i any, willReplaceOnChanges bool)
 }
 
 // Annotated is used to describe the fields of an object or a resource. Annotated can be

--- a/infer/schema_test.go
+++ b/infer/schema_test.go
@@ -40,6 +40,8 @@ func (r *TestResource) Annotate(a Annotator) {
 	a.Describe(&r.P1, "This is a test property.")
 	a.SetDefault(&r.P1, defaultValue)
 	a.Deprecate(&r.P1, "This field is deprecated.")
+
+	a.WillReplaceOnChanges(&r.P1, true)
 }
 
 func (r *AnonymousEmbed) Annotate(a Annotator) {
@@ -72,4 +74,7 @@ func TestResourceAnnotations(t *testing.T) {
 	assert.Equal(t, "This is an embedded property.", p2.Description)
 	assert.Equal(t, "default2", p2.Default)
 	assert.Equal(t, "This field is also deprecated.", p2.DeprecationMessage)
+
+	assert.True(t, p1.WillReplaceOnChanges)
+	assert.False(t, p2.WillReplaceOnChanges)
 }

--- a/internal/introspect/annotator.go
+++ b/internal/introspect/annotator.go
@@ -23,22 +23,24 @@ import (
 
 func NewAnnotator(resource any) Annotator {
 	return Annotator{
-		Descriptions:        map[string]string{},
-		Defaults:            map[string]any{},
-		DefaultEnvs:         map[string][]string{},
-		DeprecationMessages: map[string]string{},
-		matcher:             NewFieldMatcher(resource),
+		Descriptions:               map[string]string{},
+		Defaults:                   map[string]any{},
+		DefaultEnvs:                map[string][]string{},
+		DeprecationMessages:        map[string]string{},
+		WillReplaceOnChangesFields: map[string]bool{},
+		matcher:                    NewFieldMatcher(resource),
 	}
 }
 
 // Annotator implements the Annotator interface as defined in resource/resource.go.
 type Annotator struct {
-	Descriptions        map[string]string
-	Defaults            map[string]any
-	DefaultEnvs         map[string][]string
-	Token               string
-	Aliases             []string
-	DeprecationMessages map[string]string
+	Descriptions               map[string]string
+	Defaults                   map[string]any
+	DefaultEnvs                map[string][]string
+	Token                      string
+	Aliases                    []string
+	DeprecationMessages        map[string]string
+	WillReplaceOnChangesFields map[string]bool
 
 	matcher FieldMatcher
 }
@@ -124,6 +126,11 @@ func (a *Annotator) Deprecate(i any, message string) {
 		panic("Could not annotate field: could not find field")
 	}
 	a.DeprecationMessages[field.Name] = message
+}
+
+func (a *Annotator) WillReplaceOnChanges(i any, willReplaceOnChanges bool) {
+	field := a.mustGetField(i)
+	a.WillReplaceOnChangesFields[field.Name] = willReplaceOnChanges
 }
 
 // formatToken formats a (module, token) pair into a valid token string.


### PR DESCRIPTION
This allows the user to set `willReplaceOnChanges`. It's unclear to me if we should merge this, since `replaceOnChanges` should be preferred over `willReplaceOnChanges` in every case I can think of in a hand-written provider.