### PR TITLE
Preserve string config values that parse as JSON strings

### DIFF
--- a/middleware/complexconfig/provider.go
+++ b/middleware/complexconfig/provider.go
@@ -205,11 +205,12 @@ func fixEncoding(v resource.PropertyValue, spec schema.PropertySpec) resource.Pr
 
 	out := resource.NewPropertyValueRepl(target, nil, replv)
 
-	// If the expected type is a string and the raw underlying type is not a string,
-	// then don't use the JSON encoded value (since it might be a valid JSON value of
-	// a type other then string, for example: 42, a JSON number but a valid string
-	// value).
-	if spec.Type == "string" && !unwrap(out).IsString() {
+	// The engine sends plain strings as-is; only secret, computed and output
+	// strings arrive JSON encoded. So for a string typed variable, a decoded
+	// value is only trusted when it is wrapped in one of those markers and its
+	// element is a string. Otherwise the raw value is a literal that happens to
+	// parse as JSON (for example: 42, or "hi" with the quotes included).
+	if spec.Type == "string" && (out.IsString() || !unwrap(out).IsString()) {
 		return v
 	}
 	return out

--- a/middleware/complexconfig/provider_test.go
+++ b/middleware/complexconfig/provider_test.go
@@ -78,6 +78,25 @@ func TestComplexConfigEncoding(t *testing.T) {
 				"$": property.New("42"),
 			}),
 		},
+		{
+			name: "json-string-looking-string-args",
+			input: property.NewMap(map[string]property.Value{
+				"$": property.New(`"hi"`),
+			}),
+			schema: func() (schema.PackageSpec, error) {
+				var p schema.PackageSpec
+				p.Config.Variables = map[string]schema.PropertySpec{
+					"$": {TypeSpec: schema.TypeSpec{
+						Type: "string",
+					}},
+				}
+
+				return p, nil
+			},
+			expected: property.NewMap(map[string]property.Value{
+				"$": property.New(`"hi"`),
+			}),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

`complexconfig` decoded every string that parsed as JSON. A `string` typed config variable whose literal value was itself a JSON string (for example `"hi"` including the quotes) had its quotes stripped before reaching `CheckConfig`.

## Fix

The engine only JSON encodes secret, computed and output strings; plain strings are sent as-is. So for a `string` typed variable, a decoded value is only used when it is wrapped in one of those markers. A decoded plain string is a literal and is left untouched.

Fixes https://github.com/pulumi/pulumi-go-provider/issues/591