### PR TITLE
Correctly encode & decode `types.AssetOrArchive`

### DIFF
--- a/infer/internal/ende/ende.go
+++ b/infer/internal/ende/ende.go
@@ -16,6 +16,7 @@
 package ende
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/pulumi/pulumi-go-provider/infer/types"
@@ -23,6 +24,8 @@ import (
 	"github.com/pulumi/pulumi-go-provider/internal/putil"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	rarchive "github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	rasset "github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/mapper"
@@ -212,16 +215,24 @@ func (e *ende) walk(
 			if typ == nil || typ.Kind() != reflect.Struct {
 				return e.walkMap(v, path, elemType, alignTypes)
 			}
-		case typ == reflect.TypeOf(types.AssetOrArchive{}):
+		case typ == reflect.TypeFor[types.AssetOrArchive]():
 			// Translate Pulumi's AssetOrArchive union type to types.AssetOrArchive.
 			// See #237 for more background.
-			var aa types.AssetOrArchive
+			//
+			// Wrap the typed asset/archive PropertyValue under the appropriate signature key
+			// so the mapper sees the field tags it expects, but keep the original typed
+			// pointer rather than reflecting it into a map. The engine's RPC unmarshal already
+			// recursively types inner Assets entries on a *archive.Archive; reflecting through
+			// resource.NewPropertyValue would flatten those into raw map[string]any values that
+			// the generic mapper.Decode can no longer recover into typed *asset.Asset /
+			// *archive.Archive pointers.
+			obj := resource.PropertyMap{}
 			if v.IsAsset() {
-				aa = types.AssetOrArchive{Asset: v.AssetValue()}
+				obj[AssetSignature] = v
 			} else if v.IsArchive() {
-				aa = types.AssetOrArchive{Archive: v.ArchiveValue()}
+				obj[ArchiveSignature] = v
 			}
-			return resource.NewPropertyValue(aa)
+			return resource.NewObjectProperty(obj)
 		// This is a scalar value, so we can return it as is.
 		default:
 			return v
@@ -409,11 +420,31 @@ should never happen. Please file an issue at https://github.com/pulumi/pulumi-go
 
 	if asset, ok := raw.(map[string]any); ok {
 		if kind, ok := asset[sig.Key]; ok {
-			if kind == sig.AssetSig || kind == sig.ArchiveSig {
-				return resource.NewObjectProperty(resource.NewPropertyMapFromMap(asset)), true
-			}
-			panic(`Encountered an unknown kind in an AssetOrArchive. This should never
+			switch kind {
+			case sig.AssetSig:
+				a, isAsset, err := rasset.Deserialize(asset)
+				if err != nil {
+					panic(fmt.Sprintf("failed to deserialize asset in AssetOrArchive: %v", err))
+				}
+				if !isAsset {
+					panic(`Encountered an AssetOrArchive value that did not deserialize as an asset. This should
+never happen. Please file an issue at https://github.com/pulumi/pulumi-go-provider/issues.`)
+				}
+				return resource.NewProperty(a), true
+			case sig.ArchiveSig:
+				a, isArchive, err := rarchive.Deserialize(asset)
+				if err != nil {
+					panic(fmt.Sprintf("failed to deserialize archive in AssetOrArchive: %v", err))
+				}
+				if !isArchive {
+					panic(`Encountered an AssetOrArchive value that did not deserialize as an archive. This should
+never happen. Please file an issue at https://github.com/pulumi/pulumi-go-provider/issues.`)
+				}
+				return resource.NewProperty(a), true
+			default:
+				panic(`Encountered an unknown kind in an AssetOrArchive. This should never
 happen. Please file an issue at https://github.com/pulumi/pulumi-go-provider/issues.`)
+			}
 		}
 	}
 

--- a/infer/internal/ende/ende_test.go
+++ b/infer/internal/ende/ende_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+
 	"github.com/pulumi/pulumi-go-provider/infer/types"
 	rType "github.com/pulumi/pulumi-go-provider/internal/rapid/reflect"
 	rResource "github.com/pulumi/pulumi-go-provider/internal/rapid/resource"
@@ -198,28 +200,108 @@ func TestDecodeAssets(t *testing.T) {
 	})
 }
 
+func TestDecodeAssetArchiveInteriorTyping(t *testing.T) {
+	t.Parallel()
+
+	type input struct {
+		Source types.AssetOrArchive `pulumi:"source"`
+	}
+
+	innerAsset, err := asset.FromText("hello")
+	require.NoError(t, err)
+	innerArchive, err := archive.FromAssets(map[string]any{
+		"nested-asset": innerAsset,
+	})
+	require.NoError(t, err)
+	outer, err := archive.FromAssets(map[string]any{
+		"inner-asset":   innerAsset,
+		"inner-archive": innerArchive,
+	})
+	require.NoError(t, err)
+
+	pMap := property.NewMap(map[string]property.Value{
+		"source": property.New(outer),
+	})
+
+	enc, got, err := Decode[input](pMap)
+	require.NoError(t, err)
+
+	assert.Equal(t, types.AssetOrArchive{Archive: &archive.Archive{
+		Sig:  sig.ArchiveSig,
+		Hash: "f572f54b8f8252f419ff94d54b0b01783c256c5e57f29328f81f131c7ab4a717",
+		Assets: map[string]any{
+			"inner-archive": &archive.Archive{
+				Sig:  sig.ArchiveSig,
+				Hash: "82521fd7095bc6e6b97f424f21ab9b132b63f57b3c885ed0081ae187964c8bb8",
+				Assets: map[string]any{
+					"nested-asset": &asset.Asset{
+						Sig:  sig.AssetSig,
+						Hash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+						Text: "hello",
+					},
+				},
+			},
+			"inner-asset": &asset.Asset{
+				Sig:  sig.AssetSig,
+				Hash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+				Text: "hello",
+			},
+		},
+	}}, got.Source)
+
+	m, err := enc.Encode(got)
+	require.NoError(t, err)
+	assert.Equal(t, r.PropertyMap{
+		"source": r.NewProperty(&archive.Archive{
+			Sig:  sig.ArchiveSig,
+			Hash: "f572f54b8f8252f419ff94d54b0b01783c256c5e57f29328f81f131c7ab4a717",
+			Assets: map[string]any{
+				"inner-asset": &asset.Asset{
+					Sig:  sig.AssetSig,
+					Hash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+					Text: "hello",
+				},
+				"inner-archive": &archive.Archive{
+					Sig:  sig.ArchiveSig,
+					Hash: "82521fd7095bc6e6b97f424f21ab9b132b63f57b3c885ed0081ae187964c8bb8",
+					Assets: map[string]any{
+						"nested-asset": &asset.Asset{
+							Sig:  sig.AssetSig,
+							Hash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+							Text: "hello",
+						},
+					},
+				},
+			},
+		}),
+	}, m)
+}
+
 func TestEncodeAsset(t *testing.T) {
 	t.Parallel()
+
+	type wrap struct {
+		AA types.AssetOrArchive `pulumi:"aa"`
+	}
 
 	t.Run("standard asset", func(t *testing.T) {
 		t.Parallel()
 
 		a, err := asset.FromText("pulumi")
 		require.NoError(t, err)
-		aa := types.AssetOrArchive{Asset: a}
 
 		encoder := Encoder{new(ende)}
 
-		properties, err := encoder.Encode(aa)
+		properties, err := encoder.Encode(wrap{AA: types.AssetOrArchive{Asset: a}})
 		require.NoError(t, err)
 
 		assert.Equal(t,
 			r.PropertyMap{
-				sig.Key: r.NewStringProperty(sig.AssetSig),
-				"hash":  r.NewStringProperty(a.Hash),
-				"text":  r.NewStringProperty("pulumi"),
-				"path":  r.NewStringProperty(""),
-				"uri":   r.NewStringProperty(""),
+				"aa": r.NewProperty(&asset.Asset{
+					Sig:  sig.AssetSig,
+					Hash: a.Hash,
+					Text: "pulumi",
+				}),
 			},
 			properties)
 	})
@@ -229,19 +311,19 @@ func TestEncodeAsset(t *testing.T) {
 
 		a, err := archive.FromPath(t.TempDir())
 		require.NoError(t, err)
-		aa := types.AssetOrArchive{Archive: a}
 
 		encoder := Encoder{new(ende)}
 
-		properties, err := encoder.Encode(aa)
+		properties, err := encoder.Encode(wrap{AA: types.AssetOrArchive{Archive: a}})
 		require.NoError(t, err)
 
 		assert.Equal(t,
 			r.PropertyMap{
-				sig.Key: r.NewStringProperty(sig.ArchiveSig),
-				"hash":  r.NewStringProperty(a.Hash),
-				"path":  r.NewStringProperty(a.Path),
-				"uri":   r.NewStringProperty(""),
+				"aa": r.NewProperty(&archive.Archive{
+					Sig:  sig.ArchiveSig,
+					Hash: a.Hash,
+					Path: a.Path,
+				}),
 			},
 			properties)
 	})

--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -521,19 +521,17 @@ func TestHydrateFromState(t *testing.T) {
 	testAsset, err := asset.FromText("pulumi")
 	require.NoError(t, err)
 
-	// testHydrateFromState decodes and encodes, so the asset should come back out as a plain asset
-	// after having been decoded to an AssetOrArchive.
+	// testHydrateFromState decodes and encodes, so the asset should come back out as a typed asset
+	// (with a populated Sig) after having been decoded to an AssetOrArchive.
 	t.Run("assets", testHydrateFromState[hasAsset](
 		property.NewMap(map[string]property.Value{
 			"aa": property.New(testAsset),
 		}),
 		property.NewMap(map[string]property.Value{
-			"aa": property.New(map[string]property.Value{
-				sig.Key: property.New(sig.AssetSig),
-				"text":  property.New("pulumi"),
-				"hash":  property.New(testAsset.Hash),
-				"path":  property.New(""),
-				"uri":   property.New(""),
+			"aa": property.New(&asset.Asset{
+				Sig:  sig.AssetSig,
+				Hash: testAsset.Hash,
+				Text: "pulumi",
 			}),
 		}),
 		nil,


### PR DESCRIPTION
Previously, `infer`'s  `ende` package wasn't decoding the assets & archives wrapped in a `(archive.Archive).Assets`  map (an `AssetArchive`). This caused providers that used `types.AssetOrArchive` to fail to correctly access the inner value.

This behavior was first observed in
https://github.com/pulumi/pulumi-command/pull/1222, when Claude believed it was necessary to add `normalizeArchiveAssets`:

https://github.com/pulumi/pulumi-command/pull/1222/changes/de9a192b7f0b302c2057d4fd20971696d9a468e7#diff-0e11b7420ae2bcfc462b4686f8051474c6d2d7abec7503055c758316ad3b77e7R280-R313

This commit also fixes a less important bug when `ende`'s `Encode` is called on assets & archives. It now correctly turns them back into `archive.Archive` & `asset.Asset` instead of a raw property map. This bug is less important since both representations have the same wire format, and are thus indistinguishable to the engine.