### PR TITLE
Surface every engine-sent ConstructRequest field

### DIFF
--- a/internal/rpc/marshal.go
+++ b/internal/rpc/marshal.go
@@ -34,6 +34,41 @@ func UnmarshalProperties(s *structpb.Struct) (property.Map, error) {
 	return resource.FromResourcePropertyValue(resource.NewProperty(rm)).AsMap(), err
 }
 
+// UnmarshalPropertyValue unmarshals a single structpb.Value into a
+// property.Value; a nil input unmarshals to the null value. This implementation
+// is guaranteed to be lossless.
+func UnmarshalPropertyValue(v *structpb.Value) (property.Value, error) {
+	if v == nil {
+		return property.Value{}, nil
+	}
+	rv, err := plugin.UnmarshalPropertyValue("", v, plugin.MarshalOptions{
+		KeepUnknowns:     true,
+		KeepResources:    true,
+		KeepSecrets:      true,
+		KeepOutputValues: true,
+	})
+	if err != nil || rv == nil {
+		return property.Value{}, err
+	}
+	return resource.FromResourcePropertyValue(*rv), nil
+}
+
+// MarshalPropertyValue marshals a single property.Value into a structpb.Value;
+// the null value marshals to nil, mirroring UnmarshalPropertyValue. This
+// implementation is guaranteed to be lossless.
+func MarshalPropertyValue(v property.Value) (*structpb.Value, error) {
+	if v.IsNull() {
+		return nil, nil
+	}
+	return plugin.MarshalPropertyValue("", resource.ToResourcePropertyValue(v), plugin.MarshalOptions{
+		KeepUnknowns:     true,
+		KeepSecrets:      true,
+		KeepOutputValues: true,
+		KeepResources:    true,
+		KeepByteString:   true,
+	})
+}
+
 // MarshalProperties marshals a PropertyMap into a structpb.Struct.
 // This implementation is guaranteed to be lossless.
 func MarshalProperties(m property.Map) (*structpb.Struct, error) {

--- a/middleware/rpc/provider_test.go
+++ b/middleware/rpc/provider_test.go
@@ -96,6 +96,13 @@ func (m *mockResourceProviderServer) Create(
 	return m.cannedResp.(*pulumirpc.CreateResponse), nil
 }
 
+func (m *mockResourceProviderServer) Construct(
+	ctx context.Context, req *pulumirpc.ConstructRequest,
+) (*pulumirpc.ConstructResponse, error) {
+	m.capturedReq = req
+	return m.cannedResp.(*pulumirpc.ConstructResponse), nil
+}
+
 func (m *mockResourceProviderServer) Parameterize(
 	ctx context.Context, req *pulumirpc.ParameterizeRequest,
 ) (*pulumirpc.ParameterizeResponse, error) {
@@ -310,6 +317,73 @@ func TestParameterizeValuePassthrough(t *testing.T) {
 			return s.Parameterize
 		},
 	)
+}
+
+// TestConstructPassthrough verifies a ConstructRequest — including the
+// execution-context and resource-option fields the engine sends — passes
+// through the wrapper to the underlying provider unchanged.
+func TestConstructPassthrough(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockResourceProviderServer{cannedResp: &pulumirpc.ConfigureResponse{
+		SupportsPreview: true,
+		AcceptSecrets:   true,
+		AcceptResources: true,
+		AcceptOutputs:   true,
+	}}
+	server := wrapProvider(t, mock)
+
+	_, err := server.Configure(t.Context(), &pulumirpc.ConfigureRequest{})
+	require.NoError(t, err)
+
+	cannedResp := &pulumirpc.ConstructResponse{
+		Urn: "urn:pulumi:stack::proj::pkg:index:Comp::comp",
+		State: &structpb.Struct{Fields: map[string]*structpb.Value{
+			"out": {Kind: &structpb.Value_StringValue{StringValue: "value"}},
+		}},
+	}
+	mock.cannedResp = cannedResp
+
+	req := &pulumirpc.ConstructRequest{
+		Project:          "proj",
+		Stack:            "stack",
+		Type:             "pkg:index:Comp",
+		Name:             "comp",
+		Config:           map[string]string{"proj:apiKey": "secret"},
+		ConfigSecretKeys: []string{"proj:apiKey"},
+		Parallel:         4,
+		MonitorEndpoint:  "127.0.0.1:1234",
+		Inputs: &structpb.Struct{Fields: map[string]*structpb.Value{
+			"foo": {Kind: &structpb.Value_StringValue{StringValue: "bar"}},
+		}},
+		InputDependencies:       map[string]*pulumirpc.ConstructRequest_PropertyDependencies{},
+		Providers:               map[string]string{},
+		Aliases:                 []*pulumirpc.Alias{},
+		Dependencies:            []string{},
+		AdditionalSecretOutputs: []string{},
+		Organization:            "acme",
+		StackTraceHandle:        "handle",
+		ReplaceWith:             []string{"urn:pulumi:stack::proj::pkg:index:Other::sibling"},
+		ResourceHooks: &pulumirpc.ConstructRequest_ResourceHooksBinding{
+			BeforeCreate: []string{"bc"},
+			AfterCreate:  []string{"ac"},
+			BeforeUpdate: []string{"bu"},
+			AfterUpdate:  []string{"au"},
+			BeforeDelete: []string{"bd"},
+			AfterDelete:  []string{"ad"},
+			OnError:      []string{"oe"},
+		},
+		ReplacementTrigger:  &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "trigger"}},
+		AcceptsOutputValues: true,
+	}
+
+	resp, err := server.Construct(t.Context(), req)
+	require.NoError(t, err)
+
+	assert.Equal(t, req, mock.capturedReq,
+		"Request should be passed through to underlying provider unchanged")
+	assert.Equal(t, cannedResp, resp,
+		"Response should be passed through from underlying provider unchanged")
 }
 
 func TestCreatePreviewWithoutSupport(t *testing.T) {

--- a/provider.go
+++ b/provider.go
@@ -1421,6 +1421,38 @@ type ConstructRequest struct {
 	// RetainOnDelete is true if deletion of the resource should not
 	// delete the resource in the provider.
 	RetainOnDelete *bool
+
+	// Organization is the organization of the stack being deployed into.
+	Organization string
+
+	// ResourceHooks binds resource hook names to the lifecycle events of the
+	// component (and by extension, its nested resources).
+	ResourceHooks *ResourceHooksBinding
+
+	// StackTraceHandle supports stitching stack traces together across
+	// plugins.
+	StackTraceHandle string
+
+	// ReplaceWith is the set of URNs of resources whose replacement should
+	// also trigger a replacement of this resource.
+	ReplaceWith []presource.URN
+
+	// ReplacementTrigger is an arbitrary value the engine diffs against its
+	// last recorded value, triggering a replacement when they are not equal.
+	// The null value means no trigger is set.
+	ReplacementTrigger property.Value
+}
+
+// ResourceHooksBinding binds resource hook names to a resource's lifecycle
+// events.
+type ResourceHooksBinding struct {
+	BeforeCreate []string
+	AfterCreate  []string
+	BeforeUpdate []string
+	AfterUpdate  []string
+	BeforeDelete []string
+	AfterDelete  []string
+	OnError      []string
 }
 
 // ProviderReference is a (URN, ID) tuple that refers to a particular provider instance.
@@ -1552,6 +1584,31 @@ func newConstructRequest(req *rpc.ConstructRequest,
 		IgnoreChanges:       req.IgnoreChanges,
 		ReplaceOnChanges:    req.ReplaceOnChanges,
 		RetainOnDelete:      req.RetainOnDelete,
+		Organization:        req.GetOrganization(),
+		StackTraceHandle:    req.GetStackTraceHandle(),
+		ReplaceWith:         toUrns(req.GetReplaceWith()),
+		ReplacementTrigger: func() property.Value {
+			v, err := internalrpc.UnmarshalPropertyValue(req.GetReplacementTrigger())
+			if err != nil {
+				errs.Errors = append(errs.Errors, fmt.Errorf("invalid replacement trigger: %w", err))
+			}
+			return v
+		}(),
+		ResourceHooks: func() *ResourceHooksBinding {
+			h := req.GetResourceHooks()
+			if h == nil {
+				return nil
+			}
+			return &ResourceHooksBinding{
+				BeforeCreate: h.GetBeforeCreate(),
+				AfterCreate:  h.GetAfterCreate(),
+				BeforeUpdate: h.GetBeforeUpdate(),
+				AfterUpdate:  h.GetAfterUpdate(),
+				BeforeDelete: h.GetBeforeDelete(),
+				AfterDelete:  h.GetAfterDelete(),
+				OnError:      h.GetOnError(),
+			}
+		}(),
 		CustomTimeouts: func() *presource.CustomTimeouts {
 			t := req.GetCustomTimeouts()
 			if t == nil {
@@ -1599,6 +1656,11 @@ func (c ConstructRequest) rpc(marshal propertyToRPC) *rpc.ConstructRequest {
 		return nil
 	}
 
+	trigger, err := internalrpc.MarshalPropertyValue(c.ReplacementTrigger)
+	if err != nil {
+		return nil
+	}
+
 	req := &rpc.ConstructRequest{
 		Project: string(c.Urn.Project()),
 		Stack:   string(c.Urn.Stack()),
@@ -1639,7 +1701,23 @@ func (c ConstructRequest) rpc(marshal propertyToRPC) *rpc.ConstructRequest {
 		IgnoreChanges:           c.IgnoreChanges,
 		ReplaceOnChanges:        c.ReplaceOnChanges,
 		RetainOnDelete:          c.RetainOnDelete,
+		Organization:            c.Organization,
+		StackTraceHandle:        c.StackTraceHandle,
+		ReplaceWith:             fromUrns(c.ReplaceWith),
+		ReplacementTrigger:      trigger,
 		AcceptsOutputValues:     true,
+	}
+
+	if h := c.ResourceHooks; h != nil {
+		req.ResourceHooks = &rpc.ConstructRequest_ResourceHooksBinding{
+			BeforeCreate: h.BeforeCreate,
+			AfterCreate:  h.AfterCreate,
+			BeforeUpdate: h.BeforeUpdate,
+			AfterUpdate:  h.AfterUpdate,
+			BeforeDelete: h.BeforeDelete,
+			AfterDelete:  h.AfterDelete,
+			OnError:      h.OnError,
+		}
 	}
 
 	if ct := c.CustomTimeouts; ct != nil {

--- a/provider_test.go
+++ b/provider_test.go
@@ -18,9 +18,16 @@ import (
 	"context"
 	"testing"
 
+	presource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	pconfig "github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	internalrpc "github.com/pulumi/pulumi-go-provider/internal/rpc"
 )
 
 func TestMarshalPreservesNulls(t *testing.T) {
@@ -226,4 +233,68 @@ func TestGetSchema(t *testing.T) {
 		assert.Equal(t, "mypackage", spec.Name)
 		assert.Equal(t, "1.0.0", spec.Version)
 	})
+}
+
+// TestConstructRequestRPC verifies the proto ConstructRequest translates into
+// the public ConstructRequest — including the execution-context and
+// resource-option fields the engine sends — and that the reverse translation
+// loses none of it: a request round-tripped through rpc() reads back equal.
+func TestConstructRequestRPC(t *testing.T) {
+	t.Parallel()
+
+	req := &rpc.ConstructRequest{
+		Project:          "proj",
+		Stack:            "stack",
+		Type:             "pkg:index:Comp",
+		Name:             "comp",
+		Organization:     "acme",
+		StackTraceHandle: "handle",
+		ReplaceWith:      []string{"urn:pulumi:stack::proj::pkg:index:Other::sibling"},
+		ResourceHooks: &rpc.ConstructRequest_ResourceHooksBinding{
+			BeforeCreate: []string{"bc"},
+			AfterCreate:  []string{"ac"},
+			BeforeUpdate: []string{"bu"},
+			AfterUpdate:  []string{"au"},
+			BeforeDelete: []string{"bd"},
+			AfterDelete:  []string{"ad"},
+			OnError:      []string{"oe"},
+		},
+		ReplacementTrigger:  structpb.NewStringValue("trigger"),
+		AcceptsOutputValues: true,
+	}
+
+	got, err := newConstructRequest(req, internalrpc.UnmarshalProperties)
+	require.NoError(t, err)
+
+	assert.Equal(t, ConstructRequest{
+		Urn:                     presource.NewURN("stack", "proj", "", "pkg:index:Comp", "comp"),
+		Config:                  map[pconfig.Key]string{},
+		ConfigSecretKeys:        []pconfig.Key{},
+		MonitorEndpoint:         "",
+		Inputs:                  property.Map{},
+		Providers:               map[tokens.Package]ProviderReference{},
+		Aliases:                 []presource.URN{},
+		Dependencies:            []presource.URN{},
+		AdditionalSecretOutputs: []string{},
+		Organization:            "acme",
+		StackTraceHandle:        "handle",
+		ReplaceWith:             []presource.URN{"urn:pulumi:stack::proj::pkg:index:Other::sibling"},
+		ResourceHooks: &ResourceHooksBinding{
+			BeforeCreate: []string{"bc"},
+			AfterCreate:  []string{"ac"},
+			BeforeUpdate: []string{"bu"},
+			AfterUpdate:  []string{"au"},
+			BeforeDelete: []string{"bd"},
+			AfterDelete:  []string{"ad"},
+			OnError:      []string{"oe"},
+		},
+		ReplacementTrigger: property.New("trigger"),
+	}, got)
+
+	// The reverse translation must preserve everything the forward translation
+	// reads: converting back to a proto request and re-parsing it yields the
+	// same request.
+	again, err := newConstructRequest(got.rpc(internalrpc.MarshalProperties), internalrpc.UnmarshalProperties)
+	require.NoError(t, err)
+	assert.Equal(t, got, again)
 }


### PR DESCRIPTION
The proto `ConstructRequest` carries `organization`, `resource_hooks`, `stack_trace_handle`, `replace_with`, and `replacement_trigger`, but `newConstructRequest` never read them — component providers silently lost those execution-context and resource-option fields.

This adds all five to `p.ConstructRequest`, maps them in both `newConstructRequest` and the reverse `ConstructRequest.rpc` (round-trip proven lossless by `TestConstructRequestRPC`), and adds single-value marshal helpers to `internal/rpc`.

`ReplacementTrigger` is a `property.Value` where null means "no trigger set" — the engine's own convention: it normalizes an absent field to the null property on intake, its diff treats null as no-trigger (`shouldTriggerReplace`), and it omits the field when marshaling a null trigger.