### PR TITLE
`rpc.Provider` correctly handles wrapping providers without preview support

### DIFF
--- a/middleware/rpc/provider.go
+++ b/middleware/rpc/provider.go
@@ -199,7 +199,8 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 		},
 		Create: func(ctx context.Context, req p.CreateRequest) (p.CreateResponse, error) {
 			if req.DryRun && runtime.configuration != nil && !runtime.configuration.SupportsPreview {
-				return p.CreateResponse{}, nil
+				// Mirror the default preview behavior: assume inputs are state.
+				return p.CreateResponse{Properties: req.Properties}, nil
 			}
 
 			inProperties, err := runtime.propertyToRPC(req.Properties)
@@ -249,7 +250,9 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 		},
 		Update: func(ctx context.Context, req p.UpdateRequest) (p.UpdateResponse, error) {
 			if req.DryRun && runtime.configuration != nil && !runtime.configuration.SupportsPreview {
-				return p.UpdateResponse{}, nil
+				// Mirror the default preview behavior: assume that inputs
+				// are state.
+				return p.UpdateResponse{Properties: req.Inputs}, nil
 			}
 
 			inOlds, err := runtime.propertyToRPC(req.State)


### PR DESCRIPTION
When a provider doesn't support preview, the engine defaults to using inputs as state. We need to mirror this behavior to allow `rpc.Provider` to wrap providers that don't support preview natively.

Stacked on https://github.com/pulumi/pulumi-go-provider/pull/415