### PR TITLE
[infer] Diff provider config on version without replacing

### DIFF
--- a/infer/configuration.go
+++ b/infer/configuration.go
@@ -141,15 +141,46 @@ func (c *config[T]) checkConfig(ctx context.Context, req p.CheckRequest) (p.Chec
 }
 
 func (c *config[T]) diffConfig(ctx context.Context, req p.DiffRequest) (p.DiffResponse, error) {
-	// We currently replace the provider on any changes
-	// (https://github.com/pulumi/pulumi-go-provider/issues/409) except for
-	// version.
-	return diff[T, T](ctx, req, c.receiver,
-		func(field string) bool { return field != "version" },
+	// We currently replace the provider on any changes to T
+	// (https://github.com/pulumi/pulumi-go-provider/issues/409). The engine-managed
+	// "version" input is not part of T and is diffed separately: a version change
+	// updates the provider in place.
+	resp, err := diff[T, T](ctx, req, c.receiver,
+		func(string) bool { return true },
 		func(m property.Map) (ende.Encoder, T, mapper.MappingError) {
 			enc, err := ende.DecodeConfig(m, c.receiver)
 			return enc, *c.receiver, err
 		})
+	if err != nil {
+		return p.DiffResponse{}, err
+	}
+	return diffProviderVersion(req, resp), nil
+}
+
+// diffProviderVersion merges a diff of the "version" input into resp.
+//
+// A provider's state is its checked inputs, so the old version is read from req.State.
+// This runs after [CustomDiff] too: a custom Diff only sees T and so cannot observe
+// version.
+func diffProviderVersion(req p.DiffRequest, resp p.DiffResponse) p.DiffResponse {
+	const key = "version"
+	old, new := req.State.Get(key), req.Inputs.Get(key)
+	if old.Equals(new) {
+		return resp
+	}
+	kind := p.Update
+	switch {
+	case old.IsNull():
+		kind = p.Add
+	case new.IsNull():
+		kind = p.Delete
+	}
+	if resp.DetailedDiff == nil {
+		resp.DetailedDiff = map[string]p.PropertyDiff{}
+	}
+	resp.DetailedDiff[key] = p.PropertyDiff{Kind: kind, InputDiff: true}
+	resp.HasChanges = true
+	return resp
 }
 
 func (c *config[T]) configure(ctx context.Context, req p.ConfigureRequest) error {

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -252,6 +252,9 @@ func TestInferCustomDiffConfig(t *testing.T) {
 
 	resp, err := s.DiffConfig(p.DiffRequest{
 		Urn: resource.CreateURN("p", "pulumi:providers:test", "", "test", "dev"),
+		State: property.NewMap(map[string]property.Value{
+			"version": property.New("1.2.3"),
+		}),
 		Inputs: property.NewMap(map[string]property.Value{
 			"version": property.New("1.2.3"),
 		}),
@@ -260,6 +263,50 @@ func TestInferCustomDiffConfig(t *testing.T) {
 
 	assert.False(t, resp.HasChanges)
 	assert.Empty(t, resp.DetailedDiff)
+}
+
+// Test that a provider version change is an update, not a replace
+// (https://github.com/pulumi/pulumi-go-provider/issues/592).
+func TestInferDiffConfigVersionChange(t *testing.T) {
+	t.Parallel()
+
+	req := p.DiffRequest{
+		Urn: resource.CreateURN("p", "pulumi:providers:test", "", "test", "dev"),
+		State: property.NewMap(map[string]property.Value{
+			"field":   property.New("value"),
+			"version": property.New("1.2.3"),
+		}),
+		Inputs: property.NewMap(map[string]property.Value{
+			"field":   property.New("value"),
+			"version": property.New("1.2.4"),
+		}),
+	}
+	want := p.DiffResponse{
+		HasChanges: true,
+		DetailedDiff: map[string]p.PropertyDiff{
+			"version": {Kind: p.Update, InputDiff: true},
+		},
+	}
+
+	for name, cfg := range map[string]infer.InferredConfig{
+		"default-diff": infer.Config(&config{}),
+		"custom-diff":  infer.Config(&configWithPointerDiff{}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			s, err := integration.NewServer(t.Context(),
+				"test",
+				semver.MustParse("0.0.0"),
+				integration.WithProvider(infer.Provider(infer.Options{Config: cfg})),
+			)
+			require.NoError(t, err)
+
+			resp, err := s.DiffConfig(req)
+			require.NoError(t, err)
+			assert.Equal(t, want, resp)
+		})
+	}
 }
 
 type configWithDiff struct {


### PR DESCRIPTION
Fixes #592.

The shared `diff` strips the engine-managed `version` input before comparing old and new inputs, so bumping a provider's version produced no diff at all and the provider was never updated to the new version. That strip can't simply be removed: the `CustomDiff` path decodes inputs strictly, and old inputs for config are fabricated from `T`'s struct fields (the provider isn't configured yet during `DiffConfig`, so the engine's old inputs aren't available).

`diffConfig` now runs the unchanged struct diff and then merges a `version` entry, comparing `req.State["version"]` (a provider's state is its checked inputs) to `req.Inputs["version"]`. A change is reported as an `Update`, never a replace, so the engine reloads the plugin at the new version in place. This runs after `CustomDiff` too, since a custom `Diff` only sees `T` and cannot observe `version`.
