### PR TITLE
Do not re-apply ignoreChanges from state in Diff and Update

### DIFF
--- a/infer/resource.go
+++ b/infer/resource.go
@@ -1162,13 +1162,11 @@ func diff[R, I, O any](
 	ctx context.Context, req p.DiffRequest, r *R, forceReplace func(string) bool,
 	decode func(property.Map) (ende.Encoder, O, mapper.MappingError),
 ) (p.DiffResponse, error) {
-	for _, ignoredChange := range req.IgnoreChanges {
-		v, ok := req.State.GetOk(ignoredChange)
-		if ok {
-			req.Inputs = req.Inputs.Set(ignoredChange, v)
-		}
-	}
-
+	// req.IgnoreChanges is deliberately not applied here: the engine resets ignored
+	// input paths back to their old *input* values before calling Check, Diff or
+	// Update (processIgnoreChanges in pulumi/pulumi's step generator). Re-applying
+	// them here from req.State would substitute old *output* values and manufacture
+	// phantom diffs (https://github.com/pulumi/pulumi-go-provider/issues/565).
 	for k := range req.Inputs.All {
 		// We ignore version input from the engine and any underscore-prefixed
 		// properties as they're assumed to be internal.
@@ -1422,13 +1420,6 @@ func (rc *derivedResourceController[R, I, O]) Update(
 		return p.UpdateResponse{}, status.Errorf(codes.Unimplemented,
 			"Update is not implemented for resource %s", req.Urn)
 	}
-	for _, ignoredChange := range req.IgnoreChanges {
-		v, ok := req.State.GetOk(ignoredChange)
-		if ok {
-			req.Inputs = req.Inputs.Set(ignoredChange, v)
-		}
-	}
-
 	_, olds, err := hydrateFromState[R, I, O](ctx, req.State, ende.Decode)
 	if err != nil {
 		return p.UpdateResponse{}, err

--- a/tests/grpc/ignore_changes_consumer/Pulumi.yaml
+++ b/tests/grpc/ignore_changes_consumer/Pulumi.yaml
@@ -1,0 +1,16 @@
+name: test
+runtime: yaml
+
+plugins:
+  providers:
+    - name: test
+      path: .
+
+resources:
+  team:
+    type: test:index:Team
+    properties:
+      slug: a
+    options:
+      ignoreChanges:
+        - members

--- a/tests/grpc/ignore_changes_consumer/step2/Pulumi.yaml
+++ b/tests/grpc/ignore_changes_consumer/step2/Pulumi.yaml
@@ -1,0 +1,16 @@
+name: test
+runtime: yaml
+
+plugins:
+  providers:
+    - name: test
+      path: .
+
+resources:
+  team:
+    type: test:index:Team
+    properties:
+      slug: b
+    options:
+      ignoreChanges:
+        - members

--- a/tests/grpc/ignore_changes_provider/main.go
+++ b/tests/grpc/ignore_changes_provider/main.go
@@ -1,0 +1,88 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This provider reproduces https://github.com/pulumi/pulumi-go-provider/issues/565: a
+// resource whose live "members" output is managed out-of-band and so never matches the
+// program's (absent) input. With `ignoreChanges: ["members"]` the engine must see no
+// diff, and Update must never observe the old output value as an input.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/pulumi/pulumi-go-provider/infer"
+)
+
+type Team struct{}
+
+type TeamArgs struct {
+	Slug    string   `pulumi:"slug"`
+	Members []string `pulumi:"members,optional"`
+}
+
+type TeamState struct {
+	Slug    string   `pulumi:"slug"`
+	Members []string `pulumi:"members"`
+}
+
+func (*Team) Create(
+	ctx context.Context, req infer.CreateRequest[TeamArgs],
+) (infer.CreateResponse[TeamState], error) {
+	return infer.CreateResponse[TeamState]{
+		ID: req.Name,
+		Output: TeamState{
+			Slug: req.Inputs.Slug,
+			// Simulate drift: membership is reconciled externally, so the live
+			// list never matches the program's (absent) input.
+			Members: []string{"external"},
+		},
+	}, nil
+}
+
+var _ = (infer.CustomUpdate[TeamArgs, TeamState])((*Team)(nil))
+
+func (*Team) Update(
+	ctx context.Context, req infer.UpdateRequest[TeamArgs, TeamState],
+) (infer.UpdateResponse[TeamState], error) {
+	// "members" is under ignoreChanges: the engine resets it to the old input
+	// (absent). Seeing a value here means the provider re-injected the old
+	// *output* from state, which is the bug pinned by this test.
+	if req.Inputs.Members != nil {
+		return infer.UpdateResponse[TeamState]{}, fmt.Errorf(
+			"update saw members %v as an input; ignored properties must keep their old input (absent)",
+			req.Inputs.Members)
+	}
+	return infer.UpdateResponse[TeamState]{
+		Output: TeamState{
+			Slug:    req.Inputs.Slug,
+			Members: req.State.Members,
+		},
+	}, nil
+}
+
+func main() {
+	provider, err := infer.NewProviderBuilder().
+		WithNamespace("pulumi").
+		WithResources(infer.Resource(&Team{})).
+		Build()
+	if err == nil {
+		err = provider.Run(context.Background(), "test", "0.1.0")
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		os.Exit(1)
+	}
+}

--- a/tests/grpc/ignore_changes_test.go
+++ b/tests/grpc/ignore_changes_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIgnoreChangesLifecycle pins the engine-level contract for `ignoreChanges` against
+// https://github.com/pulumi/pulumi-go-provider/issues/565.
+//
+// The test resource's live "members" output always drifts from the program's (absent)
+// input. With `ignoreChanges: ["members"]`:
+//
+//   - the `--expect-no-changes` preview/update that ProgramTest runs after the initial
+//     deployment must see no diff (no phantom `+ members` from substituting old outputs
+//     for old inputs), and
+//   - the step2 edit (slug change) triggers an Update, which fails inside the provider
+//     if the ignored property arrives carrying the old output value.
+func TestIgnoreChangesLifecycle(t *testing.T) {
+	cmd := exec.CommandContext(t.Context(), "go", "build",
+		"-o", "ignore_changes_consumer/pulumi-resource-test", "./ignore_changes_provider")
+	require.NoError(t, cmd.Run(), strings.Join(cmd.Args, " "))
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir: "ignore_changes_consumer",
+		EditDirs: []integration.EditDir{{
+			Dir:      "ignore_changes_consumer/step2",
+			Additive: true,
+		}},
+	})
+}


### PR DESCRIPTION
Fixes #565. Fixes #103.

## Problem

The infer layer reset each property in `ignoreChanges` to its value from the old **output** state before diffing and updating:

```go
for _, ignoredChange := range req.IgnoreChanges {
	v, ok := req.State.GetOk(ignoredChange)
	if ok {
		req.Inputs = req.Inputs.Set(ignoredChange, v)
	}
}
```

The engine already resets ignored input paths to their old **input** values before Check, Diff, or Update run (`processIgnoreChanges` in pulumi/pulumi's step generator), so this code both undid the engine's correct reset and substituted output values for input values. When a resource's live output drifts from its declared input — the external-reconciler pattern from #565, e.g. `pulumiservice.Team` with membership managed out-of-band — this manufactured a perpetual phantom diff (`+ [0]: <null>`) on the ignored property, and leaked the old output into the inputs seen by `Update`. (It was also path-unaware: nested paths like `metadata.labels` were treated as flat map keys.)

This answers the question in #103: the engine does handle `ignoreChanges`, and the provider-side code was not only unnecessary but incorrect.

## Fix

Delete both loops, with a comment in `diff` recording why no provider-side handling exists.

## Test

`TestIgnoreChangesLifecycle` pins the engine-level contract by running a real provider binary under the Pulumi CLI (`integration.ProgramTest`, same pattern as `TestConstructLifecycle`). The test resource's live `members` output always drifts from the program's absent input, under `ignoreChanges: ["members"]`:

- the `--expect-no-changes` preview after the initial deployment catches any phantom diff, and
- an edit step changes another property to force an `Update`, which errors inside the provider if the ignored property arrives carrying the old output value.

Verified against the pre-fix code the test fails with exactly the issue's symptoms: `+ members: [unknown]` on the empty preview, and `update saw members [external] as an input`.
