### PR TITLE
Support setting SupportPack in the schema

### DIFF
--- a/infer/provider_builder.go
+++ b/infer/provider_builder.go
@@ -265,6 +265,12 @@ func (pb *ProviderBuilder) WithNamespace(namespace string) *ProviderBuilder {
 	return pb
 }
 
+// WithSupportPack sets SupportPack on the provider's schema
+func (pb *ProviderBuilder) WithSupportPack(supportPack bool) *ProviderBuilder {
+	pb.metadata.SupportPack = supportPack
+	return pb
+}
+
 // BuildOptions builds an [Options] object from the provider builder configuration. This
 // is useful when a user wants to have more control over the provider creation process.
 func (pb *ProviderBuilder) BuildOptions() Options {

--- a/middleware/schema/schema.go
+++ b/middleware/schema/schema.go
@@ -174,6 +174,8 @@ type Metadata struct {
 	PluginDownloadURL string
 	// Namespace sets the [schema.PackageSpec.Namespace] field.
 	Namespace string
+	// SupportPack sets the [schema.PackageSpec.Meta] SupportPack field.
+	SupportPack bool
 
 	// Update allows updating the metadata function when runtime information (such as
 	// package name and version) is available.
@@ -321,6 +323,9 @@ func (s *state) generateSchema(ctx context.Context) (schema.PackageSpec, error) 
 		Functions:         map[string]schema.FunctionSpec{},
 		Types:             map[string]schema.ComplexTypeSpec{},
 		Language:          map[string]schema.RawMessage{},
+	}
+	if s.SupportPack {
+		pkg.Meta = &schema.MetadataSpec{SupportPack: true}
 	}
 	for k, v := range s.LanguageMap {
 		bytes, err := json.Marshal(v)

--- a/tests/schema_test.go
+++ b/tests/schema_test.go
@@ -97,3 +97,27 @@ func TestMergeSchema(t *testing.T) {
     }
 }`, bytes.String())
 }
+
+func TestSupportPack(t *testing.T) {
+	s := schema.Wrap(p.Provider{}, schema.Options{
+		Metadata: schema.Metadata{
+			SupportPack: true,
+		},
+		Resources: []schema.Resource{
+			&givenResource{"foo:index:foo", "foo"},
+		},
+	})
+	server, err := integration.NewServer(t.Context(),
+		"pkg",
+		semver.Version{Major: 1},
+		integration.WithProvider(s),
+	)
+	require.NoError(t, err)
+
+	res, err := server.GetSchema(p.GetSchemaRequest{})
+	require.NoError(t, err)
+
+	var spec pschema.PackageSpec
+	require.NoError(t, json.Unmarshal([]byte(res.Schema), &spec))
+	assert.Equal(t, &pschema.MetadataSpec{SupportPack: true}, spec.Meta)
+}


### PR DESCRIPTION
Add `Metadata.SupportPack` to the schema middleware and a `WithSupportPack` builder method so providers can set `meta.supportPack` in their generated schema.