### PR TITLE
Apply the `usetesting` lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,9 +10,14 @@ linters:
     - revive
     - staticcheck
     - unconvert
+    - usetesting
   disable:
     - godot
   settings:
+    usetesting:
+      os-temp-dir: true
+      context-background: true
+      context-todo: true
     revive:
       rules:
         - name: package-comments

--- a/infer/provider_builder_test.go
+++ b/infer/provider_builder_test.go
@@ -287,7 +287,7 @@ func TestWithWrapped(t *testing.T) {
 		WithWrapped(wrapped).Build()
 	require.NoError(t, err)
 
-	resp, err := p.Create(context.Background(), provider.CreateRequest{
+	resp, err := p.Create(t.Context(), provider.CreateRequest{
 		Urn: resource.URN("urn:pulumi:x::y::z:a:b::c"),
 	})
 	assert.NoError(t, err)
@@ -365,7 +365,7 @@ func TestBuildAndRun(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 
 	err = p.Run(ctx, "test-provider", "v0.0.1")

--- a/infer/resource_test.go
+++ b/infer/resource_test.go
@@ -404,7 +404,7 @@ func testHydrateFromState[O any](
 
 		ctx := testContext{
 			//nolint:revive
-			Context: context.WithValue(context.Background(), migrationsKey, migrations),
+			Context: context.WithValue(t.Context(), migrationsKey, migrations),
 		}
 
 		enc, actual, err := hydrateFromState[CustomHydrateFromState[O], struct{}, O](ctx, oldState, ende.Decode)
@@ -574,7 +574,7 @@ func TestCheck(t *testing.T) {
 		t.Run("Check "+tcName, func(t *testing.T) {
 			t.Parallel()
 			res := Resource(checkResource{})
-			checkResp, err := res.Check(context.Background(), p.CheckRequest{
+			checkResp, err := res.Check(t.Context(), p.CheckRequest{
 				Urn:    "a:b:c",
 				State:  property.Map{},
 				Inputs: tc.input,
@@ -588,7 +588,7 @@ func TestCheck(t *testing.T) {
 
 		t.Run("DefaultCheck "+tcName, func(t *testing.T) {
 			t.Parallel()
-			in, failures, err := DefaultCheck[checkResource](context.Background(), tc.input)
+			in, failures, err := DefaultCheck[checkResource](t.Context(), tc.input)
 			require.NoError(t, err)
 			assert.Empty(t, failures)
 			assert.Equal(t, tc.expected, in.P1)

--- a/middleware/complexconfig/provider_test.go
+++ b/middleware/complexconfig/provider_test.go
@@ -106,7 +106,7 @@ func TestComplexConfigEncoding(t *testing.T) {
 				},
 			})
 
-			_, err := provider.CheckConfig(context.Background(), p.CheckRequest{
+			_, err := provider.CheckConfig(t.Context(), p.CheckRequest{
 				Inputs: generateJSONEncoding(t, resource.ToResourcePropertyValue(property.New(tt.input)).ObjectValue()),
 			})
 			require.NoError(t, err)
@@ -146,7 +146,7 @@ func TestRapidComplexConfigEncoding(t *testing.T) {
 			},
 		})
 
-		_, err := provider.CheckConfig(context.Background(), p.CheckRequest{
+		_, err := provider.CheckConfig(t.Context(), p.CheckRequest{
 			Inputs: generateJSONEncoding(t, m.Copy()),
 		})
 		require.NoError(t, err)


### PR DESCRIPTION
We use this in pulumi/pulumi, and it helps LLMs avoid bad test practices.