### PR TITLE
Correctly keep `DiffResponse`'s non-detailed diffs keys top-level

### DIFF
--- a/provider_test.go
+++ b/provider_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024, Pulumi Corporation.
+// Copyright 2022-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,94 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDiffResponseRPC(t *testing.T) {
+	t.Parallel()
+	t.Run("nested property paths are flattened to top-level keys", func(t *testing.T) {
+		t.Parallel()
+		resp := DiffResponse{
+			HasChanges: true,
+			DetailedDiff: map[string]PropertyDiff{
+				"foo.bar.baz": {Kind: Update},
+				"foo.qux":     {Kind: Update},
+				"other":       {Kind: Update},
+			},
+		}
+
+		rpcResp := resp.rpc()
+
+		// Both "foo.bar.baz" and "foo.qux" should map to "foo"
+		assert.ElementsMatch(t, []string{"foo", "other"}, rpcResp.Diffs)
+		assert.Empty(t, rpcResp.Replaces)
+		assert.Empty(t, rpcResp.Stables)
+	})
+
+	t.Run("different diff kinds populate correct fields", func(t *testing.T) {
+		t.Parallel()
+		resp := DiffResponse{
+			HasChanges: true,
+			DetailedDiff: map[string]PropertyDiff{
+				"add":           {Kind: Add},
+				"addReplace":    {Kind: AddReplace},
+				"delete":        {Kind: Delete},
+				"deleteReplace": {Kind: DeleteReplace},
+				"update":        {Kind: Update},
+				"updateReplace": {Kind: UpdateReplace},
+				"stable":        {Kind: Stable},
+			},
+		}
+
+		rpcResp := resp.rpc()
+
+		// All kinds except Stable should be in Diffs
+		assert.ElementsMatch(t, []string{
+			"add", "addReplace", "delete", "deleteReplace", "update", "updateReplace",
+		}, rpcResp.Diffs)
+
+		// Only replace kinds should be in Replaces
+		assert.ElementsMatch(t, []string{
+			"addReplace", "deleteReplace", "updateReplace",
+		}, rpcResp.Replaces)
+
+		// Only Stable should be in Stables
+		assert.ElementsMatch(t, []string{"stable"}, rpcResp.Stables)
+	})
+
+	t.Run("nested paths with replace kinds", func(t *testing.T) {
+		t.Parallel()
+		resp := DiffResponse{
+			HasChanges: true,
+			DetailedDiff: map[string]PropertyDiff{
+				"resource.property.nested":  {Kind: UpdateReplace},
+				"resource.other":            {Kind: Update},
+				"different.path":            {Kind: AddReplace},
+				"different.another.deep[0]": {Kind: Delete},
+			},
+		}
+
+		rpcResp := resp.rpc()
+
+		// "resource.property.nested" and "resource.other" -> "resource"
+		// "different.path" and "different.another.deep[0]" -> "different"
+		assert.ElementsMatch(t, []string{"resource", "different"}, rpcResp.Diffs)
+		assert.ElementsMatch(t, []string{"resource", "different"}, rpcResp.Replaces)
+		assert.Empty(t, rpcResp.Stables)
+	})
+
+	t.Run("empty detailed diff returns nil slices", func(t *testing.T) {
+		t.Parallel()
+		resp := DiffResponse{
+			HasChanges:   true,
+			DetailedDiff: map[string]PropertyDiff{},
+		}
+
+		rpcResp := resp.rpc()
+
+		assert.Nil(t, rpcResp.Diffs)
+		assert.Nil(t, rpcResp.Replaces)
+		assert.Nil(t, rpcResp.Stables)
+	})
+}
 
 func TestGetSchema(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
This is necessary for diff to display correctly.

Stacked on top of https://github.com/pulumi/pulumi-go-provider/pull/416.