### PR TITLE
[infer] Validate enum values at runtime

### DIFF
--- a/examples/dna-store/consumer/Pulumi.yaml
+++ b/examples/dna-store/consumer/Pulumi.yaml
@@ -10,7 +10,7 @@ resources:
   you:
     type: dna-store:DNAStore
     properties:
-      data: [1, 2, 3, 4]
+      data: [0, 1, 2, 3]
       filedir: ${pulumi.cwd}/data
       metadata:
         sampleType: human

--- a/examples/dna-store/main.go
+++ b/examples/dna-store/main.go
@@ -117,7 +117,7 @@ func (*DNAStore) Create(ctx context.Context, req infer.CreateRequest[DNAStoreArg
 		case T:
 			bytes[i] = 'T'
 		default:
-			retErr("'%s' is not a valid DNA molecule", b)
+			return retErr("'%s' is not a valid DNA molecule", b)
 		}
 	}
 	err = os.WriteFile(path, bytes, 0644)

--- a/infer/component.go
+++ b/infer/component.go
@@ -16,6 +16,7 @@ package infer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -119,6 +120,15 @@ func (rc *derivedComponentController[R, T, I, O]) GetToken() (tokens.Type, error
 // Construct implements InferredComponent.
 func (rc *derivedComponentController[R, T, I, O]) Construct(ctx context.Context, req p.ConstructRequest,
 ) (p.ConstructResponse, error) {
+	// Construct has no CheckFailure channel, so enum violations are reported as an
+	// error.
+	if failures := validateEnums[I](req.Inputs); len(failures) > 0 {
+		errs := make([]error, len(failures))
+		for i, f := range failures {
+			errs[i] = fmt.Errorf("%s: %s", f.Property, f.Reason)
+		}
+		return p.ConstructResponse{}, errors.Join(errs...)
+	}
 	return p.ProgramConstruct(ctx, req, func(
 		ctx *pulumi.Context, typ, name string, inputs comProvider.ConstructInputs, opts pulumi.ResourceOption,
 	) (*comProvider.ConstructResult, error) {

--- a/infer/configuration.go
+++ b/infer/configuration.go
@@ -121,6 +121,7 @@ func (c *config[T]) checkConfig(ctx context.Context, req p.CheckRequest) (p.Chec
 	if err != nil {
 		return p.CheckResponse{}, err
 	}
+	failures = append(failures, validateEnums[T](req.Inputs)...)
 
 	err = applyDefaults(c.receiver)
 	if err != nil {

--- a/infer/function.go
+++ b/infer/function.go
@@ -155,6 +155,7 @@ func (r *derivedInvokeController[F, I, O]) Invoke(ctx context.Context, req p.Inv
 	if err != nil {
 		return p.InvokeResponse{}, err
 	}
+	mapFailures = append(mapFailures, validateEnums[I](req.Args)...)
 	if len(mapFailures) > 0 {
 		return p.InvokeResponse{
 			Failures: mapFailures,

--- a/infer/internal/ende/ende.go
+++ b/infer/internal/ende/ende.go
@@ -94,8 +94,31 @@ func DecodeAny(m property.Map, dst any) (Encoder, mapper.MappingError) {
 	return decode(rm, dst, false, false)
 }
 
+// A Visitor is called by [Visit] for each known leaf value in a property map, with the
+// static type the value will decode into. typ is nil when the value has no corresponding
+// type information. secret is true if the value or any of its ancestors is secret. path
+// is only valid for the duration of the call.
+type Visitor func(typ reflect.Type, v resource.PropertyValue, path resource.PropertyPath, secret bool)
+
+// Visit walks m as it would be decoded into T, calling visit on each known leaf value.
+//
+// Unknown values are not visited, since they don't have a value yet.
+func Visit[T any](m property.Map, visit Visitor) {
+	rm := resource.ToResourcePropertyValue(property.New(m)).ObjectValue()
+	e := &ende{visitor: visit}
+	e.simplify(rm, reflect.TypeFor[T]())
+}
+
 // An ENcoder DEcoder.
-type ende struct{ changes []change }
+type ende struct {
+	changes []change
+
+	// visitor, if set, is called on each known leaf value found during walk.
+	visitor Visitor
+	// secretDepth counts the secret wrappers enclosing the value currently being
+	// walked.
+	secretDepth int
+}
 
 type change struct {
 	path        resource.PropertyPath
@@ -177,7 +200,9 @@ func (e *ende) walk(
 		// To allow full fidelity reconstructing maps, we extract nested secrets
 		// first. We then extract the top level secret. We need this ordering to
 		// re-embed nested secrets.
+		e.secretDepth++
 		el := e.walk(v.SecretValue().Element, path, typ, alignTypes)
+		e.secretDepth--
 		e.mark(change{path: path, secret: true})
 		return el
 	case v.IsComputed():
@@ -186,7 +211,13 @@ func (e *ende) walk(
 		return el
 	case v.IsOutput():
 		output := v.OutputValue()
+		if output.Secret {
+			e.secretDepth++
+		}
 		el := e.walk(output.Element, path, typ, !output.Known)
+		if output.Secret {
+			e.secretDepth--
+		}
 		e.mark(change{
 			path:        path,
 			computed:    !output.Known,
@@ -235,6 +266,9 @@ func (e *ende) walk(
 			return resource.NewObjectProperty(obj)
 		// This is a scalar value, so we can return it as is.
 		default:
+			if e.visitor != nil {
+				e.visitor(typ, v, path, e.secretDepth > 0)
+			}
 			return v
 		}
 	}
@@ -469,5 +503,5 @@ func (e *ende) AllowUnknown(allowUnknowns bool) Encoder {
 		changes = append(changes, v)
 	}
 
-	return Encoder{&ende{changes}}
+	return Encoder{&ende{changes: changes}}
 }

--- a/infer/resource.go
+++ b/infer/resource.go
@@ -1103,12 +1103,12 @@ func defaultCheck[I any](i I) (I, error) {
 
 func decodeCheckingMapErrors[I any](inputs property.Map) (ende.Encoder, I, []p.CheckFailure, error) {
 	encoder, i, err := ende.Decode[I](inputs)
-	if err != nil {
-		failures, e := checkFailureFromMapError(err)
+	failures, e := checkFailureFromMapError(err)
+	if e != nil {
 		return encoder, i, failures, e
 	}
 
-	return encoder, i, nil, nil
+	return encoder, i, append(failures, validateEnums[I](inputs)...), nil
 }
 
 // checkFailureFromMapError converts from a [mapper.MappingError] to a [p.CheckFailure]:

--- a/infer/types.go
+++ b/infer/types.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 
 	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer/internal/ende"
 	"github.com/pulumi/pulumi-go-provider/infer/types"
 	"github.com/pulumi/pulumi-go-provider/internal/introspect"
 	"github.com/pulumi/pulumi-go-provider/middleware/schema"
@@ -144,75 +145,41 @@ func isEnum(t reflect.Type) (func() enum, bool) {
 // whose shape doesn't match I are skipped, since the decoder already reports them.
 func validateEnums[I any](inputs property.Map) []p.CheckFailure {
 	var failures []p.CheckFailure
-	var walk func(t reflect.Type, v property.Value, path string)
-	walk = func(t reflect.Type, v property.Value, path string) {
-		if v.IsComputed() || v.IsNull() {
+	ende.Visit[I](inputs, func(
+		typ reflect.Type, v resource.PropertyValue, path resource.PropertyPath, secret bool,
+	) {
+		if typ == nil {
 			return
 		}
-		for t.Kind() == reflect.Pointer {
-			t = t.Elem()
+		if nT, inputty, err := underlyingType(typ); err == nil && inputty {
+			typ = nT
 		}
-		if nT, inputty, err := underlyingType(t); err == nil && inputty {
-			t = nT
-		}
-		if enumFn, ok := isEnum(t); ok {
-			if f := checkEnumValue(t, v, path, enumFn().values); f != nil {
-				failures = append(failures, *f)
-			}
+		enumFn, ok := isEnum(typ)
+		if !ok {
 			return
 		}
-		switch t.Kind() {
-		case reflect.Struct:
-			if !v.IsMap() {
-				return
-			}
-			m := v.AsMap()
-			for _, field := range reflect.VisibleFields(t) {
-				info, err := introspect.ParseTag(field)
-				if err != nil || info.Internal {
-					continue
-				}
-				fieldPath := info.Name
-				if path != "" {
-					fieldPath = path + "." + info.Name
-				}
-				if fv, ok := m.GetOk(info.Name); ok {
-					walk(field.Type, fv, fieldPath)
-				}
-			}
-		case reflect.Slice, reflect.Array:
-			if !v.IsArray() {
-				return
-			}
-			for i, el := range v.AsArray().All {
-				walk(t.Elem(), el, fmt.Sprintf("%s[%d]", path, i))
-			}
-		case reflect.Map:
-			if !v.IsMap() {
-				return
-			}
-			for k, el := range v.AsMap().All {
-				walk(t.Elem(), el, fmt.Sprintf("%s[%q]", path, k))
-			}
+		if f := checkEnumValue(typ, v, path.String(), enumFn().values, secret); f != nil {
+			failures = append(failures, *f)
 		}
-	}
-	walk(reflect.TypeFor[I](), property.New(inputs), "")
+	})
 	return failures
 }
 
 // checkEnumValue returns a failure if v is a valid value for t's kind but not one of
 // t's declared enum values.
-func checkEnumValue(t reflect.Type, v property.Value, path string, values []EnumValue[any]) *p.CheckFailure {
+func checkEnumValue(
+	t reflect.Type, v resource.PropertyValue, path string, values []EnumValue[any], secret bool,
+) *p.CheckFailure {
 	var got any
 	switch {
 	case t.Kind() == reflect.String && v.IsString():
-		got = v.AsString()
+		got = v.StringValue()
 	case t.Kind() == reflect.Bool && v.IsBool():
-		got = v.AsBool()
+		got = v.BoolValue()
 	case t.Kind() == reflect.Int && v.IsNumber():
-		got = int(v.AsNumber())
+		got = int(v.NumberValue())
 	case t.Kind() == reflect.Float64 && v.IsNumber():
-		got = v.AsNumber()
+		got = v.NumberValue()
 	default:
 		return nil
 	}
@@ -224,7 +191,7 @@ func checkEnumValue(t reflect.Type, v property.Value, path string, values []Enum
 		valid[i] = fmt.Sprintf("%#v", ev.Value)
 	}
 	display := fmt.Sprintf("%#v", got)
-	if v.Secret() {
+	if secret {
 		display = "[secret]"
 	}
 	return &p.CheckFailure{

--- a/infer/types.go
+++ b/infer/types.go
@@ -18,12 +18,15 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 
+	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer/types"
 	"github.com/pulumi/pulumi-go-provider/internal/introspect"
 	"github.com/pulumi/pulumi-go-provider/middleware/schema"
@@ -132,6 +135,103 @@ func isEnum(t reflect.Type) (func() enum, bool) {
 			values: values,
 		}
 	}, true
+}
+
+// validateEnums checks that each enum-typed property in I holds one of its declared
+// values, returning a [p.CheckFailure] for each property that doesn't.
+//
+// Unknown values are skipped, since they can't be validated until they resolve. Values
+// whose shape doesn't match I are skipped, since the decoder already reports them.
+func validateEnums[I any](inputs property.Map) []p.CheckFailure {
+	var failures []p.CheckFailure
+	var walk func(t reflect.Type, v property.Value, path string)
+	walk = func(t reflect.Type, v property.Value, path string) {
+		if v.IsComputed() || v.IsNull() {
+			return
+		}
+		for t.Kind() == reflect.Pointer {
+			t = t.Elem()
+		}
+		if nT, inputty, err := underlyingType(t); err == nil && inputty {
+			t = nT
+		}
+		if enumFn, ok := isEnum(t); ok {
+			if f := checkEnumValue(t, v, path, enumFn().values); f != nil {
+				failures = append(failures, *f)
+			}
+			return
+		}
+		switch t.Kind() {
+		case reflect.Struct:
+			if !v.IsMap() {
+				return
+			}
+			m := v.AsMap()
+			for _, field := range reflect.VisibleFields(t) {
+				info, err := introspect.ParseTag(field)
+				if err != nil || info.Internal {
+					continue
+				}
+				fieldPath := info.Name
+				if path != "" {
+					fieldPath = path + "." + info.Name
+				}
+				if fv, ok := m.GetOk(info.Name); ok {
+					walk(field.Type, fv, fieldPath)
+				}
+			}
+		case reflect.Slice, reflect.Array:
+			if !v.IsArray() {
+				return
+			}
+			for i, el := range v.AsArray().All {
+				walk(t.Elem(), el, fmt.Sprintf("%s[%d]", path, i))
+			}
+		case reflect.Map:
+			if !v.IsMap() {
+				return
+			}
+			for k, el := range v.AsMap().All {
+				walk(t.Elem(), el, fmt.Sprintf("%s[%q]", path, k))
+			}
+		}
+	}
+	walk(reflect.TypeFor[I](), property.New(inputs), "")
+	return failures
+}
+
+// checkEnumValue returns a failure if v is a valid value for t's kind but not one of
+// t's declared enum values.
+func checkEnumValue(t reflect.Type, v property.Value, path string, values []EnumValue[any]) *p.CheckFailure {
+	var got any
+	switch {
+	case t.Kind() == reflect.String && v.IsString():
+		got = v.AsString()
+	case t.Kind() == reflect.Bool && v.IsBool():
+		got = v.AsBool()
+	case t.Kind() == reflect.Int && v.IsNumber():
+		got = int(v.AsNumber())
+	case t.Kind() == reflect.Float64 && v.IsNumber():
+		got = v.AsNumber()
+	default:
+		return nil
+	}
+	valid := make([]string, len(values))
+	for i, ev := range values {
+		if ev.Value == got {
+			return nil
+		}
+		valid[i] = fmt.Sprintf("%#v", ev.Value)
+	}
+	display := fmt.Sprintf("%#v", got)
+	if v.Secret() {
+		display = "[secret]"
+	}
+	return &p.CheckFailure{
+		Property: path,
+		Reason: fmt.Sprintf("%s is not a valid value for the enum %q; valid values are %s",
+			display, t.Name(), strings.Join(valid, ", ")),
+	}
 }
 
 // Take a enum type and return it's base type.

--- a/tests/resource_test.go
+++ b/tests/resource_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi-go-provider/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 type res struct{}
@@ -44,6 +45,158 @@ func (c res) Create(context.Context, infer.CreateRequest[resInput]) (infer.Creat
 var _ infer.Annotated = res{}
 
 func (c res) Annotate(a infer.Annotator) { a.SetToken("index", "res") }
+
+type enumRes struct{}
+
+type region string
+
+func (region) Values() []infer.EnumValue[region] {
+	return []infer.EnumValue[region]{
+		{Value: "us-east-1"},
+		{Value: "eu-west-1"},
+	}
+}
+
+type enumResInput struct {
+	Region region `pulumi:"region"`
+}
+
+func (enumRes) Create(context.Context, infer.CreateRequest[enumResInput]) (infer.CreateResponse[enumResInput], error) {
+	panic("unimplemented")
+}
+
+func (enumRes) Annotate(a infer.Annotator) { a.SetToken("index", "enumRes") }
+
+// TestInferCheckRejectsInvalidEnumValues reproduces
+// https://github.com/pulumi/pulumi-go-provider/issues/585: the default Check
+// should reject values outside the enum's declared value set.
+func TestInferCheckRejectsInvalidEnumValues(t *testing.T) {
+	t.Parallel()
+
+	s, err := integration.NewServer(t.Context(),
+		"test",
+		semver.MustParse("0.0.0"),
+		integration.WithProvider(infer.Provider(infer.Options{
+			Resources: []infer.InferredResource{
+				infer.Resource(enumRes{}),
+			},
+		})))
+	require.NoError(t, err)
+
+	check := func(region property.Value) p.CheckResponse {
+		resp, err := s.Check(p.CheckRequest{
+			Urn: resource.CreateURN("name", "test:index:enumRes", "", "proj", "stack"),
+			Inputs: property.NewMap(map[string]property.Value{
+				"region": region,
+			}),
+		})
+		require.NoError(t, err)
+		return resp
+	}
+
+	assert.Equal(t, []p.CheckFailure{{
+		Property: "region",
+		Reason:   `"mars-1" is not a valid value for the enum "region"; valid values are "us-east-1", "eu-west-1"`,
+	}}, check(property.New("mars-1")).Failures)
+
+	valid := check(property.New("us-east-1"))
+	assert.Empty(t, valid.Failures)
+	assert.Equal(t, property.New("us-east-1"), valid.Inputs.Get("region"))
+
+	// Unknown values can't be validated until they resolve.
+	assert.Empty(t, check(property.New(property.Computed)).Failures)
+}
+
+type enumFn struct{}
+
+func (enumFn) Invoke(
+	context.Context, infer.FunctionRequest[enumResInput],
+) (infer.FunctionResponse[enumResInput], error) {
+	panic("unimplemented")
+}
+
+func (enumFn) Annotate(a infer.Annotator) { a.SetToken("index", "enumFn") }
+
+func TestInferInvokeRejectsInvalidEnumValues(t *testing.T) {
+	t.Parallel()
+
+	s, err := integration.NewServer(t.Context(),
+		"test",
+		semver.MustParse("0.0.0"),
+		integration.WithProvider(infer.Provider(infer.Options{
+			Functions: []infer.InferredFunction{infer.Function(enumFn{})},
+		})))
+	require.NoError(t, err)
+
+	resp, err := s.Invoke(p.InvokeRequest{
+		Token: "test:index:enumFn",
+		Args: property.NewMap(map[string]property.Value{
+			"region": property.New("mars-1"),
+		}),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []p.CheckFailure{{
+		Property: "region",
+		Reason:   `"mars-1" is not a valid value for the enum "region"; valid values are "us-east-1", "eu-west-1"`,
+	}}, resp.Failures)
+}
+
+type enumComp struct{ pulumi.ResourceState }
+
+func TestInferConstructRejectsInvalidEnumValues(t *testing.T) {
+	t.Parallel()
+
+	s, err := integration.NewServer(t.Context(),
+		"test",
+		semver.MustParse("0.0.0"),
+		integration.WithProvider(infer.Provider(infer.Options{
+			Components: []infer.InferredComponent{
+				infer.ComponentF(func(
+					*pulumi.Context, string, enumResInput, ...pulumi.ResourceOption,
+				) (*enumComp, error) {
+					panic("unimplemented")
+				}),
+			},
+		})))
+	require.NoError(t, err)
+
+	_, err = s.Construct(p.ConstructRequest{
+		Urn: resource.CreateURN("name", "test:tests:enumComp", "", "proj", "stack"),
+		Inputs: property.NewMap(map[string]property.Value{
+			"region": property.New("mars-1"),
+		}),
+	})
+	assert.EqualError(t, err,
+		`region: "mars-1" is not a valid value for the enum "region"; valid values are "us-east-1", "eu-west-1"`)
+}
+
+type enumConfig struct {
+	Region region `pulumi:"region"`
+}
+
+func TestInferCheckConfigRejectsInvalidEnumValues(t *testing.T) {
+	t.Parallel()
+
+	s, err := integration.NewServer(t.Context(),
+		"test",
+		semver.MustParse("0.0.0"),
+		integration.WithProvider(infer.Provider(infer.Options{
+			Config: infer.Config(&enumConfig{}),
+		})))
+	require.NoError(t, err)
+
+	resp, err := s.CheckConfig(p.CheckRequest{
+		Urn: resource.CreateURN("provider", "pulumi:providers:test", "", "proj", "stack"),
+		Inputs: property.NewMap(map[string]property.Value{
+			"region": property.New("mars-1"),
+		}),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []p.CheckFailure{{
+		Property: "region",
+		Reason:   `"mars-1" is not a valid value for the enum "region"; valid values are "us-east-1", "eu-west-1"`,
+	}}, resp.Failures)
+}
 
 func TestInferCheckSecrets(t *testing.T) {
 	t.Parallel()

--- a/tests/resource_test.go
+++ b/tests/resource_test.go
@@ -105,6 +105,12 @@ func TestInferCheckRejectsInvalidEnumValues(t *testing.T) {
 
 	// Unknown values can't be validated until they resolve.
 	assert.Empty(t, check(property.New(property.Computed)).Failures)
+
+	// Secret values are validated, but redacted in the failure message.
+	assert.Equal(t, []p.CheckFailure{{
+		Property: "region",
+		Reason:   `[secret] is not a valid value for the enum "region"; valid values are "us-east-1", "eu-west-1"`,
+	}}, check(property.New("mars-1").WithSecret(true)).Failures)
 }
 
 type enumFn struct{}


### PR DESCRIPTION
Fixes #585.

Enum types declared with `Values()` previously only affected schema generation and SDK types; the default provider paths accepted arbitrary raw values. This PR validates enum membership wherever the protocol lets us report it:

- **Check / `DefaultCheck`**: a `CheckFailure` per invalid enum value, alongside any decode failures.
- **Invoke**: invalid enum args are returned as `InvokeResponse.Failures`.
- **CheckConfig**: provider configuration is validated the same way.
- **Construct**: has no `CheckFailure` channel, so violations are returned as an error, one line per property.

Semantics:

- Unknown (computed) values are skippe.
- Values whose shape doesn't match the input type are skipped.
- Secret values are validated, but redacted in the failure message so they don't leak into previews.
- State decoding paths (Read, Diff, Update, Delete) are intentionally left unvalidated: those values describe external reality (or pre-validation state) rather than user intent.