### PR TITLE
Mark input fields with an in-memory default as required outputs

### DIFF
--- a/infer/schema.go
+++ b/infer/schema.go
@@ -295,7 +295,10 @@ func propertyListFromType(typ reflect.Type, indicatePlain bool, propType propert
 		if err != nil {
 			return nil, nil, fmt.Errorf("invalid type '%s' on '%s.%s': %w", fieldType, typ, field.Name, err)
 		}
-		if !tags.Optional {
+		// A field with an in-memory default is always populated on outputs, so it
+		// is required there even when optional on inputs. Env-only defaults don't
+		// guarantee population (the variable may be unset), so they stay optional.
+		if !tags.Optional || (propType == outputType && annotations.Defaults[tags.Name] != nil) {
 			required = append(required, tags.Name)
 		}
 		spec := &schema.PropertySpec{

--- a/infer/schema_test.go
+++ b/infer/schema_test.go
@@ -72,4 +72,9 @@ func TestResourceAnnotations(t *testing.T) {
 	assert.Equal(t, "This is an embedded property.", p2.Description)
 	assert.Equal(t, "default2", p2.Default)
 	assert.Equal(t, "This field is also deprecated.", p2.DeprecationMessage)
+
+	// Optional fields with a default value are always populated, so they are
+	// required on outputs while staying optional on inputs.
+	assert.Equal(t, []string{"p2", "p1"}, spec.Required)
+	assert.Equal(t, []string(nil), spec.RequiredInputs)
 }

--- a/infer/tests/schema_test.go
+++ b/infer/tests/schema_test.go
@@ -192,6 +192,7 @@ func TestGetSchema(t *testing.T) {
         "other": { "$ref": "#/types/test:index:RecursiveArgs" },
         "value": { "type": "string", "default": "default-value" }
       },
+      "required": ["value"],
       "inputProperties": {
         "other": { "$ref": "#/types/test:index:RecursiveArgs" },
         "value": { "type": "string", "default": "default-value" }
@@ -254,7 +255,7 @@ func TestGetSchema(t *testing.T) {
         "pi": { "type": "integer", "default": 2 },
         "s": { "type": "string", "default": "one" }
       },
-      "required": ["nestedPtr"],
+      "required": ["s", "pi", "nestedPtr"],
       "inputProperties": {
         "arrNested": {
           "type": "array",


### PR DESCRIPTION
An optional input field with a default value set via `infer.Annotator.SetDefault` is always populated, since `applyDefaults` applies the default whenever the field is unset. The field is therefore guaranteed to be present on the resource's outputs, so it now appears in the output `required` set while remaining optional on inputs. Generated SDKs then type such fields as non-nullable on state.

Fields whose default comes only from an environment variable stay optional on outputs, since the variable may be unset at runtime.

Fixes #537.