### PR TITLE
feat: let a component learn its own plugin identity

### DIFF
--- a/infer/provider.go
+++ b/infer/provider.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/internal/key"
 	t "github.com/pulumi/pulumi-go-provider/middleware"
 	"github.com/pulumi/pulumi-go-provider/middleware/cancel"
 	"github.com/pulumi/pulumi-go-provider/middleware/complexconfig" //nolint:staticcheck
@@ -170,6 +171,16 @@ func Wrap(provider p.Provider, opts Options) p.Provider {
 		provider.CheckConfig = config.checkConfig
 		provider = mContext.Wrap(provider, func(ctx context.Context) context.Context {
 			return context.WithValue(ctx, configKey, opts.Config)
+		})
+	}
+
+	// Publish the provider's own plugin download URL on the context, so a component
+	// registering a resource of this package from inside Construct can stamp it onto
+	// that resource. The Construct gRPC request carries no such field, and the version
+	// alongside it already rides on [p.RunInfo]. See [p.GetPluginIdentity].
+	if url := opts.PluginDownloadURL; url != "" {
+		provider = mContext.Wrap(provider, func(ctx context.Context) context.Context {
+			return context.WithValue(ctx, key.PluginDownloadURL, url)
 		})
 	}
 

--- a/infer/tests/plugin_identity_test.go
+++ b/infer/tests/plugin_identity_test.go
@@ -1,0 +1,200 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi-go-provider/integration"
+	"github.com/pulumi/pulumi-go-provider/middleware/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const identityDownloadURL = "github://api.github.com/example/pulumi-identity"
+
+// identityModuleMap maps this test package's Go package name onto the "index" module,
+// matching the rest of the suite.
+var identityModuleMap = map[tokens.ModuleName]tokens.ModuleName{"tests": "index"}
+
+// identityChild is a resource the component below registers itself, the way a component
+// provider registers a resource of its own package from inside Construct.
+type identityChild struct {
+	pulumi.ResourceState
+}
+
+type IdentityComponentArgs struct{}
+
+type IdentityComponent struct {
+	pulumi.ResourceState
+	IdentityComponentArgs
+}
+
+// NewIdentityComponent registers one child of its own package, stamped with the running
+// provider's plugin identity, and one child of a foreign package, deliberately left
+// alone.
+func NewIdentityComponent(ctx *pulumi.Context, name string, args IdentityComponentArgs,
+	opts ...pulumi.ResourceOption,
+) (*IdentityComponent, error) {
+	comp := &IdentityComponent{}
+	if err := ctx.RegisterComponentResource(p.GetTypeToken(ctx), name, comp, opts...); err != nil {
+		return nil, err
+	}
+
+	self := p.GetPluginIdentity(ctx.Context())
+
+	child := &identityChild{}
+	err := ctx.RegisterResource("test:index:IdentityChild", name+"-child", pulumi.Map{}, child,
+		append(self.ResourceOptions(), pulumi.Parent(comp))...)
+	if err != nil {
+		return nil, err
+	}
+
+	foreign := &identityChild{}
+	err = ctx.RegisterResource("other:index:Thing", name+"-foreign", pulumi.Map{}, foreign,
+		pulumi.Parent(comp))
+	if err != nil {
+		return nil, err
+	}
+
+	return comp, nil
+}
+
+// registration is the subset of a RegisterResource call this test asserts on.
+type registration struct {
+	version     string
+	downloadURL string
+}
+
+// TestConstructStampsOwnPluginIdentity asserts that a component can learn the identity of
+// the plugin serving it, and that applying it records both the version and the download
+// URL on a self-registered resource. Without them the engine writes a provider carrying
+// neither, and resolves the plugin from github.com/pulumi/pulumi-<name>, which does not
+// exist for a third-party provider.
+func TestConstructStampsOwnPluginIdentity(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	seen := map[string]registration{}
+
+	prov := identityProvider(t, &integration.MockResourceMonitor{
+		NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
+			if rpc := args.RegisterRPC; rpc != nil {
+				mu.Lock()
+				seen[string(args.TypeToken)] = registration{
+					version:     rpc.GetVersion(),
+					downloadURL: rpc.GetPluginDownloadURL(),
+				}
+				mu.Unlock()
+			}
+			return args.ID, property.Map{}, nil
+		},
+	})
+
+	_, err := prov.Construct(p.ConstructRequest{
+		Urn:    childUrn("IdentityComponent", "test-component", "test-parent"),
+		Parent: urn("Parent", "test-parent"),
+		Inputs: property.Map{},
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	own, ok := seen["test:index:IdentityChild"]
+	require.True(t, ok, "the component's own child was never registered; seen: %v", seen)
+	assert.Equal(t, "1.0.0", own.version,
+		"a self-registered resource must record the version of the plugin that created it")
+	assert.Equal(t, identityDownloadURL, own.downloadURL,
+		"a self-registered resource must record where its plugin can be downloaded from")
+
+	// The identity names one specific plugin, so it must not leak onto resources of
+	// other packages — that would send the engine looking for their plugin at our
+	// version and our URL.
+	foreign, ok := seen["other:index:Thing"]
+	require.True(t, ok, "the foreign child was never registered; seen: %v", seen)
+	assert.Empty(t, foreign.version)
+	assert.Empty(t, foreign.downloadURL)
+}
+
+// TestGetPluginIdentityWithoutDownloadURL covers a provider that never set one: the
+// version still comes through, and the call does not fail.
+func TestGetPluginIdentityWithoutDownloadURL(t *testing.T) {
+	t.Parallel()
+
+	var got p.PluginIdentity
+	prov, err := integration.NewServer(t.Context(), "test", semver.MustParse("1.0.0"),
+		integration.WithProvider(infer.Provider(infer.Options{
+			ModuleMap: identityModuleMap,
+			Components: []infer.InferredComponent{
+				infer.ComponentF(func(ctx *pulumi.Context, name string, args IdentityComponentArgs,
+					opts ...pulumi.ResourceOption,
+				) (*IdentityComponent, error) {
+					got = p.GetPluginIdentity(ctx.Context())
+					comp := &IdentityComponent{}
+					err := ctx.RegisterComponentResource(p.GetTypeToken(ctx), name, comp, opts...)
+					return comp, err
+				}),
+			},
+		})),
+		integration.WithMocks(&integration.MockResourceMonitor{
+			NewResourceF: func(args integration.MockResourceArgs) (string, property.Map, error) {
+				return args.ID, property.Map{}, nil
+			},
+		}),
+	)
+	require.NoError(t, err)
+
+	_, err = prov.Construct(p.ConstructRequest{
+		Urn:    childUrn("IdentityComponent", "test-component", "test-parent"),
+		Parent: urn("Parent", "test-parent"),
+		Inputs: property.Map{},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "test", got.Package)
+	assert.Equal(t, "1.0.0", got.Version)
+	assert.Empty(t, got.DownloadURL)
+	applied, err := pulumi.NewResourceOptions(got.ResourceOptions()...)
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0", applied.Version)
+	assert.Empty(t, applied.PluginDownloadURL, "no URL option is produced when the provider set none")
+}
+
+func identityProvider(t testing.TB, mocks pulumi.MockResourceMonitor) integration.Server {
+	prov := infer.Provider(infer.Options{
+		Metadata: schema.Metadata{
+			PluginDownloadURL: identityDownloadURL,
+		},
+		ModuleMap: identityModuleMap,
+		Components: []infer.InferredComponent{
+			infer.ComponentF(NewIdentityComponent),
+		},
+	})
+	s, err := integration.NewServer(t.Context(), "test", semver.MustParse("1.0.0"),
+		integration.WithProvider(prov),
+		integration.WithMocks(mocks),
+	)
+	require.NoError(t, err)
+	return s
+}

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -19,10 +19,11 @@
 package key
 
 type (
-	runtimeInfoType  struct{}
-	logType          struct{}
-	urnType          struct{}
-	providerHostType struct{}
+	runtimeInfoType       struct{}
+	logType               struct{}
+	urnType               struct{}
+	providerHostType      struct{}
+	pluginDownloadURLType struct{}
 )
 
 var (
@@ -34,6 +35,9 @@ var (
 	URN = urnType{}
 	// ProviderHost is used to retrieve a [provider.ProviderHost] from ctx.
 	ProviderHost = providerHostType{}
+	// PluginDownloadURL is used to retrieve the running provider's own plugin
+	// download URL from ctx.
+	PluginDownloadURL = pluginDownloadURLType{}
 )
 
 // ForceNoDetailedDiff acts as a side-channel in

--- a/self.go
+++ b/self.go
@@ -1,0 +1,104 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/pulumi/pulumi-go-provider/internal/key"
+)
+
+// PluginIdentity describes the plugin serving the current request: the package it
+// implements, the version it was built as, and the URL the engine can download it from.
+//
+// A component that registers a resource of its own package from inside Construct needs
+// this. Such a registration goes straight to [pulumi.Context.RegisterResource], which
+// applies no package defaults — unlike a registration made through a generated SDK,
+// where codegen bakes the version and the download URL into the resource's default
+// options. Without them the engine records a provider with neither field, and resolves
+// the plugin later from the conventional github.com/pulumi/pulumi-<name> location. For a
+// third-party provider no such repository exists, so any later operation that starts
+// with a cold plugin cache — a destroy from a fresh workspace is the usual one — fails to
+// load the plugin at all.
+//
+// [ConstructRequest] cannot carry these: the Construct gRPC request has no field for
+// either, so the values come from the running provider itself.
+type PluginIdentity struct {
+	// Package is the Pulumi package this provider serves, e.g. "random".
+	Package string
+
+	// Version is the provider's own version, e.g. "1.2.3". Empty if the provider was
+	// run without one.
+	Version string
+
+	// DownloadURL is the URL the engine should download this provider's plugin from,
+	// e.g. "github://api.github.com/pulumi/pulumi-random". Empty unless the provider
+	// set one, which [github.com/pulumi/pulumi-go-provider/infer.ProviderBuilder.WithPluginDownloadURL]
+	// does.
+	DownloadURL string
+}
+
+// ResourceOptions returns the options that record this identity on a resource.
+//
+// Apply them only to resources of this provider's own [PluginIdentity.Package]. They name
+// one specific plugin, so passing them to a resource of another package — an aws:s3/bucket
+// created alongside your own — sends the engine looking for that package's plugin at your
+// version and your URL, which is not what you want. Give each such resource the options
+// belonging to its own package instead, or none at all.
+//
+// Empty fields are skipped, so a provider that set no download URL still gets its version
+// recorded.
+func (id PluginIdentity) ResourceOptions() []pulumi.ResourceOption {
+	opts := make([]pulumi.ResourceOption, 0, 2)
+	if id.Version != "" {
+		opts = append(opts, pulumi.Version(id.Version))
+	}
+	if id.DownloadURL != "" {
+		opts = append(opts, pulumi.PluginDownloadURL(id.DownloadURL))
+	}
+	return opts
+}
+
+// GetPluginIdentity reports the identity of the plugin serving the current request.
+//
+// The [context.Context] is the one passed to a [Provider] method. Inside a component's
+// Construct, where the Pulumi Go SDK hands over a [pulumi.Context] instead, reach it with
+// [pulumi.Context.Context]:
+//
+//	func (c *Component) Construct(
+//		ctx *pulumi.Context, name, typ string, args Args, opts pulumi.ResourceOption,
+//	) (*Component, error) {
+//		self := provider.GetPluginIdentity(ctx.Context())
+//
+//		child := &MyResourceState{}
+//		err := ctx.RegisterResource("my-pkg:index:Child", name+"-child", args, child,
+//			append(self.ResourceOptions(), pulumi.Parent(comp))...)
+//		...
+//	}
+//
+// Fields the provider never supplied come back empty; the call itself never fails.
+func GetPluginIdentity(ctx context.Context) PluginIdentity {
+	var id PluginIdentity
+	if info, ok := ctx.Value(key.RuntimeInfo).(RunInfo); ok {
+		id.Package = info.PackageName
+		id.Version = info.Version
+	}
+	if url, ok := ctx.Value(key.PluginDownloadURL).(string); ok {
+		id.DownloadURL = url
+	}
+	return id
+}


### PR DESCRIPTION
## The gap

A component that registers a resource of **its own package** from inside `Construct` cannot tell the engine where that package's plugin comes from.

The registration goes straight to `ctx.RegisterResource`, which applies no package defaults. A registration made through a generated SDK does carry them — codegen bakes the version and the plugin download URL into `internal.PkgResourceDefaultOpts` — but a provider registering its own resource types from inside `Construct` never goes through that path.

The engine then records a default provider with both fields empty:

| Provider URN | `pluginDownloadURL` | Referenced by |
|---|---|---|
| `...::default_2_6_0_github_/api.github.com/<org>/<repo>` | present | 0 resources |
| `...::default` | **absent** | the self-registered resource |

The URL goes to the provider nobody needs; the one doing the work has none. The parent chain cannot supply a fallback either — the parent is a component, and a component records no provider of its own.

## Why it bites third-party providers only

With no URL recorded, the engine falls back to `github.com/pulumi/pulumi-<name>`. For a first-party package like `kubernetes` that is a real repository, so the omission is harmless and the pattern survives unnoticed. For a third-party package it is not:

```
could not create provider urn:...::pulumi:providers:my-pkg::default:
load plugin for my-pkg provider: could not find latest version for provider my-pkg:
404 HTTP error fetching plugin from
https://api.github.com/repos/pulumi/pulumi-my-pkg/releases/latest
```

It stays hidden for a long time, because two things have to miss at once:

- **`up` never fails.** Resolving the SDK-registered provider has already put the plugin in the local cache, and a versionless request matches any installed version of that plugin (`LegacySelectCompatiblePlugin`), so the bare provider finds it there and never calls out.
- **`destroy` does not run the program.** Nothing registers the SDK-side provider, so nothing populates the cache. On a machine that has the plugin installed anyway this still works; on a cold cache the bare provider has no address to fetch from and the stack cannot be destroyed at all. Recovery means hand-editing the checkpoint.

We hit exactly this on a stack that could not be torn down for four consecutive days.

## Why the values cannot come off the wire

`ConstructRequest` looked like the natural place to read them from, following what `pulumi-kubernetes`' `GetChildOptions` does — read `Version` and `PluginDownloadURL` off the incoming options and re-apply them to children. That does not work here: the Construct gRPC request has no field for either, so `newConstructRequest` has nothing to populate and the options handed to `Construct` never carry them. Only `Providers` survives the trip. (`pulumi-kubernetes` is unaffected because it is a hand-written provider on the Go SDK's `provider.Construct`, not on this framework.)

They can, however, come from the running provider, which knows both — the version already rides on `RunInfo`, and `infer` holds the download URL in its schema metadata. It just never shares them.

## The change

```go
func (c *Component) Construct(
	ctx *pulumi.Context, name, typ string, args Args, opts pulumi.ResourceOption,
) (*Component, error) {
	self := provider.GetPluginIdentity(ctx.Context())

	child := &ChildState{}
	err := ctx.RegisterResource("my-pkg:index:Child", name+"-child", args, child,
		append(self.ResourceOptions(), pulumi.Parent(comp))...)
	...
}
```

- `provider.GetPluginIdentity(ctx)` returns the `Package`, `Version` and `DownloadURL` of the plugin serving the request. Fields the provider never supplied come back empty; the call never fails.
- `PluginIdentity.ResourceOptions()` turns them into `pulumi.Version` / `pulumi.PluginDownloadURL`, skipping whichever is empty.
- `infer.Wrap` publishes the download URL on the context through the existing `mContext.Wrap` seam, next to the `RunInfo` the framework already puts there. Providers that set no URL are unaffected — no wrapper is added at all.

### Why a value and not a blanket option

The identity names one specific plugin, so it is returned to be applied per resource rather than forced onto every child of the Construct context. A component typically creates resources from other packages too, and handing them this provider's version and URL would send the engine looking for *their* plugin at *our* coordinates. Registering a stack transform would have the same problem, and a wider blast radius. The test covers both halves: the own-package child records the version and the URL, and a foreign-package child registered in the same Construct is left untouched.

This is also why the framework cannot simply do it for the author — only the call site knows which package a given `RegisterResource` belongs to.

## Test

`infer/tests/plugin_identity_test.go` reads `Version` and `PluginDownloadURL` off the `RegisterResource` RPC through `MockResourceArgs.RegisterRPC`. Removing the `infer` change makes it fail on the URL assertion. A second test covers a provider that set no download URL: the version still comes through and `ResourceOptions()` yields just the one option.

`make test_unit` and `golangci-lint run -c .golangci.yaml` are clean — the lint issues that remain (50 `goconst`, 2 `govet`) are pre-existing on `main` and untouched by this branch.

## Compatibility

Purely additive: one new exported type, one new function, one new internal context key. No existing signature or behaviour changes, and a provider that sets no `PluginDownloadURL` sees no difference.
