### PR TITLE
Respect `infer.ExplicitDependencies` for `infer.Function`

### DIFF
--- a/infer/function.go
+++ b/infer/function.go
@@ -21,7 +21,9 @@ import (
 	"unicode"
 
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer/internal/ende"
@@ -175,7 +177,20 @@ func (r *derivedInvokeController[F, I, O]) Invoke(ctx context.Context, req p.Inv
 	if err != nil {
 		return p.InvokeResponse{}, err
 	}
+
+	result := applySecrets[O](m)
+
+	if _, ok := any(r.receiver).(ExplicitDependencies[I, O]); ok {
+		setDeps, err := getDependencies(&r.receiver, &i, &o.Output, false /* isCreate */, false /* isPreview */)
+		if err != nil {
+			return p.InvokeResponse{}, err
+		}
+		out := resource.ToResourcePropertyValue(property.New(result)).ObjectValue()
+		setDeps(nil, resource.ToResourcePropertyValue(property.New(req.Args)).ObjectValue(), out)
+		result = resource.FromResourcePropertyValue(resource.NewProperty(out)).AsMap()
+	}
+
 	return p.InvokeResponse{
-		Return: applySecrets[O](m),
+		Return: result,
 	}, nil
 }

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -447,10 +447,16 @@ type FieldSelector interface {
 
 func (*fieldGenerator) isFieldSelector() {}
 
-// ExplicitDependencies describes a custom resource with the dataflow between its
-// arguments (`I`) and outputs (`O`) specified. If a CustomResource implements
-// ExplicitDependencies then WireDependencies will be called for each Create and Update
-// call with `args` and `state` holding the values they will have for that call.
+// ExplicitDependencies describes the dataflow between the arguments (`I`) and outputs
+// (`O`) of a resource or function.
+//
+// If a [CustomResource] implements ExplicitDependencies then WireDependencies will be
+// called for each Create and Update call with `args` and `state` holding the values they
+// will have for that call.
+//
+// If a function (see [Function]) implements ExplicitDependencies then WireDependencies
+// will be called for each Invoke call with `args` and `state` holding the values they
+// will have for that call.
 //
 // If ExplicitDependencies is not implemented, it is assumed that all outputs depend on
 // all inputs.

--- a/tests/invoke_test.go
+++ b/tests/invoke_test.go
@@ -76,3 +76,58 @@ func TestInferInvokeSecrets(t *testing.T) {
 		"out": property.New("value-secret").WithSecret(true),
 	}), resp.Return)
 }
+
+type invWired struct{}
+
+type invWiredInput struct {
+	Field string `pulumi:"field" provider:"secret"`
+}
+
+type invWiredOutput struct {
+	invWiredInput
+}
+
+func (invWired) Invoke(
+	ctx context.Context, req infer.FunctionRequest[invWiredInput],
+) (infer.FunctionResponse[invWiredOutput], error) {
+	return infer.FunctionResponse[invWiredOutput]{
+		Output: invWiredOutput{req.Input},
+	}, nil
+}
+
+var _ infer.ExplicitDependencies[invWiredInput, invWiredOutput] = invWired{}
+
+func (invWired) WireDependencies(f infer.FieldSelector, _ *invWiredInput, results *invWiredOutput) {
+	f.OutputField(results).NeverSecret()
+}
+
+var _ infer.Annotated = invWired{}
+
+func (c invWired) Annotate(a infer.Annotator) { a.SetToken("index", "invWired") }
+
+func TestInferInvokeExplicitDependencies(t *testing.T) {
+	t.Parallel()
+
+	s, err := integration.NewServer(t.Context(),
+		"test",
+		semver.MustParse("0.0.0"),
+		integration.WithProvider(infer.Provider(infer.Options{
+			Functions: []infer.InferredFunction{
+				infer.Function(invWired{}),
+			},
+		})),
+	)
+	require.NoError(t, err)
+
+	resp, err := s.Invoke(p.InvokeRequest{
+		Token: "test:index:invWired",
+		Args: property.NewMap(map[string]property.Value{
+			"field": property.New("value"),
+		}),
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.Failures)
+	assert.Equal(t, property.NewMap(map[string]property.Value{
+		"field": property.New("value"),
+	}), resp.Return)
+}


### PR DESCRIPTION
We now treat `infer.Function` the same way as `infer.Resource` when applying `infer.ExplicitDependencies`.

Fixes https://github.com/pulumi/pulumi-go-provider/issues/323