### PR TITLE
Breaking change: Pass through full alias specs in ConstructRequest

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -1384,7 +1384,7 @@ type ConstructRequest struct {
 	Inputs property.Map
 
 	// Aliases is the set of aliases for the component.
-	Aliases []presource.URN
+	Aliases []presource.Alias
 
 	// Dependencies is the list of resources this component depends on, i.e. the DependsOn resource option.
 	Dependencies []presource.URN
@@ -1469,22 +1469,48 @@ func toUrns(s []string) []presource.URN {
 	return r
 }
 
-func aliasesFromURNs(s []presource.URN) []*rpc.Alias {
+func aliasesToRPC(s []presource.Alias) []*rpc.Alias {
 	r := make([]*rpc.Alias, len(s))
-	for i, a := range s {
-		r[i] = &rpc.Alias{
-			Alias: &rpc.Alias_Urn{Urn: string(a)},
+	for i, alias := range s {
+		if alias.URN != "" {
+			r[i] = &rpc.Alias{Alias: &rpc.Alias_Urn{Urn: string(alias.URN)}}
+			continue
 		}
+		spec := &rpc.Alias_Spec{
+			Type:    alias.Type,
+			Name:    alias.Name,
+			Stack:   alias.Stack,
+			Project: alias.Project,
+		}
+		if alias.NoParent {
+			spec.Parent = &rpc.Alias_Spec_NoParent{NoParent: true}
+		} else if alias.Parent != "" {
+			spec.Parent = &rpc.Alias_Spec_ParentUrn{ParentUrn: string(alias.Parent)}
+		}
+		r[i] = &rpc.Alias{Alias: &rpc.Alias_Spec_{Spec: spec}}
 	}
 	return r
 }
 
-func aliasesToURNs(s []*rpc.Alias) []presource.URN {
-	r := make([]presource.URN, 0, len(s))
-	for _, a := range s {
-		urn := presource.URN(a.GetUrn())
-		if urn != "" {
-			r = append(r, urn)
+func aliasesFromRPC(s []*rpc.Alias) []presource.Alias {
+	r := make([]presource.Alias, len(s))
+	for i, alias := range s {
+		switch a := alias.GetAlias().(type) {
+		case *rpc.Alias_Spec_:
+			r[i] = presource.Alias{
+				Name:    a.Spec.GetName(),
+				Type:    a.Spec.GetType(),
+				Project: a.Spec.GetProject(),
+				Stack:   a.Spec.GetStack(),
+			}
+			switch p := a.Spec.GetParent().(type) {
+			case *rpc.Alias_Spec_ParentUrn:
+				r[i].Parent = presource.URN(p.ParentUrn)
+			case *rpc.Alias_Spec_NoParent:
+				r[i].NoParent = p.NoParent
+			}
+		case *rpc.Alias_Urn:
+			r[i] = presource.Alias{URN: presource.URN(a.Urn)}
 		}
 	}
 	return r
@@ -1570,7 +1596,7 @@ func newConstructRequest(req *rpc.ConstructRequest,
 			}
 			return m
 		}(),
-		Aliases:      aliasesToURNs(req.GetAliases()),
+		Aliases:      aliasesFromRPC(req.GetAliases()),
 		Dependencies: toUrns(req.GetDependencies()),
 		AdditionalSecretOutputs: func() []string {
 			r := make([]string, len(req.GetAdditionalSecretOutputs()))
@@ -1693,7 +1719,7 @@ func (c ConstructRequest) rpc(marshal propertyToRPC) *rpc.ConstructRequest {
 			}
 			return m
 		}(),
-		Aliases:                 aliasesFromURNs(c.Aliases),
+		Aliases:                 aliasesToRPC(c.Aliases),
 		Dependencies:            fromUrns(c.Dependencies),
 		AdditionalSecretOutputs: c.AdditionalSecretOutputs,
 		DeletedWith:             string(c.DeletedWith),

--- a/provider_test.go
+++ b/provider_test.go
@@ -250,6 +250,18 @@ func TestConstructRequestRPC(t *testing.T) {
 		Organization:     "acme",
 		StackTraceHandle: "handle",
 		ReplaceWith:      []string{"urn:pulumi:stack::proj::pkg:index:Other::sibling"},
+		Aliases: []*rpc.Alias{
+			{Alias: &rpc.Alias_Urn{Urn: "urn:pulumi:stack::proj::pkg:index:Comp::old"}},
+			{Alias: &rpc.Alias_Spec_{Spec: &rpc.Alias_Spec{
+				Type:   "pkg:index:Old",
+				Name:   "old",
+				Parent: &rpc.Alias_Spec_NoParent{NoParent: true},
+			}}},
+			{Alias: &rpc.Alias_Spec_{Spec: &rpc.Alias_Spec{
+				Type:   "pkg:index:Old",
+				Parent: &rpc.Alias_Spec_ParentUrn{ParentUrn: "urn:pulumi:stack::proj::pkg:index:Parent::p"},
+			}}},
+		},
 		ResourceHooks: &rpc.ConstructRequest_ResourceHooksBinding{
 			BeforeCreate: []string{"bc"},
 			AfterCreate:  []string{"ac"},
@@ -267,13 +279,17 @@ func TestConstructRequestRPC(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, ConstructRequest{
-		Urn:                     presource.NewURN("stack", "proj", "", "pkg:index:Comp", "comp"),
-		Config:                  map[pconfig.Key]string{},
-		ConfigSecretKeys:        []pconfig.Key{},
-		MonitorEndpoint:         "",
-		Inputs:                  property.Map{},
-		Providers:               map[tokens.Package]ProviderReference{},
-		Aliases:                 []presource.URN{},
+		Urn:              presource.NewURN("stack", "proj", "", "pkg:index:Comp", "comp"),
+		Config:           map[pconfig.Key]string{},
+		ConfigSecretKeys: []pconfig.Key{},
+		MonitorEndpoint:  "",
+		Inputs:           property.Map{},
+		Providers:        map[tokens.Package]ProviderReference{},
+		Aliases: []presource.Alias{
+			{URN: "urn:pulumi:stack::proj::pkg:index:Comp::old"},
+			{Type: "pkg:index:Old", Name: "old", NoParent: true},
+			{Type: "pkg:index:Old", Parent: "urn:pulumi:stack::proj::pkg:index:Parent::p"},
+		},
 		Dependencies:            []presource.URN{},
 		AdditionalSecretOutputs: []string{},
 		Organization:            "acme",

--- a/tests/grpc/construct_test.go
+++ b/tests/grpc/construct_test.go
@@ -64,7 +64,7 @@ func TestConstruct(t *testing.T) {
     "type": "test:index:Component",
     "name": "test-component",
     "parent": "urn:pulumi:test::test::test:index:Parent::parent",
-	"aliases": [{"urn": "urn2"}],
+	"aliases": [{"urn": "urn2"}, {"spec": {"type": "test:index:Component", "name": "old-name", "noParent": true}}],
     "inputs": {
       "k1": "s"
     },
@@ -116,7 +116,10 @@ func TestConstruct(t *testing.T) {
 			config.MustParseKey("test:c2"): "3.14",
 		}, req.Config)
 		assert.Equal(t, []config.Key{config.MustParseKey("test:c1")}, req.ConfigSecretKeys)
-		assert.Equal(t, []resource.URN{"urn2"}, req.Aliases)
+		assert.Equal(t, []resource.Alias{
+			{URN: "urn2"},
+			{Type: "test:index:Component", Name: "old-name", NoParent: true},
+		}, req.Aliases)
 		assert.Equal(t, []resource.URN{"urn3"}, req.Dependencies)
 		assert.Equal(t, &_true, req.Protect)
 		assert.Equal(t, map[tokens.Package]p.ProviderReference{


### PR DESCRIPTION
Fixes #465.

Since pulumi/pulumi#21050, aliases on a gRPC `ConstructRequest` arrive as either concrete URNs or alias specs (type, name, project, stack, parent, noParent). #464 patched the SDK update by keeping `ConstructRequest.Aliases` as `[]resource.URN`, which silently dropped every spec-form alias before it reached the component's nested resource registrations.

`ConstructRequest.Aliases` is now `[]resource.Alias`, and both translation directions (`newConstructRequest` and `ConstructRequest.rpc`) preserve the full alias, mirroring the conversions in pulumi/pulumi's `provider_server.go` / `provider_plugin.go`.

**Breaking change**: the type of `ConstructRequest.Aliases` changes from `[]resource.URN` to `[]resource.Alias`. A URN-only alias is represented as `resource.Alias{URN: ...}`.