### PR TITLE
Add pulumi-plugin.json

### DIFF
--- a/pulumi-plugin.json
+++ b/pulumi-plugin.json
@@ -1,0 +1,3 @@
+{
+    "resource": false
+}


### PR DESCRIPTION
Part of fixing https://github.com/pulumi/pulumi/issues/21086

Adds a pulumi-plugin.json to the root module to mark that this is _NOT_ a resource provider module. This is to work around some CLI logic that assumes every repo of the form "github.com/pulumi/pulumi-" is a provider of some kind.

That CLI logic may change, but adding this file also means any current CLIs will ignore this repo if pulled in.