### PR TITLE
Accept byte strings

### DIFF
--- a/integration/fake/monitor.go
+++ b/integration/fake/monitor.go
@@ -151,8 +151,9 @@ func (m *ResourceMonitorServer) Invoke(ctx context.Context, req *pulumirpc.Resou
 	}
 
 	resultOut, err := plugin.MarshalProperties(result, plugin.MarshalOptions{
-		KeepSecrets:   true,
-		KeepResources: true,
+		KeepSecrets:    true,
+		KeepResources:  true,
+		KeepByteString: true,
 	})
 	if err != nil {
 		return nil, err
@@ -208,8 +209,9 @@ func (m *ResourceMonitorServer) RegisterResource(ctx context.Context, in *pulumi
 	}()
 
 	stateOut, err := plugin.MarshalProperties(state, plugin.MarshalOptions{
-		KeepSecrets:   true,
-		KeepResources: true,
+		KeepSecrets:    true,
+		KeepResources:  true,
+		KeepByteString: true,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/rpc/marshal.go
+++ b/internal/rpc/marshal.go
@@ -43,5 +43,6 @@ func MarshalProperties(m property.Map) (*structpb.Struct, error) {
 		KeepSecrets:      true,
 		KeepOutputValues: true,
 		KeepResources:    true,
+		KeepByteString:   true,
 	})
 }

--- a/middleware/rpc/provider.go
+++ b/middleware/rpc/provider.go
@@ -66,6 +66,9 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 				MapperTarget:                req.MapperAddress,
 				LoaderTarget:                req.LoaderAddress,
 				ResolverTarget:              req.ResolverAddress,
+				// Only advertise byte-string support to the wrapped server if the engine accepts byte
+				// strings, since the wrapped server's outputs are returned to the engine.
+				AcceptsByteString: req.AcceptsByteString,
 			})
 			if err != nil {
 				return p.HandshakeResponse{}, err
@@ -79,8 +82,10 @@ func Provider(server rpc.ResourceProviderServer) p.Provider {
 				AcceptOutputs:   resp.GetAcceptOutputs(),
 				SupportsPreview: true,
 			}
+			runtime.acceptsByteString = resp.GetAcceptsByteString()
 			return p.HandshakeResponse{
 				SupportsAutonamingConfiguration: resp.GetSupportsAutonamingConfiguration(),
+				RejectNonUTF8:                   !resp.GetAcceptsByteString(),
 			}, nil
 		},
 		Parameterize: func(ctx context.Context, req p.ParameterizeRequest) (p.ParameterizeResponse, error) {
@@ -521,6 +526,11 @@ func checkFailures(resp []*rpc.CheckFailure) []p.CheckFailure {
 
 type runtime struct {
 	configuration *rpc.ConfigureResponse
+
+	// True if the wrapped server accepts strings containing bytes that are not valid UTF-8. Byte-string
+	// support is negotiated at Handshake only, so unlike the other capabilities it is not part of
+	// [rpc.ConfigureResponse].
+	acceptsByteString bool
 }
 
 func (r runtime) propertyToRPC(m property.Map) (*structpb.Struct, error) {
@@ -533,6 +543,7 @@ func (r runtime) propertyToRPC(m property.Map) (*structpb.Struct, error) {
 		KeepSecrets:      r.configuration.AcceptSecrets,
 		KeepResources:    r.configuration.AcceptResources,
 		KeepOutputValues: r.configuration.AcceptOutputs,
+		KeepByteString:   r.acceptsByteString,
 	})
 	return s, err
 }

--- a/provider.go
+++ b/provider.go
@@ -86,11 +86,17 @@ type HandshakeRequest struct {
 	// package specifications to concrete dependencies. If the engine does not expose a resolver service, this field
 	// will be nil.
 	ResolverAddress *string
+	// AcceptsByteString is true if the engine accepts strings that contain bytes that are not valid UTF-8. If
+	// false, the provider must not return such strings to the engine.
+	AcceptsByteString bool
 }
 
 // HandshakeResponse is the response for the [Provider.Handshake] method.
 type HandshakeResponse struct {
 	SupportsAutonamingConfiguration bool
+	// RejectNonUTF8 is true if the provider cannot handle strings that contain bytes that are not valid
+	// UTF-8
+	RejectNonUTF8 bool
 }
 
 type GetSchemaRequest struct {
@@ -487,9 +493,12 @@ func (d Provider) WithDefaults() Provider {
 	nyi := func(fn string) error {
 		return status.Errorf(codes.Unimplemented, "%s is not implemented", fn)
 	}
+	// Handshake defaults to success rather than Unimplemented: the RPC layer answers the
+	// engine's handshake on behalf of every provider so that protocol capabilities are
+	// negotiated even when the provider has nothing to add.
 	if d.Handshake == nil {
 		d.Handshake = func(context.Context, HandshakeRequest) (HandshakeResponse, error) {
-			return HandshakeResponse{}, nyi("Handshake")
+			return HandshakeResponse{}, nil
 		}
 	}
 	if d.GetSchema == nil {
@@ -689,6 +698,11 @@ type provider struct {
 	info   RunInfo
 	host   *comProvider.HostClient
 	client Provider
+
+	// True if the engine accepts strings containing bytes that are not valid UTF-8. Unlike the other
+	// capabilities this defaults to false: it is only enabled when the engine advertises it via Handshake,
+	// since older engines cannot decode the encoding.
+	sendByteString bool
 }
 
 var _ rpc.ResourceProviderServer = (*provider)(nil)
@@ -744,6 +758,7 @@ func (p *provider) asStruct(m property.Map) (*structpb.Struct, error) {
 		KeepSecrets:      true,
 		KeepOutputValues: true,
 		KeepResources:    true,
+		KeepByteString:   p.sendByteString,
 	})
 }
 
@@ -757,6 +772,7 @@ func (p *provider) Handshake(
 		}
 		p.host = host
 	}
+	p.sendByteString = req.GetAcceptsByteString()
 	ctx = p.ctx(ctx, "")
 	resp, err := p.client.Handshake(ctx, HandshakeRequest{
 		EngineAddress:               req.GetEngineAddress(),
@@ -769,6 +785,7 @@ func (p *provider) Handshake(
 		MapperAddress:               req.MapperTarget,
 		LoaderAddress:               req.LoaderTarget,
 		ResolverAddress:             req.ResolverTarget,
+		AcceptsByteString:           req.GetAcceptsByteString(),
 	})
 	if err != nil {
 		return nil, err
@@ -777,6 +794,7 @@ func (p *provider) Handshake(
 		AcceptSecrets:                   true,
 		AcceptResources:                 true,
 		AcceptOutputs:                   true,
+		AcceptsByteString:               !resp.RejectNonUTF8,
 		SupportsAutonamingConfiguration: resp.SupportsAutonamingConfiguration,
 	}, nil
 }

--- a/tests/handshake_test.go
+++ b/tests/handshake_test.go
@@ -19,11 +19,13 @@ import (
 	"testing"
 
 	p "github.com/pulumi/pulumi-go-provider"
+	mwrpc "github.com/pulumi/pulumi-go-provider/middleware/rpc"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func TestHandshake(t *testing.T) {
@@ -57,6 +59,7 @@ func TestHandshake(t *testing.T) {
 		MapperTarget:                &mapperAddr,
 		LoaderTarget:                &loaderAddr,
 		ResolverTarget:              &resolverAddr,
+		AcceptsByteString:           true,
 	})
 	require.NoError(t, err)
 
@@ -71,22 +74,157 @@ func TestHandshake(t *testing.T) {
 		MapperAddress:               &mapperAddr,
 		LoaderAddress:               &loaderAddr,
 		ResolverAddress:             &resolverAddr,
+		AcceptsByteString:           true,
 	}, gotRequest)
 
 	assert.Equal(t, &pulumirpc.ProviderHandshakeResponse{
 		AcceptSecrets:                   true,
 		AcceptResources:                 true,
 		AcceptOutputs:                   true,
+		AcceptsByteString:               true,
 		SupportsAutonamingConfiguration: true,
 	}, resp)
 }
 
-func TestHandshakeUnimplemented(t *testing.T) {
+// Providers that don't implement Handshake still handshake successfully, advertising byte-string
+// support by default; providers that set RejectNonUTF8 do not advertise it.
+func TestHandshakeByteStringOptIn(t *testing.T) {
 	t.Parallel()
 
-	server, err := p.RawServer("test", "0.0.0-dev", p.Provider{})(nil)
-	require.NoError(t, err)
+	for _, tt := range []struct {
+		name        string
+		provider    p.Provider
+		wantAccepts bool
+	}{
+		{name: "default", provider: p.Provider{}, wantAccepts: true},
+		{name: "reject non-UTF8", provider: p.Provider{
+			Handshake: func(context.Context, p.HandshakeRequest) (p.HandshakeResponse, error) {
+				return p.HandshakeResponse{RejectNonUTF8: true}, nil
+			},
+		}, wantAccepts: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, err = server.Handshake(t.Context(), &pulumirpc.ProviderHandshakeRequest{})
-	assert.Equal(t, codes.Unimplemented, status.Code(err))
+			server, err := p.RawServer("test", "0.0.0-dev", tt.provider)(nil)
+			require.NoError(t, err)
+
+			resp, err := server.Handshake(t.Context(), &pulumirpc.ProviderHandshakeRequest{
+				AcceptsByteString: true,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, &pulumirpc.ProviderHandshakeResponse{
+				AcceptSecrets:     true,
+				AcceptResources:   true,
+				AcceptOutputs:     true,
+				AcceptsByteString: tt.wantAccepts,
+			}, resp)
+		})
+	}
+}
+
+type handshakeServer struct {
+	pulumirpc.UnimplementedResourceProviderServer
+	acceptsByteString bool
+
+	gotRequest *pulumirpc.ProviderHandshakeRequest
+}
+
+func (s *handshakeServer) Handshake(_ context.Context, req *pulumirpc.ProviderHandshakeRequest,
+) (*pulumirpc.ProviderHandshakeResponse, error) {
+	s.gotRequest = req
+	return &pulumirpc.ProviderHandshakeResponse{
+		AcceptsByteString: s.acceptsByteString,
+	}, nil
+}
+
+// The rpc middleware propagates byte-string support in both directions: the engine's acceptance is
+// forwarded to the wrapped server (whose outputs are returned to the engine), and the wrapped
+// server's acceptance is reported back so the engine knows not to send byte strings to a wrapped
+// server that cannot decode them.
+func TestMiddlewareHandshakeByteString(t *testing.T) {
+	t.Parallel()
+
+	for _, engineAccepts := range []bool{true, false} {
+		for _, serverAccepts := range []bool{true, false} {
+			server := &handshakeServer{acceptsByteString: serverAccepts}
+			resp, err := mwrpc.Provider(server).Handshake(t.Context(), p.HandshakeRequest{
+				AcceptsByteString: engineAccepts,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, engineAccepts, server.gotRequest.GetAcceptsByteString())
+			assert.Equal(t, p.HandshakeResponse{RejectNonUTF8: !serverAccepts}, resp)
+		}
+	}
+}
+
+func TestByteString(t *testing.T) {
+	t.Parallel()
+
+	byteString := "\x00hello \x80\xfe\xff world"
+
+	newServer := func(t *testing.T, create func(p.CreateRequest) (p.CreateResponse, error),
+	) pulumirpc.ResourceProviderServer {
+		server, err := p.RawServer("test", "0.0.0-dev", p.Provider{
+			Create: func(_ context.Context, req p.CreateRequest) (p.CreateResponse, error) {
+				return create(req)
+			},
+		})(nil)
+		require.NoError(t, err)
+		return server
+	}
+
+	t.Run("round-trip when the engine accepts byte strings", func(t *testing.T) {
+		t.Parallel()
+
+		var gotProperties property.Map
+		server := newServer(t, func(req p.CreateRequest) (p.CreateResponse, error) {
+			gotProperties = req.Properties
+			return p.CreateResponse{ID: "id", Properties: req.Properties}, nil
+		})
+
+		_, err := server.Handshake(t.Context(), &pulumirpc.ProviderHandshakeRequest{
+			AcceptsByteString: true,
+		})
+		require.NoError(t, err)
+
+		properties, err := plugin.MarshalProperties(resource.PropertyMap{
+			"data": resource.NewProperty(byteString),
+		}, plugin.MarshalOptions{KeepByteString: true})
+		require.NoError(t, err)
+
+		resp, err := server.Create(t.Context(), &pulumirpc.CreateRequest{
+			Urn:        "urn:pulumi:stack::proj::test:index:res::name",
+			Properties: properties,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, property.NewMap(map[string]property.Value{
+			"data": property.New(byteString),
+		}), gotProperties)
+
+		assert.Equal(t, map[string]any{
+			resource.SigKey: resource.ByteStringSig,
+			"value":         "AGhlbGxvIID+/yB3b3JsZA==",
+		}, resp.GetProperties().AsMap()["data"])
+	})
+
+	t.Run("error when the engine does not accept byte strings", func(t *testing.T) {
+		t.Parallel()
+
+		server := newServer(t, func(p.CreateRequest) (p.CreateResponse, error) {
+			return p.CreateResponse{ID: "id", Properties: property.NewMap(map[string]property.Value{
+				"data": property.New(byteString),
+			})}, nil
+		})
+
+		_, err := server.Handshake(t.Context(), &pulumirpc.ProviderHandshakeRequest{})
+		require.NoError(t, err)
+
+		_, err = server.Create(t.Context(), &pulumirpc.CreateRequest{
+			Urn: "urn:pulumi:stack::proj::test:index:res::name",
+		})
+		assert.EqualError(t, err,
+			`the value of property "data" is a string that contains non-UTF8 bytes, which the receiver does not support`)
+	})
 }


### PR DESCRIPTION
Opt pulumi-go-provider into handling byte strings by default, and expose that option downstream.

Needed to fully complete https://github.com/pulumi-labs/pulumi-hcl/issues/268.