### PR TITLE
Remove SkipNulls: true from marshal options

### DIFF
--- a/examples/wrapped/provider.go
+++ b/examples/wrapped/provider.go
@@ -119,12 +119,12 @@ func (p *xyzProvider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pu
 	label := fmt.Sprintf("%s.Diff(%s)", p.name, urn)
 	logging.V(9).Infof("%s executing", label)
 
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: true})
 	if err != nil {
 		return nil, err
 	}
 
-	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{KeepUnknowns: true})
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func (p *xyzProvider) Create(ctx context.Context, req *pulumirpc.CreateRequest) 
 	label := fmt.Sprintf("%s.Create(%s)", p.name, urn)
 	logging.V(9).Infof("%s executing", label)
 
-	inputs, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	inputs, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{KeepUnknowns: true})
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (p *xyzProvider) Create(ctx context.Context, req *pulumirpc.CreateRequest) 
 
 	outputProperties, err := plugin.MarshalProperties(
 		resource.NewPropertyMapFromMap(outputs),
-		plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true},
+		plugin.MarshalOptions{KeepUnknowns: true},
 	)
 	if err != nil {
 		return nil, err

--- a/integration/fake/monitor.go
+++ b/integration/fake/monitor.go
@@ -132,7 +132,6 @@ func (m *ResourceMonitorServer) RegisterResourceOutputs(context.Context, *pulumi
 func (m *ResourceMonitorServer) Invoke(ctx context.Context, req *pulumirpc.ResourceInvokeRequest,
 ) (*pulumirpc.InvokeResponse, error) {
 	args, err := plugin.UnmarshalProperties(req.GetArgs(), plugin.MarshalOptions{
-		SkipNulls:        false,
 		KeepUnknowns:     true,
 		KeepSecrets:      true,
 		KeepOutputValues: true,
@@ -173,7 +172,6 @@ func (m *ResourceMonitorServer) RegisterResource(ctx context.Context, in *pulumi
 	}
 
 	inputs, err := plugin.UnmarshalProperties(in.GetObject(), plugin.MarshalOptions{
-		SkipNulls:        false,
 		KeepUnknowns:     true,
 		KeepSecrets:      true,
 		KeepOutputValues: true,

--- a/internal/rpc/marshal.go
+++ b/internal/rpc/marshal.go
@@ -26,7 +26,6 @@ import (
 // This implementation is guaranteed to be lossless.
 func UnmarshalProperties(s *structpb.Struct) (property.Map, error) {
 	rm, err := plugin.UnmarshalProperties(s, plugin.MarshalOptions{
-		SkipNulls:        false,
 		KeepUnknowns:     true,
 		KeepResources:    true,
 		KeepSecrets:      true,
@@ -40,7 +39,6 @@ func UnmarshalProperties(s *structpb.Struct) (property.Map, error) {
 func MarshalProperties(m property.Map) (*structpb.Struct, error) {
 	rm := resource.ToResourcePropertyValue(property.New(m)).ObjectValue()
 	return plugin.MarshalProperties(rm, plugin.MarshalOptions{
-		SkipNulls:        false,
 		KeepUnknowns:     true,
 		KeepSecrets:      true,
 		KeepOutputValues: true,

--- a/middleware/complexconfig/provider_test.go
+++ b/middleware/complexconfig/provider_test.go
@@ -158,7 +158,6 @@ func generateJSONEncoding(t require.TestingT, m resource.PropertyMap) property.M
 			continue
 		}
 		enc, err := plugin.MarshalPropertyValue(k, v, plugin.MarshalOptions{
-			SkipNulls:        false,
 			KeepUnknowns:     true,
 			KeepSecrets:      true,
 			KeepResources:    true,
@@ -176,7 +175,6 @@ func generateJSONEncoding(t require.TestingT, m resource.PropertyMap) property.M
 // foldViaPluginMarshal removes any information from m that is not preserved on the wire.
 func foldViaPluginMarshal(t require.TestingT, m resource.PropertyMap) resource.PropertyMap {
 	opts := plugin.MarshalOptions{
-		SkipNulls:        false,
 		KeepUnknowns:     true,
 		KeepSecrets:      true,
 		KeepResources:    true,

--- a/middleware/rpc/provider.go
+++ b/middleware/rpc/provider.go
@@ -542,7 +542,6 @@ func rpcToProperty(s *structpb.Struct, previousError error) (property.Map, error
 		return property.Map{}, previousError
 	}
 	m, err := plugin.UnmarshalProperties(s, plugin.MarshalOptions{
-		SkipNulls:        false,
 		KeepUnknowns:     true,
 		KeepSecrets:      true,
 		KeepResources:    true,

--- a/provider.go
+++ b/provider.go
@@ -730,7 +730,6 @@ func (p *provider) ctx(ctx context.Context, urn presource.URN) context.Context {
 func (p *provider) getMap(s *structpb.Struct) (property.Map, error) {
 	m, err := plugin.UnmarshalProperties(s, plugin.MarshalOptions{
 		KeepUnknowns:     true,
-		SkipNulls:        true,
 		KeepResources:    true,
 		KeepSecrets:      true,
 		KeepOutputValues: true,
@@ -742,7 +741,6 @@ func (p *provider) asStruct(m property.Map) (*structpb.Struct, error) {
 	rm := presource.ToResourcePropertyMap(m)
 	return plugin.MarshalProperties(rm, plugin.MarshalOptions{
 		KeepUnknowns:     true,
-		SkipNulls:        true,
 		KeepSecrets:      true,
 		KeepOutputValues: true,
 		KeepResources:    true,

--- a/provider_test.go
+++ b/provider_test.go
@@ -18,9 +18,26 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMarshalPreservesNulls(t *testing.T) {
+	t.Parallel()
+	p := &provider{}
+	m := property.NewMap(map[string]property.Value{
+		"null":  {},
+		"value": property.New("foo"),
+	})
+
+	s, err := p.asStruct(m)
+	require.NoError(t, err)
+
+	round, err := p.getMap(s)
+	require.NoError(t, err)
+	assert.Equal(t, m, round)
+}
 
 func TestDiffResponseRPC(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Removes all `SkipNulls: true` settings from `plugin.MarshalOptions`, so nulls are preserved when marshaling and unmarshaling properties. This matches the other marshal call sites in the repository, which already set `SkipNulls: false`.